### PR TITLE
feat(ci): GitHub Action sync develop e release ← master

### DIFF
--- a/.claude/worktrees/fervent-northcutt/.claude/settings.local.json
+++ b/.claude/worktrees/fervent-northcutt/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(cmd /c \"del /F C:\\\\Projetos\\\\PersonalFinance\\\\.git\\\\index.lock\")",
+      "Read(//c/Projetos/PersonalFinance/**)",
+      "Bash(gh pr create --base release --title 'feat\\(ci\\): GitHub Action sync develop e release ← master' --body ':*)"
+    ]
+  }
+}

--- a/.claude/worktrees/fervent-northcutt/.github/workflows/sync-branches.yml
+++ b/.claude/worktrees/fervent-northcutt/.github/workflows/sync-branches.yml
@@ -1,0 +1,32 @@
+name: Sync develop and release from master
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  sync:
+    name: Fast-forward develop and release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sync develop ← master
+        run: |
+          git checkout develop
+          git merge --ff-only origin/master
+          git push origin develop
+
+      - name: Sync release ← master
+        run: |
+          git checkout release
+          git merge --ff-only origin/master
+          git push origin release

--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -1,0 +1,32 @@
+name: Sync develop and release from master
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  sync:
+    name: Fast-forward develop and release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sync develop ← master
+        run: |
+          git checkout develop
+          git merge --ff-only origin/master
+          git push origin develop
+
+      - name: Sync release ← master
+        run: |
+          git checkout release
+          git merge --ff-only origin/master
+          git push origin release


### PR DESCRIPTION
## Summary
- Cria workflow `.github/workflows/sync-branches.yml`
- Dispara no push em `master`
- Fast-forward `develop` ← `master` e `release` ← `master` automaticamente

## Test plan
- [ ] Após merge em master, verificar que o Action roda e atualiza develop e release

🤖 Generated with [Claude Code](https://claude.com/claude-code)