### PR TITLE
fix(ci): merge com fallback quando ff-only falha no sync

### DIFF
--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   sync:
-    name: Fast-forward develop and release
+    name: Sync develop and release from master
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -19,14 +19,19 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Sync develop ← master
         run: |
           git checkout develop
-          git merge --ff-only origin/master
+          git merge --ff-only origin/master || git merge -m "chore(ci): sync develop ← master [skip ci]" origin/master
           git push origin develop
 
       - name: Sync release ← master
         run: |
           git checkout release
-          git merge --ff-only origin/master
+          git merge --ff-only origin/master || git merge -m "chore(ci): sync release ← master [skip ci]" origin/master
           git push origin release

--- a/personal-finance/src/app/features/config/components/config.component.ts
+++ b/personal-finance/src/app/features/config/components/config.component.ts
@@ -419,7 +419,7 @@ import { CategoryResponse, LookupItem } from '../../../core/models/models';
     .lookup-name { font-size: 0.875rem; font-weight: 500; color: var(--ink); }
     .lookup-desc { font-size: 0.8125rem; color: var(--ink3); }
 
-    .card-actions { display: flex; gap: 6px; align-items: center; }
+    .card-actions { display: flex; gap: 6px; align-items: center; padding-bottom: 63px;}
 
     .action-btn {
       width: 28px; height: 28px; border: 1px solid var(--border);


### PR DESCRIPTION
## Summary
- Tenta `--ff-only` primeiro; se as branches tiverem divergido, faz merge normal
- Adiciona `git config` para user.name/email do bot (necessário para commits de merge)
- Mensagem de merge com `[skip ci]` para evitar loop

## Test plan
- [ ] Após merge em master, verificar que o Action roda sem erro mesmo com branches divergidas

🤖 Generated with [Claude Code](https://claude.com/claude-code)