### PR TITLE
fix(mario-modal): add fixed height and content scrolling

### DIFF
--- a/personal-finance/src/app/shared/components/modal/mario-modal.component.ts
+++ b/personal-finance/src/app/shared/components/modal/mario-modal.component.ts
@@ -35,6 +35,9 @@ import { Component, computed, input, OnDestroy, OnInit, output, signal } from '@
       min-width: 480px;
       max-width: 660px;
       width: 90vw;
+      height: 360px;
+      display: flex;
+      flex-direction: column;
       border: 4px solid #fff;
       box-shadow:
         0 0 0 2px #000,
@@ -54,7 +57,9 @@ import { Component, computed, input, OnDestroy, OnInit, output, signal } from '@
 
     .mario-content {
       white-space: pre-wrap;
-      min-height: 80px;
+      flex: 1;
+      min-height: 0;
+      overflow-y: auto;
       word-break: break-word;
     }
 


### PR DESCRIPTION
## Changes

- Set fixed height (360px) on modal container
- Enable flexbox layout on modal for better content management
- Update content area to use `flex: 1` for flexible sizing
- Add `overflow-y: auto` to enable vertical scrolling in content
- Set `min-height: 0` to allow proper flex shrinking

## Impact
Modal now maintains a consistent height with internal scrolling for overflow content, improving UX for modals with varying content sizes.