### PR TITLE
fix(mario-modal): velocidade de animação reduzida para leitura fluida

### DIFF
--- a/personal-finance/src/app/shared/components/modal/mario-modal.component.ts
+++ b/personal-finance/src/app/shared/components/modal/mario-modal.component.ts
@@ -125,8 +125,8 @@ export class MarioModalComponent implements OnInit, OnDestroy {
 
   private intervalId: ReturnType<typeof setInterval> | null = null;
 
-  // Velocidade: ~3 caracteres por tick de 16ms (~60fps)
-  private readonly CHARS_PER_TICK = 3;
+  // Velocidade: 1 caractere por tick de 30ms
+  private readonly CHARS_PER_TICK = 1;
 
   ngOnInit(): void {
     const full = this.content();
@@ -143,7 +143,7 @@ export class MarioModalComponent implements OnInit, OnDestroy {
         this.clearInterval();
         this.animDone.set(true);
       }
-    }, 16);
+    }, 30);
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
## Summary
- Reduz `CHARS_PER_TICK` de 3 para 1 e intervalo de 16ms para 30ms
- Resultado: ~33 caracteres/segundo, leitura mais fluida estilo RPG Mario

## Test plan
- [ ] Abrir modal de qualquer ícone "?" e verificar que o texto aparece com velocidade confortável para leitura
- [ ] Verificar que o botão "▼" (pular) ainda funciona normalmente

🤖 Generated with [Claude Code](https://claude.com/claude-code)