### PR TITLE
feat(expenses): paginação server-side, filtros externos e ordenação client-side

### DIFF
--- a/personal-finance/src/app/core/models/models.ts
+++ b/personal-finance/src/app/core/models/models.ts
@@ -134,6 +134,24 @@ export interface MarkAsPaidRequest {
   paymentDate: string;
 }
 
+// ── Pagination ────────────────────────────────────────────────────────────────
+
+export interface PagedResult<T> {
+  items:      T[];
+  totalCount: number;
+  pageNumber: number;
+  pageSize:   number;
+}
+
+export interface ExpenseFilterParams {
+  pageNumber?:    number;
+  pageSize?:      number;
+  description?:   string;
+  categoryId?:    string;
+  paymentStatus?: PaymentStatus;
+  fortnightType?: FortnightType;
+}
+
 // ── Income ────────────────────────────────────────────────────────────────────
 
 export interface IncomeResponse {

--- a/personal-finance/src/app/core/services/api.service.ts
+++ b/personal-finance/src/app/core/services/api.service.ts
@@ -6,6 +6,7 @@ import {
   CategoryResponse, CreateCategoryRequest, UpdateCategoryRequest,
   PeriodResponse, CreatePeriodRequest, PeriodSummary,
   ExpenseResponse, CreateExpenseRequest, UpdateExpenseRequest, MarkAsPaidRequest,
+  PagedResult, ExpenseFilterParams,
   IncomeResponse, CreateIncomeRequest,
   LookupItem,
   CreatePaymentStatusRequest, CreateSourceTypeRequest, CreateFortnightTypeRequest,
@@ -68,9 +69,15 @@ export class ApiService {
 
   // ── Expenses ──────────────────────────────────────────────────────────────
 
-  getExpensesByPeriod(periodId: string): Observable<ExpenseResponse[]> {
-    const params = new HttpParams().set('periodId', periodId);
-    return this.http.get<ExpenseResponse[]>(`${this.base}/expenses`, { params });
+  getExpensesByPeriod(periodId: string, filters?: ExpenseFilterParams): Observable<PagedResult<ExpenseResponse>> {
+    let params = new HttpParams().set('periodId', periodId);
+    if (filters?.pageNumber != null)    params = params.set('pageNumber',    filters.pageNumber);
+    if (filters?.pageSize != null)      params = params.set('pageSize',      filters.pageSize);
+    if (filters?.description)           params = params.set('description',   filters.description);
+    if (filters?.categoryId)            params = params.set('categoryId',    filters.categoryId);
+    if (filters?.paymentStatus != null) params = params.set('paymentStatus', filters.paymentStatus);
+    if (filters?.fortnightType != null) params = params.set('fortnightType', filters.fortnightType);
+    return this.http.get<PagedResult<ExpenseResponse>>(`${this.base}/expenses`, { params });
   }
 
   getExpenseById(id: string): Observable<ExpenseResponse> {

--- a/personal-finance/src/app/features/expenses/components/expenses.component.ts
+++ b/personal-finance/src/app/features/expenses/components/expenses.component.ts
@@ -1,9 +1,10 @@
-import { Component, inject, signal, OnInit, input, ViewChild, ElementRef } from '@angular/core';
+import { Component, inject, signal, computed, OnInit, input, ViewChild, ElementRef } from '@angular/core';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { trigger, style, animate, transition } from '@angular/animations';
 import { ApiService } from '../../../core/services/api.service';
 import { HeaderComponent } from '../../../shared/components/header/header.component';
 import { SonicModalComponent } from '../../../shared/components/modal/sonic-modal.component';
+import { PaginationComponent } from '../../../shared/components/pagination/pagination.component';
 import { CurrencyBrlPipe } from '../../../shared/pipes/currency-brl.pipe';
 import {
   ExpenseResponse, PeriodResponse, CategoryResponse,
@@ -11,10 +12,12 @@ import {
   PaymentStatus, SourceType, FortnightType
 } from '../../../core/models/models';
 
+type SortCol = 'description' | 'category' | 'fortnightType' | 'dueDate' | 'amount' | 'paymentStatus';
+
 @Component({
   selector: 'app-expenses',
   standalone: true,
-  imports: [HeaderComponent, CurrencyBrlPipe, ReactiveFormsModule, SonicModalComponent],
+  imports: [HeaderComponent, CurrencyBrlPipe, ReactiveFormsModule, SonicModalComponent, PaginationComponent],
   animations: [
     trigger('backdropAnim', [
       transition(':enter', [
@@ -50,17 +53,72 @@ import {
       <div class="filter-row">
         <label class="field-label">Filtrar por período</label>
         <select #periodFilterSelect class="input" style="width:auto; min-width:180px" (change)="onPeriodFilter($event)">
-          <option value="">Todos</option>
+          <option value="">Selecione um período</option>
           @for (p of periods(); track p.id) {
             <option [value]="p.id">{{ monthName(p.month) }}/{{ p.year }}</option>
           }
         </select>
       </div>
 
+      <!-- Filtros externos (server-side) — visíveis apenas quando há período selecionado -->
+      @if (selectedPeriodId) {
+        <div class="external-filters card">
+          <div class="filters-grid">
+            <div class="filter-field">
+              <label class="field-label">Descrição</label>
+              <input
+                class="input input-sm"
+                placeholder="Buscar..."
+                [value]="filterDescription()"
+                (input)="onFilterDescriptionChange($event)"
+              />
+            </div>
+
+            <div class="filter-field">
+              <label class="field-label">Categoria</label>
+              <select class="input input-sm" (change)="onFilterCategoryChange($event)">
+                <option value="">Todas</option>
+                @for (c of categories(); track c.id) {
+                  <option [value]="c.id">{{ c.name }}</option>
+                }
+              </select>
+            </div>
+
+            <div class="filter-field">
+              <label class="field-label">Status</label>
+              <select class="input input-sm" (change)="onFilterStatusChange($event)">
+                <option value="">Todos</option>
+                <option [value]="PaymentStatus.Pending">Pendente</option>
+                <option [value]="PaymentStatus.Paid">Pago</option>
+                <option [value]="PaymentStatus.Partial">Parcial</option>
+                <option [value]="PaymentStatus.Cancelled">Cancelado</option>
+              </select>
+            </div>
+
+            <div class="filter-field">
+              <label class="field-label">Quinzena</label>
+              <select class="input input-sm" (change)="onFilterFortnightChange($event)">
+                <option value="">Ambas</option>
+                <option [value]="FortnightType.First">1ª Quinzena</option>
+                <option [value]="FortnightType.Second">2ª Quinzena</option>
+              </select>
+            </div>
+          </div>
+
+          @if (hasActiveFilters()) {
+            <button class="btn-clear-filters" (click)="clearFilters()">Limpar filtros</button>
+          }
+        </div>
+      }
+
       <!-- Lista -->
       @if (loadingList()) {
         <div class="loading-state"><span class="spinner-lg"></span></div>
-      } @else if (expenses().length === 0) {
+      } @else if (!selectedPeriodId) {
+        <div class="empty-state">
+          <p>Selecione um período para ver as despesas.</p>
+        </div>
+      } @else if (totalCount() === 0) {
         <div class="empty-state">
           <p>Nenhuma despesa encontrada.</p>
         </div>
@@ -69,17 +127,29 @@ import {
           <table class="table">
             <thead>
               <tr>
-                <th>Descrição</th>
-                <th>Categoria</th>
-                <th>Quinzena</th>
-                <th>Vencimento</th>
-                <th>Valor</th>
-                <th>Status</th>
+                <th class="sortable" (click)="toggleSort('description')">
+                  Descrição {{ sortIcon('description') }}
+                </th>
+                <th class="sortable" (click)="toggleSort('category')">
+                  Categoria {{ sortIcon('category') }}
+                </th>
+                <th class="sortable" (click)="toggleSort('fortnightType')">
+                  Quinzena {{ sortIcon('fortnightType') }}
+                </th>
+                <th class="sortable" (click)="toggleSort('dueDate')">
+                  Vencimento {{ sortIcon('dueDate') }}
+                </th>
+                <th class="sortable" (click)="toggleSort('amount')">
+                  Valor {{ sortIcon('amount') }}
+                </th>
+                <th class="sortable" (click)="toggleSort('paymentStatus')">
+                  Status {{ sortIcon('paymentStatus') }}
+                </th>
                 <th>Ações</th>
               </tr>
             </thead>
             <tbody>
-              @for (expense of expenses(); track expense.id) {
+              @for (expense of displayedExpenses(); track expense.id) {
                 <tr>
                   <td>
                     <div class="cell-primary">{{ expense.description }}</div>
@@ -126,6 +196,15 @@ import {
               }
             </tbody>
           </table>
+
+          <!-- Paginação -->
+          <app-pagination
+            [totalCount]="totalCount()"
+            [pageSize]="pageSize()"
+            [currentPage]="currentPage()"
+            (pageChange)="onPageChange($event)"
+            (pageSizeChange)="onPageSizeChange($event)"
+          />
         </div>
       }
     </div>
@@ -246,6 +325,46 @@ import {
       gap: 12px;
     }
 
+    /* ── Filtros externos ── */
+    .external-filters {
+      padding: 16px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .filters-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 12px;
+    }
+
+    .filter-field {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .input-sm {
+      height: 32px;
+      padding: 0 10px;
+      font-size: 0.8125rem;
+    }
+
+    .btn-clear-filters {
+      align-self: flex-start;
+      background: none;
+      border: none;
+      color: var(--color-info);
+      font-size: 0.8125rem;
+      cursor: pointer;
+      padding: 0;
+      text-decoration: underline;
+    }
+
+    .btn-clear-filters:hover { color: var(--rust); }
+
+    /* ── Tabela ── */
     .table-wrap { overflow-x: auto; }
     .table { width: 100%; border-collapse: collapse; font-size: 0.875rem; }
     .table th {
@@ -261,6 +380,13 @@ import {
     }
     .table tr:last-child td { border-bottom: none; }
     .table tbody tr:hover { background: var(--surface-overlay); }
+
+    .sortable {
+      cursor: pointer;
+      user-select: none;
+      white-space: nowrap;
+    }
+    .sortable:hover { color: var(--ink); }
 
     .cell-primary   { color: var(--ink); font-weight: 500; }
     .cell-secondary { font-size: 0.75rem; color: var(--ink3); margin-top: 2px; }
@@ -350,10 +476,27 @@ export class ExpensesComponent implements OnInit {
   private readonly fb  = inject(FormBuilder);
 
   readonly PaymentStatus = PaymentStatus;
+  readonly FortnightType = FortnightType;
 
-  readonly periods     = signal<PeriodResponse[]>([]);
-  readonly categories  = signal<CategoryResponse[]>([]);
+  readonly periods    = signal<PeriodResponse[]>([]);
+  readonly categories = signal<CategoryResponse[]>([]);
+
+  // Dados vindos da API (página atual)
   readonly expenses    = signal<ExpenseResponse[]>([]);
+  readonly totalCount  = signal(0);
+  readonly currentPage = signal(1);
+  readonly pageSize    = signal(20);
+
+  // Filtros externos (server-side)
+  readonly filterDescription   = signal('');
+  readonly filterCategoryId    = signal('');
+  readonly filterStatus        = signal<PaymentStatus | null>(null);
+  readonly filterFortnightType = signal<FortnightType | null>(null);
+
+  // Ordenação client-side (página atual)
+  readonly sortCol = signal<SortCol | null>(null);
+  readonly sortDir = signal<'asc' | 'desc'>('asc');
+
   readonly loadingList = signal(false);
   readonly saving      = signal(false);
   readonly apiError    = signal<string | null>(null);
@@ -361,11 +504,47 @@ export class ExpensesComponent implements OnInit {
   readonly modalMode   = signal<'create' | 'edit'>('create');
 
   private editingId: string | null = null;
-  private selectedPeriodId: string | null = null;
+  selectedPeriodId: string | null = null;
+
+  // Debounce para busca por descrição
+  private descriptionDebounce: ReturnType<typeof setTimeout> | null = null;
 
   /** Pré-seleção via query param: /expenses?periodId=xxx */
   readonly periodId = input<string>();
   @ViewChild('periodFilterSelect') periodFilterSelect!: ElementRef<HTMLSelectElement>;
+
+  /** Verifica se há algum filtro ativo */
+  readonly hasActiveFilters = computed(() =>
+    !!this.filterDescription() || !!this.filterCategoryId() ||
+    this.filterStatus() != null || this.filterFortnightType() != null);
+
+  /** Aplica ordenação client-side sobre os itens da página atual */
+  readonly displayedExpenses = computed<ExpenseResponse[]>(() => {
+    const col = this.sortCol();
+    const dir = this.sortDir();
+    const list = [...this.expenses()];
+
+    if (!col) return list;
+
+    return list.sort((a, b) => {
+      let va: string | number;
+      let vb: string | number;
+
+      switch (col) {
+        case 'description':   va = a.description.toLowerCase();   vb = b.description.toLowerCase();   break;
+        case 'category':      va = this.categoryName(a.categoryId); vb = this.categoryName(b.categoryId); break;
+        case 'fortnightType': va = a.fortnightType;               vb = b.fortnightType;               break;
+        case 'dueDate':       va = a.dueDate;                     vb = b.dueDate;                     break;
+        case 'amount':        va = a.amount;                      vb = b.amount;                      break;
+        case 'paymentStatus': va = a.paymentStatus;               vb = b.paymentStatus;               break;
+        default:              return 0;
+      }
+
+      if (va < vb) return dir === 'asc' ? -1 : 1;
+      if (va > vb) return dir === 'asc' ?  1 : -1;
+      return 0;
+    });
+  });
 
   readonly form = this.fb.group({
     periodId:      ['', Validators.required],
@@ -384,11 +563,7 @@ export class ExpensesComponent implements OnInit {
       this.periods.set(p);
       if (preId) {
         this.selectedPeriodId = preId;
-        this.loadingList.set(true);
-        this.api.getExpensesByPeriod(preId).subscribe({
-          next: e => { this.expenses.set(e); this.loadingList.set(false); },
-          error: () => this.loadingList.set(false)
-        });
+        this.loadPage();
         setTimeout(() => {
           if (this.periodFilterSelect?.nativeElement)
             this.periodFilterSelect.nativeElement.value = preId;
@@ -396,6 +571,26 @@ export class ExpensesComponent implements OnInit {
       }
     });
     this.api.getCategories().subscribe(c => this.categories.set(c));
+  }
+
+  private loadPage(): void {
+    if (!this.selectedPeriodId) return;
+    this.loadingList.set(true);
+    this.api.getExpensesByPeriod(this.selectedPeriodId, {
+      pageNumber:    this.currentPage(),
+      pageSize:      this.pageSize(),
+      description:   this.filterDescription() || undefined,
+      categoryId:    this.filterCategoryId()  || undefined,
+      paymentStatus: this.filterStatus()      ?? undefined,
+      fortnightType: this.filterFortnightType() ?? undefined,
+    }).subscribe({
+      next: result => {
+        this.expenses.set(result.items);
+        this.totalCount.set(result.totalCount);
+        this.loadingList.set(false);
+      },
+      error: () => this.loadingList.set(false)
+    });
   }
 
   openCreateModal(): void {
@@ -441,16 +636,83 @@ export class ExpensesComponent implements OnInit {
   onPeriodFilter(event: Event): void {
     const periodId = (event.target as HTMLSelectElement).value;
     this.selectedPeriodId = periodId || null;
-    if (periodId) {
-      this.loadingList.set(true);
-      this.api.getExpensesByPeriod(periodId).subscribe({
-        next: e => { this.expenses.set(e); this.loadingList.set(false); },
-        error: () => this.loadingList.set(false)
-      });
+    this.currentPage.set(1);
+    this.expenses.set([]);
+    this.totalCount.set(0);
+    if (periodId) this.loadPage();
+  }
+
+  // ── Filtros externos ──────────────────────────────────────────────────────
+
+  onFilterDescriptionChange(event: Event): void {
+    const val = (event.target as HTMLInputElement).value;
+    this.filterDescription.set(val);
+    if (this.descriptionDebounce) clearTimeout(this.descriptionDebounce);
+    this.descriptionDebounce = setTimeout(() => {
+      this.currentPage.set(1);
+      this.loadPage();
+    }, 350);
+  }
+
+  onFilterCategoryChange(event: Event): void {
+    this.filterCategoryId.set((event.target as HTMLSelectElement).value);
+    this.currentPage.set(1);
+    this.loadPage();
+  }
+
+  onFilterStatusChange(event: Event): void {
+    const val = (event.target as HTMLSelectElement).value;
+    this.filterStatus.set(val ? Number(val) as PaymentStatus : null);
+    this.currentPage.set(1);
+    this.loadPage();
+  }
+
+  onFilterFortnightChange(event: Event): void {
+    const val = (event.target as HTMLSelectElement).value;
+    this.filterFortnightType.set(val ? Number(val) as FortnightType : null);
+    this.currentPage.set(1);
+    this.loadPage();
+  }
+
+  clearFilters(): void {
+    this.filterDescription.set('');
+    this.filterCategoryId.set('');
+    this.filterStatus.set(null);
+    this.filterFortnightType.set(null);
+    this.currentPage.set(1);
+    this.loadPage();
+  }
+
+  // ── Paginação ─────────────────────────────────────────────────────────────
+
+  onPageChange(page: number): void {
+    this.currentPage.set(page);
+    this.loadPage();
+  }
+
+  onPageSizeChange(size: number): void {
+    this.pageSize.set(size);
+    this.currentPage.set(1);
+    this.loadPage();
+  }
+
+  // ── Ordenação client-side ─────────────────────────────────────────────────
+
+  toggleSort(col: SortCol): void {
+    if (this.sortCol() === col) {
+      this.sortDir.update(d => d === 'asc' ? 'desc' : 'asc');
     } else {
-      this.expenses.set([]);
+      this.sortCol.set(col);
+      this.sortDir.set('asc');
     }
   }
+
+  sortIcon(col: SortCol): string {
+    if (this.sortCol() !== col) return '↕';
+    return this.sortDir() === 'asc' ? '↑' : '↓';
+  }
+
+  // ── CRUD ──────────────────────────────────────────────────────────────────
 
   onSubmit(): void {
     if (this.form.invalid) { this.form.markAllAsTouched(); return; }
@@ -471,11 +733,11 @@ export class ExpensesComponent implements OnInit {
         fortnightType: Number(v.fortnightType) as FortnightType,
         notes:         v.notes || undefined,
       }).subscribe({
-        next: e => {
-          if (this.selectedPeriodId === e.periodId)
-            this.expenses.update(list => [e, ...list]);
+        next: () => {
           this.closeModal();
           this.saving.set(false);
+          // Recarrega a página atual para refletir o novo registro
+          this.loadPage();
         },
         error: err => {
           this.apiError.set(err.error?.message ?? 'Erro ao salvar despesa.');
@@ -538,9 +800,14 @@ export class ExpensesComponent implements OnInit {
   deleteExpense(id: string): void {
     if (!confirm('Confirma a exclusão desta despesa?')) return;
     this.api.deleteExpense(id).subscribe({
-      next: () => this.expenses.update(list => list.filter(e => e.id !== id))
+      next: () => {
+        this.expenses.update(list => list.filter(e => e.id !== id));
+        this.totalCount.update(n => n - 1);
+      }
     });
   }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
 
   categoryName(categoryId: string): string {
     return this.categories().find(c => c.id === categoryId)?.name ?? '—';

--- a/personal-finance/src/app/features/periods/components/period-detail.component.ts
+++ b/personal-finance/src/app/features/periods/components/period-detail.component.ts
@@ -532,9 +532,9 @@ export class PeriodDetailComponent implements OnInit {
       this.api.getExpensesByPeriod(periodId).toPromise(),
       this.api.getIncomesByPeriod(periodId).toPromise(),
       this.api.getCategories().toPromise(),
-    ]).then(([summary, expenses, incomes, categories]) => {
+    ]).then(([summary, expensesResult, incomes, categories]) => {
       this.summary.set(summary ?? null);
-      this.expenses.set(expenses ?? []);
+      this.expenses.set(expensesResult?.items ?? []);
       this.incomes.set(incomes ?? []);
       this.categories.set(categories ?? []);
       this.loading.set(false);

--- a/personal-finance/src/app/shared/components/pagination/pagination.component.ts
+++ b/personal-finance/src/app/shared/components/pagination/pagination.component.ts
@@ -1,0 +1,152 @@
+import { Component, input, output, computed } from '@angular/core';
+
+@Component({
+  selector: 'app-pagination',
+  standalone: true,
+  imports: [],
+  template: `
+    <div class="pagination-bar">
+      <span class="pagination-info">
+        {{ rangeStart() }}–{{ rangeEnd() }} de {{ totalCount() }} registros
+      </span>
+
+      <div class="pagination-controls">
+        <select class="page-size-select" [value]="pageSize()" (change)="onPageSizeChange($event)">
+          <option value="10">10 / pág.</option>
+          <option value="20">20 / pág.</option>
+          <option value="50">50 / pág.</option>
+        </select>
+
+        <button class="page-btn" [disabled]="currentPage() <= 1" (click)="goTo(currentPage() - 1)">
+          ‹
+        </button>
+
+        @for (p of visiblePages(); track p) {
+          @if (p === -1) {
+            <span class="page-ellipsis">…</span>
+          } @else {
+            <button
+              class="page-btn"
+              [class.active]="p === currentPage()"
+              (click)="goTo(p)"
+            >{{ p }}</button>
+          }
+        }
+
+        <button class="page-btn" [disabled]="currentPage() >= totalPages()" (click)="goTo(currentPage() + 1)">
+          ›
+        </button>
+      </div>
+    </div>
+  `,
+  styles: [`
+    .pagination-bar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 12px 16px;
+      border-top: 1px solid var(--border);
+      font-size: 0.8125rem;
+      color: var(--ink3);
+    }
+
+    .pagination-controls {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+
+    .page-size-select {
+      height: 28px;
+      padding: 0 8px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      background: var(--surface);
+      color: var(--ink2);
+      font-size: 0.8125rem;
+      cursor: pointer;
+      margin-right: 8px;
+    }
+
+    .page-btn {
+      min-width: 28px;
+      height: 28px;
+      padding: 0 6px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      background: none;
+      color: var(--ink2);
+      font-size: 0.8125rem;
+      cursor: pointer;
+      transition: all var(--transition);
+    }
+
+    .page-btn:hover:not(:disabled) {
+      background: var(--surface-overlay);
+      border-color: var(--sage2);
+      color: var(--sage2);
+    }
+
+    .page-btn.active {
+      background: var(--sage2);
+      border-color: var(--sage2);
+      color: #fff;
+      font-weight: 600;
+    }
+
+    .page-btn:disabled {
+      opacity: 0.35;
+      cursor: not-allowed;
+    }
+
+    .page-ellipsis {
+      padding: 0 4px;
+      color: var(--ink3);
+      line-height: 28px;
+    }
+  `]
+})
+export class PaginationComponent {
+  readonly totalCount  = input.required<number>();
+  readonly pageSize    = input.required<number>();
+  readonly currentPage = input.required<number>();
+
+  readonly pageChange     = output<number>();
+  readonly pageSizeChange = output<number>();
+
+  readonly totalPages = computed(() =>
+    Math.max(1, Math.ceil(this.totalCount() / this.pageSize())));
+
+  readonly rangeStart = computed(() =>
+    this.totalCount() === 0 ? 0 : (this.currentPage() - 1) * this.pageSize() + 1);
+
+  readonly rangeEnd = computed(() =>
+    Math.min(this.currentPage() * this.pageSize(), this.totalCount()));
+
+  readonly visiblePages = computed<number[]>(() => {
+    const total = this.totalPages();
+    const current = this.currentPage();
+    if (total <= 7) return Array.from({ length: total }, (_, i) => i + 1);
+
+    const pages: number[] = [1];
+    if (current > 3) pages.push(-1);
+
+    const start = Math.max(2, current - 1);
+    const end   = Math.min(total - 1, current + 1);
+    for (let i = start; i <= end; i++) pages.push(i);
+
+    if (current < total - 2) pages.push(-1);
+    pages.push(total);
+    return pages;
+  });
+
+  goTo(page: number): void {
+    if (page < 1 || page > this.totalPages()) return;
+    this.pageChange.emit(page);
+  }
+
+  onPageSizeChange(event: Event): void {
+    const size = Number((event.target as HTMLSelectElement).value);
+    this.pageSizeChange.emit(size);
+  }
+}

--- a/src/PersonalFinance.Api/Controllers/V1/Financial/ExpensesController.cs
+++ b/src/PersonalFinance.Api/Controllers/V1/Financial/ExpensesController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using PersonalFinance.Application.DTOs;
 using PersonalFinance.Application.DTOs.Financial;
 using PersonalFinance.Application.UseCases.Financial.Expenses;
 using PersonalFinance.Domain.Interfaces.Repositories;
@@ -27,17 +28,19 @@ public sealed class ExpensesController(
     private readonly IUnitOfWork _unitOfWork = unitOfWork;
 
     /// <summary>
-    /// Lista todas as despesas de um período.
+    /// Lista despesas de um período com paginação e filtros opcionais.
     /// Requer query param: ?periodId={guid}
+    /// Filtros opcionais: pageNumber, pageSize, description, categoryId, paymentStatus, fortnightType
     /// </summary>
     [HttpGet]
-    [ProducesResponseType(typeof(IEnumerable<ExpenseResponseDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(PagedResult<ExpenseResponseDto>), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> GetByPeriod(
         [FromQuery] Guid periodId,
+        [FromQuery] ExpenseFilterDto filter,
         CancellationToken ct)
     {
-        var result = await _getByPeriodUseCase.ExecuteAsync(periodId, CurrentUserId, ct);
+        var result = await _getByPeriodUseCase.ExecuteAsync(periodId, CurrentUserId, filter, ct);
         return Ok(result);
     }
 

--- a/src/PersonalFinance.Application/DTOs/Financial/FinancialDtos.cs
+++ b/src/PersonalFinance.Application/DTOs/Financial/FinancialDtos.cs
@@ -60,6 +60,15 @@ public sealed record ExpenseResponseDto(
     bool          IsActive
 );
 
+public sealed record ExpenseFilterDto(
+    int            PageNumber    = 1,
+    int            PageSize      = 20,
+    string?        Description   = null,
+    Guid?          CategoryId    = null,
+    PaymentStatus? PaymentStatus = null,
+    FortnightType? FortnightType = null
+);
+
 // ── Income ────────────────────────────────────────────────────────────────────
 
 public sealed record CreateIncomeDto(

--- a/src/PersonalFinance.Application/DTOs/PagedResult.cs
+++ b/src/PersonalFinance.Application/DTOs/PagedResult.cs
@@ -1,0 +1,10 @@
+namespace PersonalFinance.Application.DTOs;
+
+/// <summary>
+/// Resultado paginado genérico — reutilizável em qualquer listagem com paginação server-side.
+/// </summary>
+public sealed record PagedResult<T>(
+    IEnumerable<T> Items,
+    int TotalCount,
+    int PageNumber,
+    int PageSize);

--- a/src/PersonalFinance.Application/UseCases/Financial/Expenses/GetExpensesByPeriodUseCase.cs
+++ b/src/PersonalFinance.Application/UseCases/Financial/Expenses/GetExpensesByPeriodUseCase.cs
@@ -1,4 +1,5 @@
-﻿using PersonalFinance.Application.DTOs.Financial;
+using PersonalFinance.Application.DTOs;
+using PersonalFinance.Application.DTOs.Financial;
 using PersonalFinance.Domain.Entities.Financial;
 using PersonalFinance.Domain.Exceptions;
 using PersonalFinance.Domain.Interfaces.Repositories;
@@ -6,8 +7,7 @@ using PersonalFinance.Domain.Interfaces.Repositories;
 namespace PersonalFinance.Application.UseCases.Financial.Expenses
 {
     /// <summary>
-    /// Retorna todas as despesas de um período específico do usuário,
-    /// ordenadas por data de vencimento.
+    /// Retorna as despesas de um período de forma paginada com filtros opcionais.
     /// </summary>
     public sealed class GetExpensesByPeriodUseCase
     {
@@ -22,16 +22,26 @@ namespace PersonalFinance.Application.UseCases.Financial.Expenses
             _periodRepository = periodRepository;
         }
 
-        public async Task<IEnumerable<ExpenseResponseDto>> ExecuteAsync(
-            Guid periodId, Guid userId, CancellationToken ct = default)
+        public async Task<PagedResult<ExpenseResponseDto>> ExecuteAsync(
+            Guid periodId, Guid userId, ExpenseFilterDto filter, CancellationToken ct = default)
         {
             // Garante que o período pertence ao usuário antes de retornar as despesas
             var periodExists = await _periodRepository.ExistsByIdAndUserAsync(periodId, userId, ct);
             if (!periodExists)
                 throw new DomainException("Período não encontrado ou sem permissão de acesso.");
 
-            var expenses = await _expenseRepository.GetByPeriodAsync(periodId, userId, ct);
-            return expenses.Select(ToDto);
+            var (items, totalCount) = await _expenseRepository.GetPagedByPeriodAsync(
+                periodId, userId,
+                filter.PageNumber, filter.PageSize,
+                filter.Description, filter.CategoryId,
+                filter.PaymentStatus, filter.FortnightType,
+                ct);
+
+            return new PagedResult<ExpenseResponseDto>(
+                items.Select(ToDto),
+                totalCount,
+                filter.PageNumber,
+                filter.PageSize);
         }
 
         private static ExpenseResponseDto ToDto(Expense e) =>

--- a/src/PersonalFinance.Domain/Interfaces/Repositories/IExpenseRepository.cs
+++ b/src/PersonalFinance.Domain/Interfaces/Repositories/IExpenseRepository.cs
@@ -9,6 +9,17 @@ public interface IExpenseRepository
     Task<Expense?> GetByIdAndUserAsync(Guid id, Guid userId, CancellationToken ct = default);
     Task<IEnumerable<Expense>> GetByPeriodAsync(Guid periodId, Guid userId, CancellationToken ct = default);
 
+    Task<(IEnumerable<Expense> Items, int TotalCount)> GetPagedByPeriodAsync(
+        Guid          periodId,
+        Guid          userId,
+        int           pageNumber,
+        int           pageSize,
+        string?       description,
+        Guid?         categoryId,
+        PaymentStatus? paymentStatus,
+        FortnightType? fortnightType,
+        CancellationToken ct = default);
+
     /// <summary>
     /// Busca uma despesa pela chave de idempotência de importação:
     /// PeriodId + Descrição (case-insensitive) + Valor + Quinzena.

--- a/src/PersonalFinance.Infrastructure/Persistence/Repositories/Financial/ExpenseRepository.cs
+++ b/src/PersonalFinance.Infrastructure/Persistence/Repositories/Financial/ExpenseRepository.cs
@@ -55,6 +55,44 @@ public sealed class ExpenseRepository : IExpenseRepository
         return Task.CompletedTask;
     }
 
+    public async Task<(IEnumerable<Expense> Items, int TotalCount)> GetPagedByPeriodAsync(
+        Guid          periodId,
+        Guid          userId,
+        int           pageNumber,
+        int           pageSize,
+        string?       description,
+        Guid?         categoryId,
+        PaymentStatus? paymentStatus,
+        FortnightType? fortnightType,
+        CancellationToken ct = default)
+    {
+        var query = _context.Expenses
+            .Where(e => e.PeriodId == periodId && e.UserId == userId);
+
+        if (!string.IsNullOrWhiteSpace(description))
+            query = query.Where(e => e.Description.Contains(description));
+
+        if (categoryId.HasValue)
+            query = query.Where(e => e.CategoryId == categoryId.Value);
+
+        if (paymentStatus.HasValue)
+            query = query.Where(e => e.PaymentStatus == paymentStatus.Value);
+
+        if (fortnightType.HasValue)
+            query = query.Where(e => e.FortnightType == fortnightType.Value);
+
+        var totalCount = await query.CountAsync(ct);
+
+        var items = await query
+            .OrderBy(e => e.FortnightType)
+            .ThenBy(e => e.DueDate)
+            .Skip((pageNumber - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(ct);
+
+        return (items, totalCount);
+    }
+
     public async Task<bool> HasExpensesByCategoryAsync(
     Guid categoryId, CancellationToken ct = default)
     => await _context.Expenses


### PR DESCRIPTION
Closes #42

## Backend
- `PagedResult<T>` genérico em `Application/DTOs/` — reutilizável em #41, #43, #46
- `ExpenseFilterDto` com pageNumber, pageSize, description, categoryId, paymentStatus, fortnightType
- `IExpenseRepository.GetPagedByPeriodAsync` + implementação com IQueryable encadeado
- `GetExpensesByPeriodUseCase` retorna `PagedResult<ExpenseResponseDto>`
- `ExpensesController.GetByPeriod` aceita `[FromQuery] ExpenseFilterDto`

## Frontend
- `PaginationComponent` standalone genérico: prev/next, páginas com ellipsis, seletor de itens/página
- `PagedResult<T>` e `ExpenseFilterParams` em `models.ts`
- `ApiService.getExpensesByPeriod()` atualizado para retornar `PagedResult<ExpenseResponse>`
- `ExpensesComponent`: filtros externos (description, categoria, status, quinzena) com debounce na busca; ordenação client-side por qualquer coluna; paginação integrada
- `period-detail.component` adaptado ao novo tipo retornado

🤖 Generated with [Claude Code](https://claude.ai/claude-code)