### PR TITLE
feat(expenses): campo status no modal de edição

### DIFF
--- a/personal-finance/src/app/core/models/models.ts
+++ b/personal-finance/src/app/core/models/models.ts
@@ -128,6 +128,7 @@ export interface UpdateExpenseRequest {
   amount:        number;
   dueDate:       string;
   notes?:        string;
+  status:        PaymentStatus;
 }
 
 export interface MarkAsPaidRequest {

--- a/personal-finance/src/app/features/expenses/components/expenses.component.ts
+++ b/personal-finance/src/app/features/expenses/components/expenses.component.ts
@@ -294,6 +294,18 @@ type SortCol = 'description' | 'category' | 'fortnightType' | 'dueDate' | 'amoun
                 </select>
               </div>
 
+              @if (modalMode() === 'edit') {
+                <div class="field">
+                  <label class="field-label">Status</label>
+                  <select formControlName="status" class="input">
+                    <option [value]="PaymentStatus.Pending">Pendente</option>
+                    <option [value]="PaymentStatus.Paid">Pago</option>
+                    <option [value]="PaymentStatus.Partial">Parcial</option>
+                    <option [value]="PaymentStatus.Cancelled">Cancelado</option>
+                  </select>
+                </div>
+              }
+
               <div class="field field-full">
                 <label class="field-label">Observações</label>
                 <input formControlName="notes" class="input" placeholder="Opcional..." />
@@ -555,6 +567,7 @@ export class ExpensesComponent implements OnInit {
     sourceType:    [SourceType.Personal],
     fortnightType: [FortnightType.First],
     notes:         [''],
+    status:        [PaymentStatus.Pending],
   });
 
   ngOnInit(): void {
@@ -618,6 +631,7 @@ export class ExpensesComponent implements OnInit {
       sourceType:    expense.sourceType,
       fortnightType: expense.fortnightType,
       notes:         expense.notes ?? '',
+      status:        expense.paymentStatus,
     });
     this.modalOpen.set(true);
   }
@@ -748,6 +762,7 @@ export class ExpensesComponent implements OnInit {
       const id = this.editingId!;
       const sourceType    = Number(v.sourceType)    as SourceType;
       const fortnightType = Number(v.fortnightType) as FortnightType;
+      const status        = Number(v.status)        as PaymentStatus;
 
       this.api.updateExpense(id, {
         categoryId:    v.categoryId!,
@@ -757,6 +772,7 @@ export class ExpensesComponent implements OnInit {
         sourceType,
         fortnightType,
         notes:         v.notes || undefined,
+        status,
       }).subscribe({
         next: () => {
           this.expenses.update(list =>
@@ -768,6 +784,7 @@ export class ExpensesComponent implements OnInit {
                   dueDate:       v.dueDate!,
                   sourceType,
                   fortnightType,
+                  paymentStatus: status,
                   notes:         v.notes || null }
               : e
             )

--- a/src/PersonalFinance.Api/Controllers/V1/Financial/ExpensesController.cs
+++ b/src/PersonalFinance.Api/Controllers/V1/Financial/ExpensesController.cs
@@ -64,7 +64,7 @@ public sealed class ExpensesController(
         return CreatedAtAction(nameof(GetById), new { id = result.Id }, result);
     }
 
-    /// <summary>Atualiza dados editáveis da despesa. Não altera status — use PATCH.</summary>
+    /// <summary>Atualiza dados editáveis da despesa, incluindo status de pagamento.</summary>
     [HttpPut("{id:guid}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]

--- a/src/PersonalFinance.Application/DTOs/Financial/FinancialDtos.cs
+++ b/src/PersonalFinance.Application/DTOs/Financial/FinancialDtos.cs
@@ -41,7 +41,8 @@ public sealed record UpdateExpenseDto(
     string        Description,
     decimal       Amount,
     DateOnly      DueDate,
-    string?       Notes
+    string?       Notes,
+    PaymentStatus Status
 );
 
 public sealed record ExpenseResponseDto(

--- a/src/PersonalFinance.Application/UseCases/Financial/Expenses/ExpenseUseCases.cs
+++ b/src/PersonalFinance.Application/UseCases/Financial/Expenses/ExpenseUseCases.cs
@@ -85,8 +85,7 @@ public sealed class CreateExpenseUseCase
 // ══════════════════════════════════════════════════════════════════════════════
 
 /// <summary>
-/// Atualiza os dados editáveis de uma despesa existente.
-/// Não altera status de pagamento — use MarkAsPaid/MarkAsCancelled no domain.
+/// Atualiza os dados editáveis de uma despesa existente, incluindo status de pagamento.
 /// </summary>
 public sealed class UpdateExpenseUseCase
 {
@@ -135,6 +134,22 @@ public sealed class UpdateExpenseUseCase
             dueDate:       dto.DueDate,
             notes:         dto.Notes
         );
+
+        if (dto.Status != expense.PaymentStatus)
+        {
+            switch (dto.Status)
+            {
+                case PaymentStatus.Paid:
+                    expense.MarkAsPaid(DateOnly.FromDateTime(DateTime.UtcNow));
+                    break;
+                case PaymentStatus.Cancelled:
+                    expense.MarkAsCancelled();
+                    break;
+                case PaymentStatus.Partial:
+                    expense.MarkAsPartial();
+                    break;
+            }
+        }
 
         await _expenseRepository.UpdateAsync(expense, ct);
         await _unitOfWork.CommitAsync(ct);

--- a/tests/PersonalFinance.Application.Tests/Unit/Financial/FinancialUseCaseTests.cs
+++ b/tests/PersonalFinance.Application.Tests/Unit/Financial/FinancialUseCaseTests.cs
@@ -188,7 +188,7 @@ public class UpdateExpenseUseCaseTests
         var dto = new UpdateExpenseDto(
             ExpenseId, UserId, CategoryId,
             SourceType.Parental, FortnightType.Second,
-            "Internet", 150m, new DateOnly(2026, 4, 20), "Obs");
+            "Internet", 150m, new DateOnly(2026, 4, 20), "Obs", PaymentStatus.Pending);
 
         await _sut.ExecuteAsync(dto);
 
@@ -206,7 +206,7 @@ public class UpdateExpenseUseCaseTests
         var act = () => _sut.ExecuteAsync(new UpdateExpenseDto(
             ExpenseId, UserId, CategoryId,
             SourceType.Personal, FortnightType.First,
-            "Teste", 100m, new DateOnly(2026, 4, 10), null));
+            "Teste", 100m, new DateOnly(2026, 4, 10), null, PaymentStatus.Pending));
 
         await act.Should().ThrowAsync<DomainException>()
                  .WithMessage("*despesa*");


### PR DESCRIPTION
## Summary
- Adiciona `PaymentStatus Status` ao `UpdateExpenseDto` e `UpdateExpenseRequest`
- `UpdateExpenseUseCase` aplica transição de status via `MarkAsPaid` / `MarkAsCancelled` / `MarkAsPartial`
- Select de status no modal de edição, visível apenas em modo edit, populado com valor atual da despesa
- Atualização otimista do `paymentStatus` na lista após salvar

## Test plan
- [ ] Abrir modal de edição: select de status aparece com valor atual
- [ ] Alterar para Pago e salvar: status atualiza na lista
- [ ] Alterar para Cancelado: status atualiza, `PaymentDate` é limpa
- [ ] Alterar para Parcial: status atualiza
- [ ] `dotnet build` sem erros

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)