### PR TITLE
feat(expenses): campo status no modal de edição

### DIFF
--- a/tests/PersonalFinance.Api.Tests/Integration/ExpensesControllerTests.cs
+++ b/tests/PersonalFinance.Api.Tests/Integration/ExpensesControllerTests.cs
@@ -32,8 +32,8 @@ namespace PersonalFinance.Api.Tests.Integration
             var (client, pid, _) = await SetupAsync();
             var r = await client.GetAsync($"/api/v1/expenses?periodId={pid}");
             r.StatusCode.Should().Be(HttpStatusCode.OK);
-            var arr = await r.Content.ReadFromJsonAsync<JsonElement>();
-            arr.GetArrayLength().Should().Be(0); // período vazio
+            var body = await r.Content.ReadFromJsonAsync<JsonElement>();
+            body.GetProperty("items").GetArrayLength().Should().Be(0); // período vazio
         }
 
         [Fact(DisplayName = "POST e GET /expenses deve persistir e retornar a despesa")]


### PR DESCRIPTION
## Summary
- Adiciona `PaymentStatus Status` ao `UpdateExpenseDto` e `UpdateExpenseRequest`
- `UpdateExpenseUseCase` aplica transição de status via `MarkAsPaid` / `MarkAsCancelled` / `MarkAsPartial`
- Select de status no modal de edição, visível apenas em modo edit, populado com valor atual da despesa
- Atualização otimista do `paymentStatus` na lista após salvar
- Fix: teste `GetByPeriod_ShouldReturn200` ajustado para `PagedResult`

## Test plan
- [ ] Abrir modal de edição: select de status aparece com valor atual
- [ ] Alterar para Pago e salvar: status atualiza na lista
- [ ] Alterar para Cancelado: status atualiza
- [ ] Alterar para Parcial: status atualiza
- [ ] `dotnet test` sem falhas

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)