### PR TITLE
feat(expenses): campo status no modal de edição

### DIFF
--- a/tests/PersonalFinance.Api.Tests/Integration/ExpensesControllerTests.cs
+++ b/tests/PersonalFinance.Api.Tests/Integration/ExpensesControllerTests.cs
@@ -65,7 +65,7 @@ namespace PersonalFinance.Api.Tests.Integration
             // GET lista — deve conter a despesa
             var list = await client.GetAsync($"/api/v1/expenses?periodId={pid}");
             var arr = await list.Content.ReadFromJsonAsync<JsonElement>();
-            arr.GetArrayLength().Should().Be(1);
+            arr.GetProperty("items").GetArrayLength().Should().Be(1);
         }
 
         [Fact(DisplayName = "POST /expenses deve retornar 400 para amount zero")]


### PR DESCRIPTION
## Summary
- Adiciona `PaymentStatus Status` ao `UpdateExpenseDto` e `UpdateExpenseRequest`
- `UpdateExpenseUseCase` aplica transição de status via `MarkAsPaid` / `MarkAsCancelled` / `MarkAsPartial`
- Select de status no modal de edição, visível apenas em modo edit, populado com valor atual da despesa
- Atualização otimista do `paymentStatus` na lista após salvar
- Fix: testes de integração ajustados para `PagedResult`

## Test plan
- [ ] Abrir modal de edição: select de status aparece com valor atual
- [ ] Alterar para Pago e salvar: status atualiza na lista
- [ ] Alterar para Cancelado: status atualiza
- [ ] Alterar para Parcial: status atualiza
- [ ] `dotnet test` sem falhas

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)