### PR TITLE
feat(expenses): campo status no modal de edição

### DIFF
--- a/personal-finance/src/app/features/expenses/components/expenses.component.spec.ts
+++ b/personal-finance/src/app/features/expenses/components/expenses.component.spec.ts
@@ -31,7 +31,7 @@ describe('ExpensesComponent', () => {
     ]);
     apiSpy.getPeriods.and.returnValue(of([PERIOD]));
     apiSpy.getCategories.and.returnValue(of([CATEGORY]));
-    apiSpy.getExpensesByPeriod.and.returnValue(of([EXPENSE]));
+    apiSpy.getExpensesByPeriod.and.returnValue(of({ items: [EXPENSE], totalCount: 1, pageNumber: 1, pageSize: 20 }));
 
     await TestBed.configureTestingModule({
       imports: [ExpensesComponent, RouterModule.forRoot([])],

--- a/personal-finance/src/app/features/periods/components/period-detail.component.spec.ts
+++ b/personal-finance/src/app/features/periods/components/period-detail.component.spec.ts
@@ -72,7 +72,7 @@ describe('PeriodDetailComponent', () => {
       'getPeriodSummary', 'getExpensesByPeriod', 'getIncomesByPeriod', 'getCategories'
     ]);
     apiSpy.getPeriodSummary.and.returnValue(of(SUMMARY));
-    apiSpy.getExpensesByPeriod.and.returnValue(of([EXPENSE]));
+    apiSpy.getExpensesByPeriod.and.returnValue(of({ items: [EXPENSE], totalCount: 1, pageNumber: 1, pageSize: 20 }));
     apiSpy.getIncomesByPeriod.and.returnValue(of([INCOME]));
     apiSpy.getCategories.and.returnValue(of([CATEGORY]));
 


### PR DESCRIPTION
## Summary
- Adiciona `PaymentStatus Status` ao `UpdateExpenseDto` e `UpdateExpenseRequest`
- `UpdateExpenseUseCase` aplica transição de status via `MarkAsPaid` / `MarkAsCancelled` / `MarkAsPartial`
- Select de status no modal de edição, visível apenas em modo edit, populado com valor atual da despesa
- Atualização otimista do `paymentStatus` na lista após salvar
- Fix: testes de integração e specs Angular ajustados para `PagedResult`

## Test plan
- [ ] Abrir modal de edição: select de status aparece com valor atual
- [ ] Alterar para Pago e salvar: status atualiza na lista
- [ ] Alterar para Cancelado: status atualiza
- [ ] Alterar para Parcial: status atualiza
- [ ] `dotnet test` sem falhas
- [ ] `npm test -- --watch=false` → 236 SUCCESS

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)