### PR TITLE
fix(tests): corrigir mocks de getIncomesByPeriod após loadPage()

### DIFF
--- a/personal-finance/src/app/features/incomes/components/incomes.component.spec.ts
+++ b/personal-finance/src/app/features/incomes/components/incomes.component.spec.ts
@@ -122,10 +122,11 @@ describe('IncomesComponent', () => {
       });
     });
 
-    it('faz delete e create, e atualiza a lista', fakeAsync(() => {
+    it('faz delete e create, fecha modal e recarrega a lista', fakeAsync(() => {
       const updated: IncomeResponse = { ...INCOME, description: 'Salário Atualizado', amount: 3500 };
       apiSpy.deleteIncome.and.returnValue(of(undefined));
       apiSpy.createIncome.and.returnValue(of(updated));
+      apiSpy.getIncomesByPeriod.and.returnValue(of({ items: [updated], totalCount: 1, pageNumber: 1, pageSize: 20 }));
 
       component.onSubmit();
       tick();
@@ -153,6 +154,7 @@ describe('IncomesComponent', () => {
     });
 
     it('remove receita da lista', fakeAsync(() => {
+      apiSpy.getIncomesByPeriod.and.returnValue(of({ items: [], totalCount: 0, pageNumber: 1, pageSize: 20 }));
       component.deleteIncome('i-1');
       tick();
       expect(component.incomes().find(i => i.id === 'i-1')).toBeUndefined();


### PR DESCRIPTION
## Resumo

- `incomes.component.spec.ts`: mocks de `getIncomesByPeriod` atualizados nos testes de `deleteIncome` e `onSubmit edit` para refletir o `loadPage()` chamado após a operação

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)