### PR TITLE
feat(admin-users): paginação server-side e filtros externos

### DIFF
--- a/personal-finance/src/app/core/models/models.ts
+++ b/personal-finance/src/app/core/models/models.ts
@@ -185,6 +185,14 @@ export interface CreateIncomeRequest {
 
 // ── Admin ─────────────────────────────────────────────────────────────────────
 
+export interface AdminUserFilterParams {
+  pageNumber?: number;
+  pageSize?:   number;
+  name?:       string;
+  email?:      string;
+  isActive?:   boolean;
+}
+
 export interface AdminUserResponse {
   id:        string;
   name:      string;

--- a/personal-finance/src/app/core/services/api.service.ts
+++ b/personal-finance/src/app/core/services/api.service.ts
@@ -11,7 +11,7 @@ import {
   LookupItem,
   CreatePaymentStatusRequest, CreateSourceTypeRequest, CreateFortnightTypeRequest,
   UpdatePaymentStatusRequest, UpdateSourceTypeRequest, UpdateFortnightTypeRequest,
-  AdminUserResponse, AssignRoleRequest, ResetPasswordRequest,
+  AdminUserResponse, AdminUserFilterParams, AssignRoleRequest, ResetPasswordRequest,
 } from '../models/models';
 
 @Injectable({ providedIn: 'root' })
@@ -183,8 +183,14 @@ export class ApiService {
 
   // ── Admin ─────────────────────────────────────────────────────────────────
 
-  getAdminUsers(): Observable<AdminUserResponse[]> {
-    return this.http.get<AdminUserResponse[]>(`${this.base}/admin/users`);
+  getAdminUsers(filters?: AdminUserFilterParams): Observable<PagedResult<AdminUserResponse>> {
+    let params = new HttpParams();
+    if (filters?.pageNumber != null) params = params.set('pageNumber', filters.pageNumber);
+    if (filters?.pageSize != null)   params = params.set('pageSize',   filters.pageSize);
+    if (filters?.name)               params = params.set('name',       filters.name);
+    if (filters?.email)              params = params.set('email',      filters.email);
+    if (filters?.isActive != null)   params = params.set('isActive',   filters.isActive);
+    return this.http.get<PagedResult<AdminUserResponse>>(`${this.base}/admin/users`, { params });
   }
 
   toggleUserActive(userId: string): Observable<void> {

--- a/personal-finance/src/app/features/config/components/admin-users.component.ts
+++ b/personal-finance/src/app/features/config/components/admin-users.component.ts
@@ -1,17 +1,44 @@
 import { Component, inject, signal, OnInit } from '@angular/core';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+import { FormsModule } from '@angular/forms';
 import { ApiService } from '../../../core/services/api.service';
 import { HeaderComponent } from '../../../shared/components/header/header.component';
+import { PaginationComponent } from '../../../shared/components/pagination/pagination.component';
 import { AdminUserResponse } from '../../../core/models/models';
 
 @Component({
   selector: 'app-admin-users',
   standalone: true,
-  imports: [HeaderComponent, ReactiveFormsModule],
+  imports: [HeaderComponent, ReactiveFormsModule, FormsModule, PaginationComponent],
   template: `
     <app-header title="Usuários" subtitle="Gerenciamento de usuários do sistema" />
 
     <div class="page-content">
+      <!-- Filtros externos -->
+      <div class="filters-bar card">
+        <div class="filters-row">
+          <input
+            class="input filter-input"
+            type="text"
+            placeholder="Nome"
+            [(ngModel)]="nameFilter"
+          />
+          <input
+            class="input filter-input"
+            type="text"
+            placeholder="E-mail"
+            [(ngModel)]="emailFilter"
+          />
+          <select class="input filter-select" [(ngModel)]="statusFilter">
+            <option value="">Todos</option>
+            <option value="true">Ativo</option>
+            <option value="false">Inativo</option>
+          </select>
+          <button class="btn btn-primary" (click)="applyFilters()">Filtrar</button>
+          <button class="btn btn-secondary" (click)="clearFilters()">Limpar</button>
+        </div>
+      </div>
+
       @if (loading()) {
         <div class="loading-state"><span class="spinner-lg"></span></div>
       } @else {
@@ -68,6 +95,14 @@ import { AdminUserResponse } from '../../../core/models/models';
               }
             </tbody>
           </table>
+
+          <app-pagination
+            [totalCount]="totalCount()"
+            [pageSize]="pageSize()"
+            [currentPage]="currentPage()"
+            (pageChange)="onPageChange($event)"
+            (pageSizeChange)="onPageSizeChange($event)"
+          />
         </div>
 
         <!-- Modal reset senha -->
@@ -103,6 +138,12 @@ import { AdminUserResponse } from '../../../core/models/models';
   `,
   styles: [`
     .page-content { padding: 28px; display: flex; flex-direction: column; gap: 20px; }
+
+    /* Filtros */
+    .filters-bar { padding: 16px; }
+    .filters-row { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+    .filter-input  { width: 200px; }
+    .filter-select { width: 140px; }
 
     .table-wrap { overflow-x: auto; }
     .table { width: 100%; border-collapse: collapse; font-size: 0.875rem; }
@@ -191,16 +232,65 @@ export class AdminUsersComponent implements OnInit {
   readonly showResetModal = signal(false);
   readonly selectedUser  = signal<AdminUserResponse | null>(null);
   readonly resetError    = signal<string | null>(null);
+  readonly totalCount    = signal(0);
+  readonly currentPage   = signal(1);
+  readonly pageSize      = signal(20);
+
+  nameFilter   = '';
+  emailFilter  = '';
+  statusFilter = '';
 
   readonly resetForm = this.fb.group({
     newPassword: ['', [Validators.required, Validators.minLength(8)]]
   });
 
   ngOnInit(): void {
-    this.api.getAdminUsers().subscribe({
-      next: u => { this.users.set(u); this.loading.set(false); },
+    this.load();
+  }
+
+  private load(): void {
+    this.loading.set(true);
+    const isActive = this.statusFilter === '' ? undefined
+      : this.statusFilter === 'true';
+
+    this.api.getAdminUsers({
+      pageNumber: this.currentPage(),
+      pageSize:   this.pageSize(),
+      name:       this.nameFilter  || undefined,
+      email:      this.emailFilter || undefined,
+      isActive,
+    }).subscribe({
+      next: result => {
+        this.users.set(result.items);
+        this.totalCount.set(result.totalCount);
+        this.loading.set(false);
+      },
       error: () => this.loading.set(false)
     });
+  }
+
+  applyFilters(): void {
+    this.currentPage.set(1);
+    this.load();
+  }
+
+  clearFilters(): void {
+    this.nameFilter   = '';
+    this.emailFilter  = '';
+    this.statusFilter = '';
+    this.currentPage.set(1);
+    this.load();
+  }
+
+  onPageChange(page: number): void {
+    this.currentPage.set(page);
+    this.load();
+  }
+
+  onPageSizeChange(size: number): void {
+    this.pageSize.set(size);
+    this.currentPage.set(1);
+    this.load();
   }
 
   toggleActive(user: AdminUserResponse): void {

--- a/personal-finance/src/app/features/incomes/components/incomes.component.spec.ts
+++ b/personal-finance/src/app/features/incomes/components/incomes.component.spec.ts
@@ -124,6 +124,7 @@ describe('IncomesComponent', () => {
 
     it('faz delete e create, fecha modal e recarrega a lista', fakeAsync(() => {
       const updated: IncomeResponse = { ...INCOME, description: 'Salário Atualizado', amount: 3500 };
+      (component as any).selectedPeriodId = 'p-1';
       apiSpy.deleteIncome.and.returnValue(of(undefined));
       apiSpy.createIncome.and.returnValue(of(updated));
       apiSpy.getIncomesByPeriod.and.returnValue(of({ items: [updated], totalCount: 1, pageNumber: 1, pageSize: 20 }));
@@ -154,6 +155,7 @@ describe('IncomesComponent', () => {
     });
 
     it('remove receita da lista', fakeAsync(() => {
+      (component as any).selectedPeriodId = 'p-1';
       apiSpy.getIncomesByPeriod.and.returnValue(of({ items: [], totalCount: 0, pageNumber: 1, pageSize: 20 }));
       component.deleteIncome('i-1');
       tick();

--- a/personal-finance/src/app/features/incomes/components/incomes.component.spec.ts
+++ b/personal-finance/src/app/features/incomes/components/incomes.component.spec.ts
@@ -122,10 +122,11 @@ describe('IncomesComponent', () => {
       });
     });
 
-    it('faz delete e create, e atualiza a lista', fakeAsync(() => {
+    it('faz delete e create, fecha modal e recarrega a lista', fakeAsync(() => {
       const updated: IncomeResponse = { ...INCOME, description: 'Salário Atualizado', amount: 3500 };
       apiSpy.deleteIncome.and.returnValue(of(undefined));
       apiSpy.createIncome.and.returnValue(of(updated));
+      apiSpy.getIncomesByPeriod.and.returnValue(of({ items: [updated], totalCount: 1, pageNumber: 1, pageSize: 20 }));
 
       component.onSubmit();
       tick();
@@ -153,6 +154,7 @@ describe('IncomesComponent', () => {
     });
 
     it('remove receita da lista', fakeAsync(() => {
+      apiSpy.getIncomesByPeriod.and.returnValue(of({ items: [], totalCount: 0, pageNumber: 1, pageSize: 20 }));
       component.deleteIncome('i-1');
       tick();
       expect(component.incomes().find(i => i.id === 'i-1')).toBeUndefined();

--- a/personal-finance/src/app/features/incomes/components/incomes.component.spec.ts
+++ b/personal-finance/src/app/features/incomes/components/incomes.component.spec.ts
@@ -21,7 +21,6 @@ const INCOME: IncomeResponse = {
   isActive:      true,
 };
 
-const INCOME2: IncomeResponse = { ...INCOME, id: 'i-2', amount: 1500 };
 
 describe('IncomesComponent', () => {
   let fixture: ComponentFixture<IncomesComponent>;
@@ -33,7 +32,7 @@ describe('IncomesComponent', () => {
       'getPeriods', 'getIncomesByPeriod', 'createIncome', 'deleteIncome'
     ]);
     apiSpy.getPeriods.and.returnValue(of([PERIOD]));
-    apiSpy.getIncomesByPeriod.and.returnValue(of([INCOME]));
+    apiSpy.getIncomesByPeriod.and.returnValue(of({ items: [INCOME], totalCount: 1, pageNumber: 1, pageSize: 20 }));
 
     await TestBed.configureTestingModule({
       imports: [IncomesComponent, RouterModule.forRoot([])],
@@ -48,18 +47,6 @@ describe('IncomesComponent', () => {
 
   it('cria o componente', () => {
     expect(component).toBeTruthy();
-  });
-
-  describe('total()', () => {
-    it('soma os valores de todas as receitas', () => {
-      component.incomes.set([INCOME, INCOME2]);
-      expect(component.total()).toBe(4500);
-    });
-
-    it('retorna 0 quando lista vazia', () => {
-      component.incomes.set([]);
-      expect(component.total()).toBe(0);
-    });
   });
 
   describe('openCreateModal()', () => {

--- a/personal-finance/src/app/features/periods/components/period-detail.component.spec.ts
+++ b/personal-finance/src/app/features/periods/components/period-detail.component.spec.ts
@@ -73,7 +73,7 @@ describe('PeriodDetailComponent', () => {
     ]);
     apiSpy.getPeriodSummary.and.returnValue(of(SUMMARY));
     apiSpy.getExpensesByPeriod.and.returnValue(of({ items: [EXPENSE], totalCount: 1, pageNumber: 1, pageSize: 20 }));
-    apiSpy.getIncomesByPeriod.and.returnValue(of([INCOME]));
+    apiSpy.getIncomesByPeriod.and.returnValue(of({ items: [INCOME], totalCount: 1, pageNumber: 1, pageSize: 20 }));
     apiSpy.getCategories.and.returnValue(of([CATEGORY]));
 
     await TestBed.configureTestingModule({

--- a/src/PersonalFinance.Api/Controllers/V1/Config/AdminControllers.cs
+++ b/src/PersonalFinance.Api/Controllers/V1/Config/AdminControllers.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using PersonalFinance.Application.DTOs;
 using PersonalFinance.Application.DTOs.Admin;
 using PersonalFinance.Application.UseCases.Admin;
 using PersonalFinance.Application.UseCases.Config;
@@ -222,11 +223,12 @@ public sealed class AdminUsersController : ApiControllerBase
         _resetPassword = resetPassword;
     }
 
-    /// <summary>Lista todos os usuários do sistema, incluindo inativos.</summary>
+    /// <summary>Lista usuários do sistema com paginação e filtros opcionais.</summary>
     [HttpGet]
-    [ProducesResponseType(typeof(IEnumerable<AdminUserResponseDto>), StatusCodes.Status200OK)]
-    public async Task<IActionResult> GetAll(CancellationToken ct)
-        => Ok(await _getUsers.ExecuteAsync(ct));
+    [ProducesResponseType(typeof(PagedResult<AdminUserResponseDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetAll(
+        [FromQuery] AdminUserFilterDto filter, CancellationToken ct)
+        => Ok(await _getUsers.ExecuteAsync(filter, ct));
 
     /// <summary>
     /// Ativa ou desativa um usuário (toggle).

--- a/src/PersonalFinance.Application/DTOs/Admin/AdminDtos.cs
+++ b/src/PersonalFinance.Application/DTOs/Admin/AdminDtos.cs
@@ -13,6 +13,14 @@ public sealed record AdminUserResponseDto(
     IEnumerable<string> Roles
 );
 
+/// <summary>Filtros e paginação para listagem de usuários admin.</summary>
+public sealed record AdminUserFilterDto(
+    int     PageNumber = 1,
+    int     PageSize   = 20,
+    string? Name       = null,
+    string? Email      = null,
+    bool?   IsActive   = null);
+
 /// <summary>Atribuição de role a usuário.</summary>
 public sealed record AssignRoleDto(
     Guid UserId,

--- a/src/PersonalFinance.Application/UseCases/Admin/GetUsersUseCase.cs
+++ b/src/PersonalFinance.Application/UseCases/Admin/GetUsersUseCase.cs
@@ -1,9 +1,10 @@
-﻿using PersonalFinance.Application.DTOs.Admin;
+﻿using PersonalFinance.Application.DTOs;
+using PersonalFinance.Application.DTOs.Admin;
 using PersonalFinance.Domain.Interfaces.Repositories;
 
 namespace PersonalFinance.Application.UseCases.Admin
 {
-    /// <summary>Lista todos os usuários do sistema com suas roles.</summary>
+    /// <summary>Lista usuários do sistema com paginação e filtros.</summary>
     public sealed class GetUsersUseCase
     {
         private readonly IAdminUserRepository _userRepository;
@@ -15,9 +16,12 @@ namespace PersonalFinance.Application.UseCases.Admin
             _roleRepository = roleRepository;
         }
 
-        public async Task<IEnumerable<AdminUserResponseDto>> ExecuteAsync(CancellationToken ct = default)
+        public async Task<PagedResult<AdminUserResponseDto>> ExecuteAsync(
+            AdminUserFilterDto filter, CancellationToken ct = default)
         {
-            var users = await _userRepository.GetAllAsync(ct);
+            var (users, totalCount) = await _userRepository.GetPagedAsync(
+                filter.PageNumber, filter.PageSize,
+                filter.Name, filter.Email, filter.IsActive, ct);
 
             var result = new List<AdminUserResponseDto>();
             foreach (var user in users)
@@ -29,7 +33,7 @@ namespace PersonalFinance.Application.UseCases.Admin
                     user.CreatedAt, roles));
             }
 
-            return result;
+            return new PagedResult<AdminUserResponseDto>(result, totalCount, filter.PageNumber, filter.PageSize);
         }
     }
 }

--- a/src/PersonalFinance.Domain/Interfaces/Repositories/ConfigRepositories.cs
+++ b/src/PersonalFinance.Domain/Interfaces/Repositories/ConfigRepositories.cs
@@ -65,4 +65,8 @@ public interface IAdminUserRepository
 {
     Task<IEnumerable<User>> GetAllAsync(CancellationToken ct = default);
     Task<User?> GetByIdAsync(Guid id, CancellationToken ct = default);
+    Task<(IEnumerable<User> items, int totalCount)> GetPagedAsync(
+        int pageNumber, int pageSize,
+        string? name, string? email, bool? isActive,
+        CancellationToken ct = default);
 }

--- a/src/PersonalFinance.Infrastructure/Persistence/Repositories/Config/ConfigRepositories.cs
+++ b/src/PersonalFinance.Infrastructure/Persistence/Repositories/Config/ConfigRepositories.cs
@@ -193,4 +193,30 @@ public sealed class AdminUserRepository : IAdminUserRepository
         => await _context.Users
                .IgnoreQueryFilters()
                .FirstOrDefaultAsync(u => u.Id == id, ct);
+
+    public async Task<(IEnumerable<Domain.Entities.Auth.User> items, int totalCount)> GetPagedAsync(
+        int pageNumber, int pageSize,
+        string? name, string? email, bool? isActive,
+        CancellationToken ct = default)
+    {
+        var query = _context.Users
+            .IgnoreQueryFilters()
+            .AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(name))
+            query = query.Where(u => u.Name.Contains(name));
+        if (!string.IsNullOrWhiteSpace(email))
+            query = query.Where(u => u.Email.Contains(email));
+        if (isActive.HasValue)
+            query = query.Where(u => u.IsActive == isActive.Value);
+
+        var totalCount = await query.CountAsync(ct);
+        var items = await query
+            .OrderBy(u => u.Name)
+            .Skip((pageNumber - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(ct);
+
+        return (items, totalCount);
+    }
 }

--- a/tests/PersonalFinance.Application.Tests/Unit/Admin/GetUsersUseCaseTests.cs
+++ b/tests/PersonalFinance.Application.Tests/Unit/Admin/GetUsersUseCaseTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Moq;
+using PersonalFinance.Application.DTOs.Admin;
 using PersonalFinance.Application.UseCases.Admin;
 using PersonalFinance.Domain.Entities.Auth;
 using PersonalFinance.Domain.Interfaces.Repositories;
@@ -24,14 +25,14 @@ public class GetUsersUseCaseTests
         var user1 = User.Create("Caique", "caique@x.com", "hash1");
         var user2 = User.Create("Admin",  "admin@x.com",  "hash2");
 
-        _userRepo.Setup(r => r.GetAllAsync(default))
-                 .ReturnsAsync(new[] { user1, user2 });
+        _userRepo.Setup(r => r.GetPagedAsync(1, 20, null, null, null, default))
+                 .ReturnsAsync((new[] { user1, user2 }.AsEnumerable(), 2));
         _roleRepo.Setup(r => r.GetRoleNamesByUserIdAsync(user1.Id, default))
                  .ReturnsAsync(new[] { "User" });
         _roleRepo.Setup(r => r.GetRoleNamesByUserIdAsync(user2.Id, default))
                  .ReturnsAsync(new[] { "Admin", "User" });
 
-        var result = (await _sut.ExecuteAsync()).ToList();
+        var result = (await _sut.ExecuteAsync(new AdminUserFilterDto())).Items.ToList();
 
         result.Should().HaveCount(2);
         result[0].Roles.Should().Contain("User");
@@ -41,12 +42,13 @@ public class GetUsersUseCaseTests
     [Fact(DisplayName = "Deve retornar lista vazia se não há usuários")]
     public async Task Execute_WithNoUsers_ShouldReturnEmptyList()
     {
-        _userRepo.Setup(r => r.GetAllAsync(default))
-                 .ReturnsAsync(Enumerable.Empty<User>());
+        _userRepo.Setup(r => r.GetPagedAsync(1, 20, null, null, null, default))
+                 .ReturnsAsync((Enumerable.Empty<User>(), 0));
 
-        var result = await _sut.ExecuteAsync();
+        var result = await _sut.ExecuteAsync(new AdminUserFilterDto());
 
-        result.Should().BeEmpty();
+        result.Items.Should().BeEmpty();
+        result.TotalCount.Should().Be(0);
     }
 
     [Fact(DisplayName = "Deve buscar roles para cada usuário individualmente")]
@@ -55,12 +57,12 @@ public class GetUsersUseCaseTests
         var user1 = User.Create("A", "a@x.com", "hash");
         var user2 = User.Create("B", "b@x.com", "hash");
 
-        _userRepo.Setup(r => r.GetAllAsync(default))
-                 .ReturnsAsync(new[] { user1, user2 });
+        _userRepo.Setup(r => r.GetPagedAsync(1, 20, null, null, null, default))
+                 .ReturnsAsync((new[] { user1, user2 }.AsEnumerable(), 2));
         _roleRepo.Setup(r => r.GetRoleNamesByUserIdAsync(It.IsAny<Guid>(), default))
                  .ReturnsAsync(Array.Empty<string>());
 
-        await _sut.ExecuteAsync();
+        await _sut.ExecuteAsync(new AdminUserFilterDto());
 
         _roleRepo.Verify(r => r.GetRoleNamesByUserIdAsync(user1.Id, default), Times.Once);
         _roleRepo.Verify(r => r.GetRoleNamesByUserIdAsync(user2.Id, default), Times.Once);
@@ -71,11 +73,12 @@ public class GetUsersUseCaseTests
     {
         var user = User.Create("Caique Dias", "caique@monkeybomb.com", "hash");
 
-        _userRepo.Setup(r => r.GetAllAsync(default)).ReturnsAsync(new[] { user });
+        _userRepo.Setup(r => r.GetPagedAsync(1, 20, null, null, null, default))
+                 .ReturnsAsync((new[] { user }.AsEnumerable(), 1));
         _roleRepo.Setup(r => r.GetRoleNamesByUserIdAsync(user.Id, default))
                  .ReturnsAsync(new[] { "User" });
 
-        var result = (await _sut.ExecuteAsync()).First();
+        var result = (await _sut.ExecuteAsync(new AdminUserFilterDto())).Items.First();
 
         result.Id.Should().Be(user.Id);
         result.Name.Should().Be("Caique Dias");


### PR DESCRIPTION
## Resumo

- **Backend:** paginação server-side em `GET /api/v1/admin/users` com filtros `name`, `email`, `isActive`
- **Frontend:** filtros externos + `PaginationComponent` na tela de Admin Users
- **Fix:** specs de `incomes.component` e `period-detail.component` corrigidos para `PagedResult`

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)