### PR TITLE
feat(dashboard): gráficos de despesas por categoria (#40)

### DIFF
--- a/personal-finance/src/app/app.config.ts
+++ b/personal-finance/src/app/app.config.ts
@@ -2,6 +2,7 @@ import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter, withComponentInputBinding } from '@angular/router';
 import { provideHttpClient, withInterceptors, withFetch } from '@angular/common/http';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { provideEcharts } from 'ngx-echarts';
 import { routes } from './app.routes';
 import { authInterceptor } from './core/auth/auth.interceptor';
 
@@ -14,5 +15,6 @@ export const appConfig: ApplicationConfig = {
       withInterceptors([authInterceptor])
     ),
     provideAnimationsAsync(),
+    provideEcharts(),
   ]
 };

--- a/personal-finance/src/app/core/models/models.ts
+++ b/personal-finance/src/app/core/models/models.ts
@@ -243,3 +243,18 @@ export const FORTNIGHT_TYPE_LABELS: Record<FortnightType, string> = {
   [FortnightType.First]:  '1ª Quinzena',
   [FortnightType.Second]: '2ª Quinzena',
 };
+
+// ── Reports ───────────────────────────────────────────────────────────────────
+
+export interface ExpenseByCategoryItem {
+  categoryId:    string;
+  categoryName:  string;
+  categoryColor: string;
+  total:         number;
+}
+
+export interface ExpensesReport {
+  year:  number;
+  month: number | null;
+  items: ExpenseByCategoryItem[];
+}

--- a/personal-finance/src/app/core/services/api.service.ts
+++ b/personal-finance/src/app/core/services/api.service.ts
@@ -12,6 +12,7 @@ import {
   CreatePaymentStatusRequest, CreateSourceTypeRequest, CreateFortnightTypeRequest,
   UpdatePaymentStatusRequest, UpdateSourceTypeRequest, UpdateFortnightTypeRequest,
   AdminUserResponse, AdminUserFilterParams, AssignRoleRequest, ResetPasswordRequest,
+  ExpensesReport,
 } from '../models/models';
 
 @Injectable({ providedIn: 'root' })
@@ -208,5 +209,13 @@ export class ApiService {
 
   resetUserPassword(userId: string, data: ResetPasswordRequest): Observable<void> {
     return this.http.patch<void>(`${this.base}/admin/users/${userId}/reset-password`, data);
+  }
+
+  // ── Reports ────────────────────────────────────────────────────────────────
+
+  getExpensesReport(year: number, month?: number): Observable<ExpensesReport> {
+    let params = new HttpParams().set('year', year);
+    if (month != null) params = params.set('month', month);
+    return this.http.get<ExpensesReport>(`${this.base}/reports/expenses`, { params });
   }
 }

--- a/personal-finance/src/app/features/dashboard/components/dashboard.component.spec.ts
+++ b/personal-finance/src/app/features/dashboard/components/dashboard.component.spec.ts
@@ -6,7 +6,7 @@ import { of, throwError } from 'rxjs';
 import { DashboardComponent } from './dashboard.component';
 import { ApiService } from '../../../core/services/api.service';
 import { AuthService } from '../../../core/auth/auth.service';
-import { PeriodResponse, PeriodSummary } from '../../../core/models/models';
+import { PeriodResponse, PeriodSummary, ExpensesReport } from '../../../core/models/models';
 
 const MOCK_PERIODS: PeriodResponse[] = [
   { id: 'p-1', userId: 'u', year: 2024, month: 3, isActive: true },
@@ -34,11 +34,13 @@ describe('DashboardComponent', () => {
   let authSpy: jasmine.SpyObj<AuthService>;
 
   beforeEach(async () => {
-    apiSpy  = jasmine.createSpyObj('ApiService', ['getPeriods', 'getPeriodSummary']);
+    apiSpy  = jasmine.createSpyObj('ApiService', ['getPeriods', 'getPeriodSummary', 'getExpensesReport']);
     authSpy = jasmine.createSpyObj('AuthService', [], { currentUser: () => ({ name: 'Caique', email: 'c@t.com' }) });
 
+    const emptyReport: ExpensesReport = { year: 2024, month: null, items: [] };
     apiSpy.getPeriods.and.returnValue(of(MOCK_PERIODS));
     apiSpy.getPeriodSummary.and.returnValue(of(MOCK_SUMMARY));
+    apiSpy.getExpensesReport.and.returnValue(of(emptyReport));
 
     await TestBed.configureTestingModule({
       imports: [DashboardComponent, RouterModule.forRoot([])],

--- a/personal-finance/src/app/features/dashboard/components/dashboard.component.ts
+++ b/personal-finance/src/app/features/dashboard/components/dashboard.component.ts
@@ -1,19 +1,19 @@
 import { Component, inject, signal, computed, OnInit } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { DecimalPipe } from '@angular/common';
-import { toSignal } from '@angular/core/rxjs-interop';
-import { switchMap, catchError, of } from 'rxjs';
+import { NgxEchartsDirective } from 'ngx-echarts';
+import type { EChartsOption } from 'echarts';
 import { ApiService } from '../../../core/services/api.service';
 import { AuthService } from '../../../core/auth/auth.service';
 import { HeaderComponent } from '../../../shared/components/header/header.component';
 import { StatCardComponent } from '../../../shared/components/stat-card/stat-card.component';
 import { CurrencyBrlPipe } from '../../../shared/pipes/currency-brl.pipe';
-import { PeriodResponse, PeriodSummary, MONTH_NAMES, PaymentStatus } from '../../../core/models/models';
+import { PeriodResponse, PeriodSummary, MONTH_NAMES, MONTH_NAMES as MONTHS, PaymentStatus, ExpensesReport } from '../../../core/models/models';
 
 @Component({
   selector: 'app-dashboard',
   standalone: true,
-  imports: [HeaderComponent, StatCardComponent, CurrencyBrlPipe, DecimalPipe, RouterLink],
+  imports: [HeaderComponent, StatCardComponent, CurrencyBrlPipe, DecimalPipe, RouterLink, NgxEchartsDirective],
   template: `
     <app-header
       title="Dashboard"
@@ -170,6 +170,51 @@ import { PeriodResponse, PeriodSummary, MONTH_NAMES, PaymentStatus } from '../..
       } @else if (!loadingPeriods() && filteredPeriods().length > 0) {
         <div class="empty-state">
           <span>Selecione um período para ver o resumo</span>
+        </div>
+      }
+
+      <!-- Gráficos de despesas -->
+      @if (availableYears().length > 0) {
+        <div class="charts-section">
+          <h2 class="charts-section-title">Análise de Despesas — {{ selectedYear() }}</h2>
+          <div class="charts-grid">
+
+            <!-- Gráfico 1 — Pizza por categoria (anual) -->
+            <div class="card chart-card">
+              <h3 class="detail-card-title">Despesas por Categoria (Anual)</h3>
+              @if (loadingChart1()) {
+                <div class="chart-loading"><span class="spinner-lg"></span></div>
+              } @else if (chart1Options()) {
+                <div echarts [options]="chart1Options()!" class="echart"></div>
+              } @else {
+                <div class="chart-empty">Sem dados para o período</div>
+              }
+            </div>
+
+            <!-- Gráfico 2 — Barras por categoria (mensal) -->
+            <div class="card chart-card">
+              <div class="chart-card-header">
+                <h3 class="detail-card-title" style="margin-bottom:0">Despesas por Categoria</h3>
+                <select
+                  class="year-dropdown"
+                  [value]="selectedMonth()"
+                  (change)="selectMonth(+$any($event.target).value)"
+                >
+                  @for (m of MONTH_NAMES; track $index) {
+                    <option [value]="$index + 1">{{ m }}</option>
+                  }
+                </select>
+              </div>
+              @if (loadingChart2()) {
+                <div class="chart-loading"><span class="spinner-lg"></span></div>
+              } @else if (chart2Options()) {
+                <div echarts [options]="chart2Options()!" class="echart"></div>
+              } @else {
+                <div class="chart-empty">Sem dados para o período</div>
+              }
+            </div>
+
+          </div>
         </div>
       }
 
@@ -364,11 +409,54 @@ import { PeriodResponse, PeriodSummary, MONTH_NAMES, PaymentStatus } from '../..
     }
 
     @keyframes spin { to { transform: rotate(360deg); } }
+
+    /* ── Gráficos ── */
+    .charts-section {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    .charts-section-title {
+      font-size: 1rem;
+      font-weight: 600;
+      color: var(--ink);
+    }
+
+    .charts-grid {
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 16px;
+    }
+
+    @media (max-width: 960px) { .charts-grid { grid-template-columns: 1fr; } }
+
+    .chart-card { padding: 20px; }
+
+    .chart-card-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 16px;
+    }
+
+    .echart { width: 100%; height: 300px; }
+
+    .chart-loading, .chart-empty {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 300px;
+      color: var(--ink3);
+      font-size: 0.875rem;
+    }
   `]
 })
 export class DashboardComponent implements OnInit {
   private readonly api  = inject(ApiService);
   private readonly auth = inject(AuthService);
+
+  readonly MONTH_NAMES = MONTH_NAMES;
 
   readonly periods          = signal<PeriodResponse[]>([]);
   readonly selectedYear     = signal<number>(new Date().getFullYear());
@@ -376,6 +464,12 @@ export class DashboardComponent implements OnInit {
   readonly summary          = signal<PeriodSummary | null>(null);
   readonly loadingPeriods   = signal(true);
   readonly loadingSummary   = signal(false);
+
+  readonly selectedMonth  = signal<number>(new Date().getMonth() + 1);
+  readonly loadingChart1  = signal(false);
+  readonly loadingChart2  = signal(false);
+  readonly chart1Options  = signal<EChartsOption | null>(null);
+  readonly chart2Options  = signal<EChartsOption | null>(null);
 
   readonly availableYears = computed(() =>
     [...new Set(this.periods().map(p => p.year))].sort((a, b) => b - a)
@@ -421,6 +515,8 @@ export class DashboardComponent implements OnInit {
           }
           // Seleciona o período mais recente por padrão
           this.selectPeriod(periods[0].id);
+          // Carrega gráficos com o ano selecionado
+          this.loadCharts(this.selectedYear(), this.selectedMonth());
         }
       },
       error: () => this.loadingPeriods.set(false)
@@ -445,9 +541,95 @@ export class DashboardComponent implements OnInit {
     this.selectedYear.set(year);
     this.selectedPeriodId.set(null);
     this.summary.set(null);
+    this.loadCharts(year, this.selectedMonth());
+  }
+
+  selectMonth(month: number): void {
+    this.selectedMonth.set(month);
+    this.loadChart2(this.selectedYear(), month);
   }
 
   monthName(month: number): string {
     return MONTH_NAMES[month - 1].substring(0, 3);
+  }
+
+  private loadCharts(year: number, month: number): void {
+    this.loadChart1(year);
+    this.loadChart2(year, month);
+  }
+
+  private loadChart1(year: number): void {
+    this.loadingChart1.set(true);
+    this.chart1Options.set(null);
+    this.api.getExpensesReport(year).subscribe({
+      next: report => {
+        this.chart1Options.set(this.buildPieOptions(report));
+        this.loadingChart1.set(false);
+      },
+      error: () => this.loadingChart1.set(false),
+    });
+  }
+
+  private loadChart2(year: number, month: number): void {
+    this.loadingChart2.set(true);
+    this.chart2Options.set(null);
+    this.api.getExpensesReport(year, month).subscribe({
+      next: report => {
+        this.chart2Options.set(this.buildBarOptions(report));
+        this.loadingChart2.set(false);
+      },
+      error: () => this.loadingChart2.set(false),
+    });
+  }
+
+  private buildPieOptions(report: ExpensesReport): EChartsOption | null {
+    if (!report.items.length) return null;
+    return {
+      tooltip: {
+        trigger: 'item',
+        formatter: (params: any) =>
+          `${params.name}<br/><b>R$ ${params.value.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}</b> (${params.percent}%)`,
+      },
+      legend: { orient: 'vertical', right: 10, top: 'center', textStyle: { fontSize: 12 } },
+      series: [{
+        type: 'pie',
+        radius: ['40%', '70%'],
+        center: ['38%', '50%'],
+        avoidLabelOverlap: false,
+        label: { show: false },
+        emphasis: { label: { show: true, fontSize: 13, fontWeight: 'bold' } },
+        data: report.items.map(i => ({
+          name: i.categoryName,
+          value: i.total,
+          itemStyle: { color: i.categoryColor },
+        })),
+      }],
+    };
+  }
+
+  private buildBarOptions(report: ExpensesReport): EChartsOption | null {
+    if (!report.items.length) return null;
+    return {
+      tooltip: {
+        trigger: 'axis',
+        axisPointer: { type: 'shadow' },
+        formatter: (params: any) => {
+          const p = Array.isArray(params) ? params[0] : params;
+          return `${p.name}<br/><b>R$ ${Number(p.value).toLocaleString('pt-BR', { minimumFractionDigits: 2 })}</b>`;
+        },
+      },
+      grid: { left: 16, right: 16, bottom: 40, top: 16, containLabel: true },
+      xAxis: {
+        type: 'category',
+        data: report.items.map(i => i.categoryName),
+        axisLabel: { fontSize: 11, rotate: report.items.length > 5 ? 30 : 0 },
+      },
+      yAxis: { type: 'value', axisLabel: { formatter: (v: number) => `R$ ${v.toLocaleString('pt-BR')}` } },
+      series: [{
+        type: 'bar',
+        data: report.items.map(i => ({ value: i.total, itemStyle: { color: i.categoryColor } })),
+        barMaxWidth: 60,
+      }],
+    };
   }
 }

--- a/personal-finance/src/app/features/dashboard/components/dashboard.component.ts
+++ b/personal-finance/src/app/features/dashboard/components/dashboard.component.ts
@@ -1,10 +1,11 @@
-import { Component, inject, signal, computed, OnInit } from '@angular/core';
+import { Component, inject, signal, computed, OnInit, effect } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { DecimalPipe } from '@angular/common';
 import { NgxEchartsDirective } from 'ngx-echarts';
 import type { EChartsOption } from 'echarts';
 import { ApiService } from '../../../core/services/api.service';
 import { AuthService } from '../../../core/auth/auth.service';
+import { ThemeService } from '../../../core/services/theme.service';
 import { HeaderComponent } from '../../../shared/components/header/header.component';
 import { StatCardComponent } from '../../../shared/components/stat-card/stat-card.component';
 import { CurrencyBrlPipe } from '../../../shared/pipes/currency-brl.pipe';
@@ -453,8 +454,9 @@ import { PeriodResponse, PeriodSummary, MONTH_NAMES, MONTH_NAMES as MONTHS, Paym
   `]
 })
 export class DashboardComponent implements OnInit {
-  private readonly api  = inject(ApiService);
-  private readonly auth = inject(AuthService);
+  private readonly api   = inject(ApiService);
+  private readonly auth  = inject(AuthService);
+  private readonly theme = inject(ThemeService);
 
   readonly MONTH_NAMES = MONTH_NAMES;
 
@@ -470,6 +472,8 @@ export class DashboardComponent implements OnInit {
   readonly loadingChart2  = signal(false);
   readonly chart1Options  = signal<EChartsOption | null>(null);
   readonly chart2Options  = signal<EChartsOption | null>(null);
+
+  private readonly chartTextColor = computed(() => this.theme.isDark() ? '#ccc' : '#444');
 
   readonly availableYears = computed(() =>
     [...new Set(this.periods().map(p => p.year))].sort((a, b) => b - a)
@@ -501,6 +505,15 @@ export class DashboardComponent implements OnInit {
   readonly incomeIcon = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>`;
   readonly expenseIcon = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><polyline points="19 12 12 19 5 12"/></svg>`;
   readonly owedIcon    = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>`;
+
+  constructor() {
+    // Reconstrói os gráficos ao trocar de tema para aplicar cor de texto correta
+    effect(() => {
+      this.theme.isDark(); // leitura reativa
+      if (this.chart1Options()) this.loadChart1(this.selectedYear());
+      if (this.chart2Options()) this.loadChart2(this.selectedYear(), this.selectedMonth());
+    });
+  }
 
   ngOnInit(): void {
     this.api.getPeriods().subscribe({
@@ -575,7 +588,7 @@ export class DashboardComponent implements OnInit {
     this.chart2Options.set(null);
     this.api.getExpensesReport(year, month).subscribe({
       next: report => {
-        this.chart2Options.set(this.buildBarOptions(report));
+        this.chart2Options.set(this.buildPieOptions(report));
         this.loadingChart2.set(false);
       },
       error: () => this.loadingChart2.set(false),
@@ -584,51 +597,33 @@ export class DashboardComponent implements OnInit {
 
   private buildPieOptions(report: ExpensesReport): EChartsOption | null {
     if (!report.items.length) return null;
+    const textColor = this.chartTextColor();
     return {
       tooltip: {
         trigger: 'item',
         formatter: (params: any) =>
           `${params.name}<br/><b>R$ ${params.value.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}</b> (${params.percent}%)`,
       },
-      legend: { orient: 'vertical', right: 10, top: 'center', textStyle: { fontSize: 12 } },
+      legend: {
+        orient: 'vertical',
+        right: 10,
+        top: 'center',
+        textStyle: { fontSize: 12, color: textColor },
+      },
       series: [{
         type: 'pie',
         radius: ['40%', '70%'],
         center: ['38%', '50%'],
         avoidLabelOverlap: false,
         label: { show: false },
-        emphasis: { label: { show: true, fontSize: 13, fontWeight: 'bold' } },
+        emphasis: {
+          label: { show: true, fontSize: 13, fontWeight: 'bold', color: textColor },
+        },
         data: report.items.map(i => ({
           name: i.categoryName,
           value: i.total,
           itemStyle: { color: i.categoryColor },
         })),
-      }],
-    };
-  }
-
-  private buildBarOptions(report: ExpensesReport): EChartsOption | null {
-    if (!report.items.length) return null;
-    return {
-      tooltip: {
-        trigger: 'axis',
-        axisPointer: { type: 'shadow' },
-        formatter: (params: any) => {
-          const p = Array.isArray(params) ? params[0] : params;
-          return `${p.name}<br/><b>R$ ${Number(p.value).toLocaleString('pt-BR', { minimumFractionDigits: 2 })}</b>`;
-        },
-      },
-      grid: { left: 16, right: 16, bottom: 40, top: 16, containLabel: true },
-      xAxis: {
-        type: 'category',
-        data: report.items.map(i => i.categoryName),
-        axisLabel: { fontSize: 11, rotate: report.items.length > 5 ? 30 : 0 },
-      },
-      yAxis: { type: 'value', axisLabel: { formatter: (v: number) => `R$ ${v.toLocaleString('pt-BR')}` } },
-      series: [{
-        type: 'bar',
-        data: report.items.map(i => ({ value: i.total, itemStyle: { color: i.categoryColor } })),
-        barMaxWidth: 60,
       }],
     };
   }

--- a/personal-finance/src/app/features/dashboard/components/dashboard.component.ts
+++ b/personal-finance/src/app/features/dashboard/components/dashboard.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal, computed, OnInit, effect } from '@angular/core';
+import { Component, inject, signal, computed, OnInit, effect, untracked } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { DecimalPipe } from '@angular/common';
 import { NgxEchartsDirective } from 'ngx-echarts';
@@ -507,11 +507,14 @@ export class DashboardComponent implements OnInit {
   readonly owedIcon    = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>`;
 
   constructor() {
-    // Reconstrói os gráficos ao trocar de tema para aplicar cor de texto correta
+    // Reconstrói os gráficos ao trocar de tema para aplicar cor de texto correta.
+    // untracked() evita dependência nos signals de opções, prevenindo loop.
     effect(() => {
-      this.theme.isDark(); // leitura reativa
-      if (this.chart1Options()) this.loadChart1(this.selectedYear());
-      if (this.chart2Options()) this.loadChart2(this.selectedYear(), this.selectedMonth());
+      this.theme.isDark(); // única dependência reativa: mudança de tema
+      untracked(() => {
+        if (this.chart1Options()) this.loadChart1(this.selectedYear());
+        if (this.chart2Options()) this.loadChart2(this.selectedYear(), this.selectedMonth());
+      });
     });
   }
 

--- a/src/PersonalFinance.Api/Controllers/V1/Reports/ReportsController.cs
+++ b/src/PersonalFinance.Api/Controllers/V1/Reports/ReportsController.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Mvc;
+using PersonalFinance.Application.DTOs.Reports;
+using PersonalFinance.Application.UseCases.Reports;
+
+namespace PersonalFinance.Api.Controllers.V1.Reports;
+
+/// <summary>
+/// Endpoints de relatórios de despesas.
+/// </summary>
+[Route("api/v1/reports")]
+public sealed class ReportsController(GetExpensesReportUseCase getExpensesReportUseCase)
+    : ApiControllerBase
+{
+    private readonly GetExpensesReportUseCase _getExpensesReportUseCase = getExpensesReportUseCase;
+
+    /// <summary>
+    /// Retorna despesas agrupadas por categoria para o ano informado.
+    /// Quando month é informado, filtra pelo mês específico.
+    /// </summary>
+    [HttpGet("expenses")]
+    [ProducesResponseType(typeof(ExpensesReportDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> GetExpenses(
+        [FromQuery] int year,
+        [FromQuery] int? month,
+        CancellationToken ct)
+    {
+        if (year <= 0)
+            return BadRequest("O ano é obrigatório.");
+
+        if (month.HasValue && (month < 1 || month > 12))
+            return BadRequest("O mês deve estar entre 1 e 12.");
+
+        var result = await _getExpensesReportUseCase.ExecuteAsync(CurrentUserId, year, month, ct);
+        return Ok(result);
+    }
+}

--- a/src/PersonalFinance.Api/Extensions/ApplicationExtensions.cs
+++ b/src/PersonalFinance.Api/Extensions/ApplicationExtensions.cs
@@ -5,6 +5,7 @@ using PersonalFinance.Application.UseCases.Financial.Expenses;
 using PersonalFinance.Application.UseCases.Financial.Incomes;
 using PersonalFinance.Application.UseCases.Financial.Periods;
 using PersonalFinance.Application.UseCases.Import;
+using PersonalFinance.Application.UseCases.Reports;
 
 namespace PersonalFinance.Api.Extensions;
 
@@ -68,6 +69,9 @@ public static class ApplicationExtensions
 
         // ── Import ────────────────────────────────────────────────────────────────────
         services.AddScoped<ImportLegacyDataUseCase>();
+
+        // ── Reports ───────────────────────────────────────────────────────────
+        services.AddScoped<GetExpensesReportUseCase>();
 
         return services;
     }

--- a/src/PersonalFinance.Application/DTOs/Reports/ReportDtos.cs
+++ b/src/PersonalFinance.Application/DTOs/Reports/ReportDtos.cs
@@ -1,0 +1,22 @@
+namespace PersonalFinance.Application.DTOs.Reports;
+
+/// <summary>
+/// Item de despesa agrupado por categoria.
+/// </summary>
+public sealed record ExpenseByCategoryItemDto(
+    Guid    CategoryId,
+    string  CategoryName,
+    string  CategoryColor,
+    decimal Total
+);
+
+/// <summary>
+/// Resultado do relatório de despesas.
+/// Month nulo → agregação anual por categoria (Gráfico 1 — pizza).
+/// Month preenchido → agregação do mês por categoria (Gráfico 2 — barras).
+/// </summary>
+public sealed record ExpensesReportDto(
+    int                                    Year,
+    int?                                   Month,
+    IReadOnlyList<ExpenseByCategoryItemDto> Items
+);

--- a/src/PersonalFinance.Application/Interfaces/IReportRepository.cs
+++ b/src/PersonalFinance.Application/Interfaces/IReportRepository.cs
@@ -1,4 +1,5 @@
 using PersonalFinance.Application.DTOs.Financial;
+using PersonalFinance.Application.DTOs.Reports;
 
 namespace PersonalFinance.Application.Interfaces;
 
@@ -17,5 +18,15 @@ public interface IReportRepository
     Task<PeriodSummaryDto?> GetPeriodSummaryAsync(
         Guid periodId,
         Guid userId,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Agrega despesas por categoria para o ano informado.
+    /// Se month for informado, filtra pelo mês específico.
+    /// </summary>
+    Task<ExpensesReportDto> GetExpensesReportAsync(
+        Guid userId,
+        int year,
+        int? month,
         CancellationToken ct = default);
 }

--- a/src/PersonalFinance.Application/UseCases/Reports/GetExpensesReportUseCase.cs
+++ b/src/PersonalFinance.Application/UseCases/Reports/GetExpensesReportUseCase.cs
@@ -1,0 +1,22 @@
+using PersonalFinance.Application.DTOs.Reports;
+using PersonalFinance.Application.Interfaces;
+
+namespace PersonalFinance.Application.UseCases.Reports;
+
+/// <summary>
+/// Retorna despesas agrupadas por categoria para o ano (e opcionalmente mês) informado.
+/// </summary>
+public sealed class GetExpensesReportUseCase
+{
+    private readonly IReportRepository _repository;
+
+    public GetExpensesReportUseCase(IReportRepository repository)
+        => _repository = repository;
+
+    public Task<ExpensesReportDto> ExecuteAsync(
+        Guid userId,
+        int year,
+        int? month,
+        CancellationToken ct = default)
+        => _repository.GetExpensesReportAsync(userId, year, month, ct);
+}

--- a/src/PersonalFinance.Infrastructure/Persistence/Repositories/Reports/ReportRepository.cs
+++ b/src/PersonalFinance.Infrastructure/Persistence/Repositories/Reports/ReportRepository.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using PersonalFinance.Application.DTOs.Financial;
+using PersonalFinance.Application.DTOs.Reports;
 using PersonalFinance.Application.Interfaces;
 using PersonalFinance.Infrastructure.Persistence.Context;
 
@@ -59,6 +60,39 @@ namespace PersonalFinance.Infrastructure.Persistence.Repositories.Reports
                 TotalSecondFortnight: row.TotalSecondFortnight,
                 Balance: row.Balance
             );
+        }
+
+        public async Task<ExpensesReportDto> GetExpensesReportAsync(
+            Guid userId,
+            int year,
+            int? month,
+            CancellationToken ct = default)
+        {
+            var shortYear = (short)year;
+
+            var items = await _context.Expenses
+                .Join(_context.Periods,
+                    e => e.PeriodId,
+                    p => p.Id,
+                    (e, p) => new { Expense = e, Period = p })
+                .Where(x =>
+                    x.Expense.UserId == userId &&
+                    x.Period.Year == shortYear &&
+                    (!month.HasValue || x.Period.Month == (byte)month.Value))
+                .Join(_context.Categories,
+                    x => x.Expense.CategoryId,
+                    c => c.Id,
+                    (x, c) => new { x.Expense, Category = c })
+                .GroupBy(x => new { x.Expense.CategoryId, x.Category.Name, x.Category.Color })
+                .Select(g => new ExpenseByCategoryItemDto(
+                    g.Key.CategoryId,
+                    g.Key.Name,
+                    g.Key.Color,
+                    g.Sum(x => x.Expense.Amount)))
+                .OrderByDescending(i => i.Total)
+                .ToListAsync(ct);
+
+            return new ExpensesReportDto(year, month, items);
         }
 
         // Tipo interno para mapeamento do SQL raw — nunca exposto fora da Infrastructure

--- a/src/PersonalFinance.Infrastructure/Persistence/Repositories/Reports/ReportRepository.cs
+++ b/src/PersonalFinance.Infrastructure/Persistence/Repositories/Reports/ReportRepository.cs
@@ -70,34 +70,37 @@ namespace PersonalFinance.Infrastructure.Persistence.Repositories.Reports
         {
             var shortYear = (short)year;
 
-            // Filtro base: join Expenses + Periods + projeção plana (evita acesso aninhado no GroupBy)
-            var baseQuery = _context.Expenses
+            // Etapa 1 — SELECT plano via SQL (sem GroupBy no banco, evita problema de tradução EF Core)
+            var flatQuery = _context.Expenses
                 .Join(_context.Periods,
                     e => e.PeriodId,
                     p => p.Id,
                     (e, p) => new { e.UserId, e.CategoryId, e.Amount, p.Year, p.Month })
                 .Where(x => x.UserId == userId && x.Year == shortYear);
 
-            // Filtro de mês aplicado separadamente para garantir tradução SQL
             if (month.HasValue)
             {
                 var byteMonth = (byte)month.Value;
-                baseQuery = baseQuery.Where(x => x.Month == byteMonth);
+                flatQuery = flatQuery.Where(x => x.Month == byteMonth);
             }
 
-            var items = await baseQuery
+            var flat = await flatQuery
                 .Join(_context.Categories,
                     x => x.CategoryId,
                     c => c.Id,
-                    (x, c) => new { x.CategoryId, c.Name, c.Color, x.Amount })
-                .GroupBy(x => new { x.CategoryId, x.Name, x.Color })
+                    (x, c) => new { x.CategoryId, CategoryName = c.Name, CategoryColor = c.Color, x.Amount })
+                .ToListAsync(ct);
+
+            // Etapa 2 — agrupamento no cliente (dados já filtrados e projetados)
+            var items = flat
+                .GroupBy(x => new { x.CategoryId, x.CategoryName, x.CategoryColor })
                 .Select(g => new ExpenseByCategoryItemDto(
                     g.Key.CategoryId,
-                    g.Key.Name,
-                    g.Key.Color,
+                    g.Key.CategoryName,
+                    g.Key.CategoryColor,
                     g.Sum(x => x.Amount)))
                 .OrderByDescending(i => i.Total)
-                .ToListAsync(ct);
+                .ToList();
 
             return new ExpensesReportDto(year, month, items);
         }

--- a/src/PersonalFinance.Infrastructure/Persistence/Repositories/Reports/ReportRepository.cs
+++ b/src/PersonalFinance.Infrastructure/Persistence/Repositories/Reports/ReportRepository.cs
@@ -70,25 +70,32 @@ namespace PersonalFinance.Infrastructure.Persistence.Repositories.Reports
         {
             var shortYear = (short)year;
 
-            var items = await _context.Expenses
+            // Filtro base: join Expenses + Periods + projeção plana (evita acesso aninhado no GroupBy)
+            var baseQuery = _context.Expenses
                 .Join(_context.Periods,
                     e => e.PeriodId,
                     p => p.Id,
-                    (e, p) => new { Expense = e, Period = p })
-                .Where(x =>
-                    x.Expense.UserId == userId &&
-                    x.Period.Year == shortYear &&
-                    (!month.HasValue || x.Period.Month == (byte)month.Value))
+                    (e, p) => new { e.UserId, e.CategoryId, e.Amount, p.Year, p.Month })
+                .Where(x => x.UserId == userId && x.Year == shortYear);
+
+            // Filtro de mês aplicado separadamente para garantir tradução SQL
+            if (month.HasValue)
+            {
+                var byteMonth = (byte)month.Value;
+                baseQuery = baseQuery.Where(x => x.Month == byteMonth);
+            }
+
+            var items = await baseQuery
                 .Join(_context.Categories,
-                    x => x.Expense.CategoryId,
+                    x => x.CategoryId,
                     c => c.Id,
-                    (x, c) => new { x.Expense, Category = c })
-                .GroupBy(x => new { x.Expense.CategoryId, x.Category.Name, x.Category.Color })
+                    (x, c) => new { x.CategoryId, c.Name, c.Color, x.Amount })
+                .GroupBy(x => new { x.CategoryId, x.Name, x.Color })
                 .Select(g => new ExpenseByCategoryItemDto(
                     g.Key.CategoryId,
                     g.Key.Name,
                     g.Key.Color,
-                    g.Sum(x => x.Expense.Amount)))
+                    g.Sum(x => x.Amount)))
                 .OrderByDescending(i => i.Total)
                 .ToListAsync(ct);
 

--- a/tests/PersonalFinance.Api.Tests/Integration/FakeReportRepository.cs
+++ b/tests/PersonalFinance.Api.Tests/Integration/FakeReportRepository.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using PersonalFinance.Application.DTOs.Financial;
+using PersonalFinance.Application.DTOs.Reports;
 using PersonalFinance.Application.Interfaces;
 using PersonalFinance.Domain.Enums;
 using PersonalFinance.Infrastructure.Persistence.Context;
@@ -61,6 +62,44 @@ namespace PersonalFinance.Api.Tests.Integration
                 TotalSecondFortnight: totalSecondFortnight,
                 Balance: totalIncome - totalExpense
             );
+        }
+
+        public async Task<ExpensesReportDto> GetExpensesReportAsync(
+            Guid userId, int year, int? month, CancellationToken ct = default)
+        {
+            var shortYear = (short)year;
+
+            var periods = await _context.Periods
+                .IgnoreQueryFilters()
+                .Where(p => p.UserId == userId && p.Year == shortYear && (month == null || p.Month == (byte)month.Value))
+                .Select(p => p.Id)
+                .ToListAsync(ct);
+
+            var expenses = await _context.Expenses
+                .IgnoreQueryFilters()
+                .Where(e => e.UserId == userId && periods.Contains(e.PeriodId) && e.DeletedAt == null)
+                .ToListAsync(ct);
+
+            var categories = await _context.Categories
+                .IgnoreQueryFilters()
+                .Where(c => expenses.Select(e => e.CategoryId).Contains(c.Id))
+                .ToDictionaryAsync(c => c.Id, ct);
+
+            var items = expenses
+                .GroupBy(e => e.CategoryId)
+                .Select(g =>
+                {
+                    categories.TryGetValue(g.Key, out var cat);
+                    return new ExpenseByCategoryItemDto(
+                        g.Key,
+                        cat?.Name ?? "Desconhecida",
+                        cat?.Color ?? "#888888",
+                        g.Sum(e => e.Amount));
+                })
+                .OrderByDescending(i => i.Total)
+                .ToList();
+
+            return new ExpensesReportDto(year, month, items);
         }
 
     }


### PR DESCRIPTION
## Summary
- Backend: `GET /api/v1/reports/expenses?year=&month=` — endpoint único, `month` opcional; agregação via EF Core (SELECT plano + GroupBy no cliente)
- Frontend: dois gráficos ECharts (pizza) no dashboard — anual por categoria e mensal por categoria com dropdown de mês; ambos reagem ao filtro de ano e ao tema escuro/claro

## Test plan
- [x] Gráfico 1 (pizza anual) carrega ao acessar o dashboard
- [x] Gráfico 2 (pizza mensal) carrega com mês corrente por padrão
- [x] Trocar ano atualiza os dois gráficos
- [x] Trocar mês no dropdown recarrega somente o Gráfico 2
- [x] Cores do texto corretas em tema escuro e claro
- [x] Estado vazio exibido quando não há despesas no período

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)