### PR TITLE
feat(admin): CRUD de usuários — criação e edição

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ Thumbs.db
 # Claude Code
 .claude/settings.local.json
 .claude/worktrees/
+/.claire

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,26 @@ Necessário apenas se o token não tiver o escopo `project` (`gh auth status` pa
 5. PR: `feat/xxx` → `master` (requer aprovação do grupo)
 6. Merge em `master` dispara GitHub Action → sync automático: `develop` ← `master` e `release` ← `master`
 
+### Regra obrigatória de push no worktree
+
+O worktree Claude tem upstream configurado para a `feat/` — **nunca fazer push direto para ela**.
+
+Sequência correta:
+```bash
+# 1. Publicar SOMENTE na branch claude/
+git push origin HEAD:claude/<nome-worktree>
+
+# 2. Criar PR: claude/ → feat/ (com delta, revisável)
+gh pr create --head claude/<nome-worktree> --base feat/xxx ...
+```
+
+Se o push acidental for para a `feat/`, corrigir com:
+```bash
+# Reverter feat/ ao commit anterior (antes da implementação)
+git push origin <commit-anterior>:refs/heads/feat/xxx --force
+# Agora claude/ tem delta → criar PR normalmente
+```
+
 ### Fluxo Hotfix
 
 1. Criar `hotfix/xxx` a **partir de `master`** (não de `develop`) — garante estado exato de produção

--- a/personal-finance/src/app/core/models/models.ts
+++ b/personal-finance/src/app/core/models/models.ts
@@ -204,8 +204,10 @@ export interface AdminUserResponse {
   roles:     string[];
 }
 
-export interface AssignRoleRequest  { roleId: number; }
-export interface ResetPasswordRequest { newPassword: string; }
+export interface AssignRoleRequest       { roleId: number; }
+export interface ResetPasswordRequest    { newPassword: string; }
+export interface CreateUserByAdminRequest { name: string; email: string; password: string; }
+export interface UpdateUserByAdminRequest { name: string; }
 export interface CreatePaymentStatusRequest { name: string; description: string; }
 export interface CreateSourceTypeRequest    { name: string; }
 export interface CreateFortnightTypeRequest { name: string; }

--- a/personal-finance/src/app/core/services/api.service.ts
+++ b/personal-finance/src/app/core/services/api.service.ts
@@ -12,6 +12,7 @@ import {
   CreatePaymentStatusRequest, CreateSourceTypeRequest, CreateFortnightTypeRequest,
   UpdatePaymentStatusRequest, UpdateSourceTypeRequest, UpdateFortnightTypeRequest,
   AdminUserResponse, AdminUserFilterParams, AssignRoleRequest, ResetPasswordRequest,
+  CreateUserByAdminRequest, UpdateUserByAdminRequest,
   ExpensesReport,
 } from '../models/models';
 
@@ -209,6 +210,14 @@ export class ApiService {
 
   resetUserPassword(userId: string, data: ResetPasswordRequest): Observable<void> {
     return this.http.patch<void>(`${this.base}/admin/users/${userId}/reset-password`, data);
+  }
+
+  createAdminUser(data: CreateUserByAdminRequest): Observable<AdminUserResponse> {
+    return this.http.post<AdminUserResponse>(`${this.base}/admin/users`, data);
+  }
+
+  updateAdminUser(userId: string, data: UpdateUserByAdminRequest): Observable<AdminUserResponse> {
+    return this.http.put<AdminUserResponse>(`${this.base}/admin/users/${userId}`, data);
   }
 
   // ── Reports ────────────────────────────────────────────────────────────────

--- a/personal-finance/src/app/features/config/components/admin-users.component.ts
+++ b/personal-finance/src/app/features/config/components/admin-users.component.ts
@@ -1,15 +1,36 @@
 import { Component, inject, signal, OnInit } from '@angular/core';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { FormsModule } from '@angular/forms';
+import { animate, style, transition, trigger } from '@angular/animations';
 import { ApiService } from '../../../core/services/api.service';
 import { HeaderComponent } from '../../../shared/components/header/header.component';
 import { PaginationComponent } from '../../../shared/components/pagination/pagination.component';
 import { AdminUserResponse } from '../../../core/models/models';
 
+const AVAILABLE_ROLES = [
+  { id: 1, name: 'Admin' },
+  { id: 2, name: 'User'  },
+];
+
 @Component({
   selector: 'app-admin-users',
   standalone: true,
   imports: [HeaderComponent, ReactiveFormsModule, FormsModule, PaginationComponent],
+  animations: [
+    trigger('backdropAnim', [
+      transition(':enter', [style({ opacity: 0 }), animate('200ms ease', style({ opacity: 1 }))]),
+      transition(':leave', [animate('180ms ease', style({ opacity: 0 }))]),
+    ]),
+    trigger('modalAnim', [
+      transition(':enter', [
+        style({ opacity: 0, transform: 'scale(0.88) translateY(-16px)' }),
+        animate('260ms cubic-bezier(0.34,1.56,0.64,1)', style({ opacity: 1, transform: 'scale(1) translateY(0)' })),
+      ]),
+      transition(':leave', [
+        animate('180ms ease-in', style({ opacity: 0, transform: 'scale(0.93) translateY(10px)' })),
+      ]),
+    ]),
+  ],
   template: `
     <app-header title="Usuários" subtitle="Gerenciamento de usuários do sistema" />
 
@@ -17,25 +38,16 @@ import { AdminUserResponse } from '../../../core/models/models';
       <!-- Filtros externos -->
       <div class="filters-bar card">
         <div class="filters-row">
-          <input
-            class="input filter-input"
-            type="text"
-            placeholder="Nome"
-            [(ngModel)]="nameFilter"
-          />
-          <input
-            class="input filter-input"
-            type="text"
-            placeholder="E-mail"
-            [(ngModel)]="emailFilter"
-          />
+          <input class="input filter-input" type="text" placeholder="Nome"   [(ngModel)]="nameFilter"   />
+          <input class="input filter-input" type="text" placeholder="E-mail" [(ngModel)]="emailFilter"  />
           <select class="input filter-select" [(ngModel)]="statusFilter">
             <option value="">Todos</option>
             <option value="true">Ativo</option>
             <option value="false">Inativo</option>
           </select>
-          <button class="btn btn-primary" (click)="applyFilters()">Filtrar</button>
+          <button class="btn btn-primary"   (click)="applyFilters()">Filtrar</button>
           <button class="btn btn-secondary" (click)="clearFilters()">Limpar</button>
+          <button class="btn btn-primary" style="margin-left: auto" (click)="openCreate()">+ Novo Usuário</button>
         </div>
       </div>
 
@@ -74,21 +86,14 @@ import { AdminUserResponse } from '../../../core/models/models';
                   <td class="text-muted text-sm">{{ formatDate(user.createdAt) }}</td>
                   <td>
                     <div class="row-actions">
+                      <button class="action-btn action-primary" (click)="openEdit(user)" title="Editar">✏️</button>
                       <button
                         class="action-btn"
                         [class]="user.isActive ? 'action-warning' : 'action-success'"
                         (click)="toggleActive(user)"
                         [title]="user.isActive ? 'Desativar' : 'Ativar'"
-                      >
-                        {{ user.isActive ? '⏸' : '▶' }}
-                      </button>
-                      <button
-                        class="action-btn action-info"
-                        (click)="openResetPassword(user)"
-                        title="Resetar senha"
-                      >
-                        🔑
-                      </button>
+                      >{{ user.isActive ? '⏸' : '▶' }}</button>
+                      <button class="action-btn action-info" (click)="openResetPassword(user)" title="Resetar senha">🔑</button>
                     </div>
                   </td>
                 </tr>
@@ -105,20 +110,90 @@ import { AdminUserResponse } from '../../../core/models/models';
           />
         </div>
 
+        <!-- Modal criar usuário -->
+        @if (showCreateModal()) {
+          <div class="modal-overlay" @backdropAnim (click)="showCreateModal.set(false)"></div>
+          <div class="modal-center" @modalAnim>
+            <div class="modal-card card" (click)="$event.stopPropagation()">
+              <h3 class="modal-title">Novo Usuário</h3>
+              <form [formGroup]="createForm" (ngSubmit)="onCreateUser()">
+                <div class="field" style="margin-bottom: 14px">
+                  <label class="field-label">Nome *</label>
+                  <input type="text" formControlName="name" class="input" placeholder="Nome completo" />
+                </div>
+                <div class="field" style="margin-bottom: 14px">
+                  <label class="field-label">E-mail *</label>
+                  <input type="email" formControlName="email" class="input" placeholder="email@exemplo.com" />
+                </div>
+                <div class="field" style="margin-bottom: 14px">
+                  <label class="field-label">Senha *</label>
+                  <input type="password" formControlName="password" class="input" placeholder="Mínimo 8 caracteres" />
+                </div>
+                @if (createError()) {
+                  <div class="form-error">{{ createError() }}</div>
+                }
+                <div class="modal-footer">
+                  <button type="button" class="btn btn-secondary" (click)="showCreateModal.set(false)">Cancelar</button>
+                  <button type="submit" class="btn btn-primary" [disabled]="loadingAction()">
+                    {{ loadingAction() ? 'Salvando...' : 'Criar' }}
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
+        }
+
+        <!-- Modal editar usuário -->
+        @if (showEditModal()) {
+          <div class="modal-overlay" @backdropAnim (click)="showEditModal.set(false)"></div>
+          <div class="modal-center" @modalAnim>
+            <div class="modal-card card" (click)="$event.stopPropagation()">
+              <h3 class="modal-title">Editar — {{ selectedUser()?.email }}</h3>
+              <form [formGroup]="editForm" (ngSubmit)="onUpdateUser()">
+                <div class="field" style="margin-bottom: 14px">
+                  <label class="field-label">Nome *</label>
+                  <input type="text" formControlName="name" class="input" />
+                </div>
+                <div class="field" style="margin-bottom: 16px">
+                  <label class="field-label">Roles</label>
+                  <div class="roles-edit">
+                    @for (role of availableRoles; track role.id) {
+                      <label class="role-check">
+                        <input
+                          type="checkbox"
+                          [checked]="selectedUser()?.roles?.includes(role.name)"
+                          (change)="onRoleToggle(role.id, role.name, $event)"
+                          [disabled]="loadingAction()"
+                        />
+                        {{ role.name }}
+                      </label>
+                    }
+                  </div>
+                </div>
+                @if (editError()) {
+                  <div class="form-error">{{ editError() }}</div>
+                }
+                <div class="modal-footer">
+                  <button type="button" class="btn btn-secondary" (click)="showEditModal.set(false)">Cancelar</button>
+                  <button type="submit" class="btn btn-primary" [disabled]="loadingAction()">
+                    {{ loadingAction() ? 'Salvando...' : 'Salvar' }}
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
+        }
+
         <!-- Modal reset senha -->
         @if (showResetModal()) {
-          <div class="modal-overlay" (click)="showResetModal.set(false)">
+          <div class="modal-overlay" @backdropAnim (click)="showResetModal.set(false)"></div>
+          <div class="modal-center" @modalAnim>
             <div class="modal-card card" (click)="$event.stopPropagation()">
               <h3 class="modal-title">Resetar senha — {{ selectedUser()?.name }}</h3>
               <form [formGroup]="resetForm" (ngSubmit)="onResetPassword()">
                 <div class="field" style="margin-bottom: 16px">
                   <label class="field-label">Nova senha *</label>
-                  <input
-                    type="password"
-                    formControlName="newPassword"
-                    class="input"
-                    placeholder="Mínimo 8 caracteres"
-                  />
+                  <input type="password" formControlName="newPassword" class="input" placeholder="Mínimo 8 caracteres" />
                 </div>
                 @if (resetError()) {
                   <div class="form-error">{{ resetError() }}</div>
@@ -175,28 +250,35 @@ import { AdminUserResponse } from '../../../core/models/models';
       display: flex; align-items: center; justify-content: center;
       transition: all var(--transition);
     }
-    .action-success:hover { background: var(--color-success-bg); border-color: var(--sage2); }
+    .action-primary:hover { background: var(--color-info-bg);    border-color: var(--color-info);    }
+    .action-success:hover { background: var(--color-success-bg); border-color: var(--sage2);         }
     .action-warning:hover { background: var(--color-warning-bg); border-color: var(--color-warning); }
     .action-info:hover    { background: var(--color-info-bg);    border-color: var(--color-info);    }
 
     /* Modal */
     .modal-overlay {
       position: fixed; inset: 0;
-      background: rgba(0,0,0,.4);
-      display: flex; align-items: center; justify-content: center;
-      z-index: 100;
+      background: rgba(0,0,0,.4); z-index: 100;
     }
-
+    .modal-center {
+      position: fixed; inset: 0; z-index: 101;
+      display: flex; align-items: center; justify-content: center;
+      pointer-events: none;
+    }
     .modal-card {
-      width: 100%; max-width: 400px;
+      width: 100%; max-width: 420px;
       padding: 28px;
       box-shadow: var(--shadow-modal);
+      pointer-events: all;
     }
 
     .modal-title { font-size: 1rem; margin-bottom: 20px; }
 
     .field { display: flex; flex-direction: column; gap: 6px; }
     .field-label { font-size: 0.875rem; font-weight: 500; color: var(--ink2); }
+
+    .roles-edit { display: flex; gap: 16px; flex-wrap: wrap; margin-top: 4px; }
+    .role-check { display: flex; align-items: center; gap: 6px; font-size: 0.875rem; cursor: pointer; }
 
     .form-error {
       margin-top: 12px; padding: 10px 14px;
@@ -206,19 +288,12 @@ import { AdminUserResponse } from '../../../core/models/models';
 
     .modal-footer { display: flex; justify-content: flex-end; gap: 10px; margin-top: 20px; }
 
-    .loading-state {
-      display: flex; align-items: center;
-      justify-content: center; padding: 64px;
-    }
-
+    .loading-state { display: flex; align-items: center; justify-content: center; padding: 64px; }
     .spinner-lg {
-      width: 32px; height: 32px;
-      border: 3px solid var(--border);
-      border-top-color: var(--sage2);
-      border-radius: 50%;
+      width: 32px; height: 32px; border: 3px solid var(--border);
+      border-top-color: var(--sage2); border-radius: 50%;
       animation: spin .8s linear infinite; display: block;
     }
-
     @keyframes spin { to { transform: rotate(360deg); } }
   `]
 })
@@ -226,33 +301,47 @@ export class AdminUsersComponent implements OnInit {
   private readonly api = inject(ApiService);
   private readonly fb  = inject(FormBuilder);
 
-  readonly users         = signal<AdminUserResponse[]>([]);
-  readonly loading       = signal(true);
-  readonly loadingAction = signal(false);
-  readonly showResetModal = signal(false);
-  readonly selectedUser  = signal<AdminUserResponse | null>(null);
-  readonly resetError    = signal<string | null>(null);
-  readonly totalCount    = signal(0);
-  readonly currentPage   = signal(1);
-  readonly pageSize      = signal(20);
+  readonly availableRoles = AVAILABLE_ROLES;
+
+  readonly users          = signal<AdminUserResponse[]>([]);
+  readonly loading        = signal(true);
+  readonly loadingAction  = signal(false);
+  readonly selectedUser   = signal<AdminUserResponse | null>(null);
+  readonly totalCount     = signal(0);
+  readonly currentPage    = signal(1);
+  readonly pageSize       = signal(20);
+
+  readonly showCreateModal = signal(false);
+  readonly showEditModal   = signal(false);
+  readonly showResetModal  = signal(false);
+
+  readonly createError = signal<string | null>(null);
+  readonly editError   = signal<string | null>(null);
+  readonly resetError  = signal<string | null>(null);
 
   nameFilter   = '';
   emailFilter  = '';
   statusFilter = '';
 
-  readonly resetForm = this.fb.group({
-    newPassword: ['', [Validators.required, Validators.minLength(8)]]
+  readonly createForm = this.fb.group({
+    name:     ['', [Validators.required]],
+    email:    ['', [Validators.required, Validators.email]],
+    password: ['', [Validators.required, Validators.minLength(8)]],
   });
 
-  ngOnInit(): void {
-    this.load();
-  }
+  readonly editForm = this.fb.group({
+    name: ['', [Validators.required]],
+  });
+
+  readonly resetForm = this.fb.group({
+    newPassword: ['', [Validators.required, Validators.minLength(8)]],
+  });
+
+  ngOnInit(): void { this.load(); }
 
   private load(): void {
     this.loading.set(true);
-    const isActive = this.statusFilter === '' ? undefined
-      : this.statusFilter === 'true';
-
+    const isActive = this.statusFilter === '' ? undefined : this.statusFilter === 'true';
     this.api.getAdminUsers({
       pageNumber: this.currentPage(),
       pageSize:   this.pageSize(),
@@ -260,48 +349,109 @@ export class AdminUsersComponent implements OnInit {
       email:      this.emailFilter || undefined,
       isActive,
     }).subscribe({
-      next: result => {
-        this.users.set(result.items);
-        this.totalCount.set(result.totalCount);
-        this.loading.set(false);
-      },
-      error: () => this.loading.set(false)
+      next: result => { this.users.set(result.items); this.totalCount.set(result.totalCount); this.loading.set(false); },
+      error: () => this.loading.set(false),
     });
   }
 
-  applyFilters(): void {
-    this.currentPage.set(1);
-    this.load();
-  }
+  applyFilters(): void { this.currentPage.set(1); this.load(); }
 
   clearFilters(): void {
-    this.nameFilter   = '';
-    this.emailFilter  = '';
-    this.statusFilter = '';
-    this.currentPage.set(1);
-    this.load();
+    this.nameFilter = ''; this.emailFilter = ''; this.statusFilter = '';
+    this.currentPage.set(1); this.load();
   }
 
-  onPageChange(page: number): void {
-    this.currentPage.set(page);
-    this.load();
-  }
-
-  onPageSizeChange(size: number): void {
-    this.pageSize.set(size);
-    this.currentPage.set(1);
-    this.load();
-  }
+  onPageChange(page: number): void { this.currentPage.set(page); this.load(); }
+  onPageSizeChange(size: number): void { this.pageSize.set(size); this.currentPage.set(1); this.load(); }
 
   toggleActive(user: AdminUserResponse): void {
     this.api.toggleUserActive(user.id).subscribe({
-      next: () => {
-        this.users.update(list => list.map(u =>
-          u.id === user.id ? { ...u, isActive: !u.isActive } : u
-        ));
-      }
+      next: () => this.users.update(list => list.map(u => u.id === user.id ? { ...u, isActive: !u.isActive } : u)),
     });
   }
+
+  // ── Criar usuário ──────────────────────────────────────────────────────────
+
+  openCreate(): void {
+    this.createForm.reset();
+    this.createError.set(null);
+    this.showCreateModal.set(true);
+  }
+
+  onCreateUser(): void {
+    if (this.createForm.invalid) return;
+    this.loadingAction.set(true);
+    const { name, email, password } = this.createForm.value;
+    this.api.createAdminUser({ name: name!, email: email!, password: password! }).subscribe({
+      next: created => {
+        this.users.update(list => [created, ...list]);
+        this.totalCount.update(c => c + 1);
+        this.showCreateModal.set(false);
+        this.loadingAction.set(false);
+      },
+      error: err => {
+        this.createError.set(err.error?.message ?? 'Erro ao criar usuário.');
+        this.loadingAction.set(false);
+      },
+    });
+  }
+
+  // ── Editar usuário ─────────────────────────────────────────────────────────
+
+  openEdit(user: AdminUserResponse): void {
+    this.selectedUser.set(user);
+    this.editForm.patchValue({ name: user.name });
+    this.editError.set(null);
+    this.showEditModal.set(true);
+  }
+
+  onUpdateUser(): void {
+    if (this.editForm.invalid) return;
+    this.loadingAction.set(true);
+    const userId = this.selectedUser()!.id;
+    const { name } = this.editForm.value;
+    this.api.updateAdminUser(userId, { name: name! }).subscribe({
+      next: updated => {
+        this.users.update(list => list.map(u => u.id === userId ? updated : u));
+        this.showEditModal.set(false);
+        this.loadingAction.set(false);
+      },
+      error: err => {
+        this.editError.set(err.error?.message ?? 'Erro ao atualizar usuário.');
+        this.loadingAction.set(false);
+      },
+    });
+  }
+
+  onRoleToggle(roleId: number, roleName: string, event: Event): void {
+    const checked = (event.target as HTMLInputElement).checked;
+    const user    = this.selectedUser()!;
+    this.loadingAction.set(true);
+
+    const req$ = checked
+      ? this.api.assignRole(user.id, { roleId })
+      : this.api.removeRole(user.id, roleId);
+
+    req$.subscribe({
+      next: () => {
+        const updatedRoles = checked
+          ? [...user.roles, roleName]
+          : user.roles.filter(r => r !== roleName);
+        const updatedUser = { ...user, roles: updatedRoles };
+        this.selectedUser.set(updatedUser);
+        this.users.update(list => list.map(u => u.id === user.id ? updatedUser : u));
+        this.loadingAction.set(false);
+      },
+      error: err => {
+        this.editError.set(err.error?.message ?? 'Erro ao alterar role.');
+        this.loadingAction.set(false);
+        // reverter o checkbox
+        (event.target as HTMLInputElement).checked = !checked;
+      },
+    });
+  }
+
+  // ── Reset senha ────────────────────────────────────────────────────────────
 
   openResetPassword(user: AdminUserResponse): void {
     this.selectedUser.set(user);
@@ -312,20 +462,12 @@ export class AdminUsersComponent implements OnInit {
 
   onResetPassword(): void {
     if (this.resetForm.invalid) return;
-
     this.loadingAction.set(true);
     const userId = this.selectedUser()!.id;
     const pass   = this.resetForm.value.newPassword!;
-
     this.api.resetUserPassword(userId, { newPassword: pass }).subscribe({
-      next: () => {
-        this.showResetModal.set(false);
-        this.loadingAction.set(false);
-      },
-      error: err => {
-        this.resetError.set(err.error?.message ?? 'Erro ao resetar senha.');
-        this.loadingAction.set(false);
-      }
+      next: () => { this.showResetModal.set(false); this.loadingAction.set(false); },
+      error: err => { this.resetError.set(err.error?.message ?? 'Erro ao resetar senha.'); this.loadingAction.set(false); },
     });
   }
 

--- a/src/PersonalFinance.Api/Controllers/V1/Config/AdminControllers.cs
+++ b/src/PersonalFinance.Api/Controllers/V1/Config/AdminControllers.cs
@@ -203,24 +203,53 @@ public sealed class ConfigController(
 [Authorize(Roles = "Admin")]
 public sealed class AdminUsersController : ApiControllerBase
 {
-    private readonly GetUsersUseCase           _getUsers;
-    private readonly ToggleUserActiveUseCase   _toggleActive;
-    private readonly AssignRoleUseCase         _assignRole;
-    private readonly RemoveRoleUseCase         _removeRole;
-    private readonly ResetUserPasswordUseCase  _resetPassword;
+    private readonly GetUsersUseCase            _getUsers;
+    private readonly ToggleUserActiveUseCase    _toggleActive;
+    private readonly AssignRoleUseCase          _assignRole;
+    private readonly RemoveRoleUseCase          _removeRole;
+    private readonly ResetUserPasswordUseCase   _resetPassword;
+    private readonly CreateUserByAdminUseCase   _createUser;
+    private readonly UpdateUserByAdminUseCase   _updateUser;
 
     public AdminUsersController(
-        GetUsersUseCase          getUsers,
-        ToggleUserActiveUseCase  toggleActive,
-        AssignRoleUseCase        assignRole,
-        RemoveRoleUseCase        removeRole,
-        ResetUserPasswordUseCase resetPassword)
+        GetUsersUseCase           getUsers,
+        ToggleUserActiveUseCase   toggleActive,
+        AssignRoleUseCase         assignRole,
+        RemoveRoleUseCase         removeRole,
+        ResetUserPasswordUseCase  resetPassword,
+        CreateUserByAdminUseCase  createUser,
+        UpdateUserByAdminUseCase  updateUser)
     {
         _getUsers      = getUsers;
         _toggleActive  = toggleActive;
         _assignRole    = assignRole;
         _removeRole    = removeRole;
         _resetPassword = resetPassword;
+        _createUser    = createUser;
+        _updateUser    = updateUser;
+    }
+
+    /// <summary>Cria um novo usuário com role padrão User.</summary>
+    [HttpPost]
+    [ProducesResponseType(typeof(AdminUserResponseDto), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> CreateUser(
+        [FromBody] CreateUserByAdminDto dto, CancellationToken ct)
+    {
+        var result = await _createUser.ExecuteAsync(dto, ct);
+        return CreatedAtAction(nameof(GetAll), result);
+    }
+
+    /// <summary>Atualiza o nome de um usuário.</summary>
+    [HttpPut("{id:guid}")]
+    [ProducesResponseType(typeof(AdminUserResponseDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UpdateUser(
+        Guid id, [FromBody] UpdateUserByAdminDto dto, CancellationToken ct)
+    {
+        var result = await _updateUser.ExecuteAsync(dto with { UserId = id }, ct);
+        return Ok(result);
     }
 
     /// <summary>Lista usuários do sistema com paginação e filtros opcionais.</summary>

--- a/src/PersonalFinance.Api/Extensions/ApplicationExtensions.cs
+++ b/src/PersonalFinance.Api/Extensions/ApplicationExtensions.cs
@@ -45,6 +45,8 @@ public static class ApplicationExtensions
         services.AddScoped<AssignRoleUseCase>();
         services.AddScoped<RemoveRoleUseCase>();
         services.AddScoped<ResetUserPasswordUseCase>();
+        services.AddScoped<CreateUserByAdminUseCase>();
+        services.AddScoped<UpdateUserByAdminUseCase>();
 
         // ── Financial — Periods ───────────────────────────────────────────────
         services.AddScoped<GetPeriodsByUserUseCase>();

--- a/src/PersonalFinance.Application/DTOs/Admin/AdminDtos.cs
+++ b/src/PersonalFinance.Application/DTOs/Admin/AdminDtos.cs
@@ -39,6 +39,19 @@ public sealed record ResetPasswordDto(
     string NewPassword
 );
 
+/// <summary>Criação de usuário pelo admin.</summary>
+public sealed record CreateUserByAdminDto(
+    string Name,
+    string Email,
+    string Password
+);
+
+/// <summary>Atualização de usuário pelo admin (somente nome).</summary>
+public sealed record UpdateUserByAdminDto(
+    Guid   UserId,
+    string Name
+);
+
 // ── Lookup tables ─────────────────────────────────────────────────────────────
 
 /// <summary>Criação de novo status de pagamento personalizado.</summary>

--- a/src/PersonalFinance.Application/UseCases/Admin/CreateUserByAdminUseCase.cs
+++ b/src/PersonalFinance.Application/UseCases/Admin/CreateUserByAdminUseCase.cs
@@ -1,0 +1,63 @@
+using PersonalFinance.Application.DTOs.Admin;
+using PersonalFinance.Domain.Entities.Auth;
+using PersonalFinance.Domain.Exceptions;
+using PersonalFinance.Domain.Interfaces.Repositories;
+using PersonalFinance.Domain.Interfaces.Services;
+
+namespace PersonalFinance.Application.UseCases.Admin;
+
+/// <summary>Cria um novo usuário com role padrão User.</summary>
+public sealed class CreateUserByAdminUseCase
+{
+    private readonly IAdminUserRepository _userRepository;
+    private readonly IUserRoleRepository  _roleRepository;
+    private readonly IPasswordHasher      _hasher;
+    private readonly IUnitOfWork          _uow;
+
+    public CreateUserByAdminUseCase(
+        IAdminUserRepository userRepository,
+        IUserRoleRepository  roleRepository,
+        IPasswordHasher      hasher,
+        IUnitOfWork          uow)
+    {
+        _userRepository = userRepository;
+        _roleRepository = roleRepository;
+        _hasher         = hasher;
+        _uow            = uow;
+    }
+
+    public async Task<AdminUserResponseDto> ExecuteAsync(
+        CreateUserByAdminDto dto, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(dto.Password) || dto.Password.Length < 8)
+            throw new DomainException("A senha deve ter no mínimo 8 caracteres.");
+
+        var exists = await _userRepository.ExistsByEmailAsync(dto.Email, ct);
+        if (exists)
+            throw new DomainException($"Já existe um usuário com o e-mail '{dto.Email}'.");
+
+        var hash = _hasher.Hash(dto.Password);
+        var user = User.Create(dto.Name, dto.Email, hash);
+
+        await _userRepository.AddAsync(user, ct);
+
+        // role padrão: User (Id = 2)
+        await _roleRepository.AssignAsync(new UserRole
+        {
+            UserId     = user.Id,
+            RoleId     = 2,
+            AssignedAt = DateTime.UtcNow
+        }, ct);
+
+        await _uow.CommitAsync(ct);
+
+        return new AdminUserResponseDto(
+            user.Id,
+            user.Name,
+            user.Email,
+            user.IsActive,
+            user.DeletedAt.HasValue,
+            user.CreatedAt,
+            ["User"]);
+    }
+}

--- a/src/PersonalFinance.Application/UseCases/Admin/UpdateUserByAdminUseCase.cs
+++ b/src/PersonalFinance.Application/UseCases/Admin/UpdateUserByAdminUseCase.cs
@@ -1,0 +1,44 @@
+using PersonalFinance.Application.DTOs.Admin;
+using PersonalFinance.Domain.Interfaces.Repositories;
+
+namespace PersonalFinance.Application.UseCases.Admin;
+
+/// <summary>Atualiza o nome de um usuário.</summary>
+public sealed class UpdateUserByAdminUseCase
+{
+    private readonly IAdminUserRepository _userRepository;
+    private readonly IUserRoleRepository  _roleRepository;
+    private readonly IUnitOfWork          _uow;
+
+    public UpdateUserByAdminUseCase(
+        IAdminUserRepository userRepository,
+        IUserRoleRepository  roleRepository,
+        IUnitOfWork          uow)
+    {
+        _userRepository = userRepository;
+        _roleRepository = roleRepository;
+        _uow            = uow;
+    }
+
+    public async Task<AdminUserResponseDto> ExecuteAsync(
+        UpdateUserByAdminDto dto, CancellationToken ct = default)
+    {
+        var user = await _userRepository.GetByIdAsync(dto.UserId, ct)
+            ?? throw new KeyNotFoundException("Usuário não encontrado.");
+
+        user.UpdateName(dto.Name);
+        await _userRepository.UpdateAsync(user, ct);
+        await _uow.CommitAsync(ct);
+
+        var roles = await _roleRepository.GetRoleNamesByUserIdAsync(user.Id, ct);
+
+        return new AdminUserResponseDto(
+            user.Id,
+            user.Name,
+            user.Email,
+            user.IsActive,
+            user.DeletedAt.HasValue,
+            user.CreatedAt,
+            roles);
+    }
+}

--- a/src/PersonalFinance.Domain/Interfaces/Repositories/ConfigRepositories.cs
+++ b/src/PersonalFinance.Domain/Interfaces/Repositories/ConfigRepositories.cs
@@ -65,8 +65,11 @@ public interface IAdminUserRepository
 {
     Task<IEnumerable<User>> GetAllAsync(CancellationToken ct = default);
     Task<User?> GetByIdAsync(Guid id, CancellationToken ct = default);
+    Task<bool> ExistsByEmailAsync(string email, CancellationToken ct = default);
     Task<(IEnumerable<User> items, int totalCount)> GetPagedAsync(
         int pageNumber, int pageSize,
         string? name, string? email, bool? isActive,
         CancellationToken ct = default);
+    Task AddAsync(User user, CancellationToken ct = default);
+    Task UpdateAsync(User user, CancellationToken ct = default);
 }

--- a/src/PersonalFinance.Infrastructure/Persistence/Repositories/Config/ConfigRepositories.cs
+++ b/src/PersonalFinance.Infrastructure/Persistence/Repositories/Config/ConfigRepositories.cs
@@ -219,4 +219,18 @@ public sealed class AdminUserRepository : IAdminUserRepository
 
         return (items, totalCount);
     }
+
+    public async Task<bool> ExistsByEmailAsync(string email, CancellationToken ct = default)
+        => await _context.Users
+               .IgnoreQueryFilters()
+               .AnyAsync(u => u.Email == email.Trim().ToLowerInvariant(), ct);
+
+    public async Task AddAsync(Domain.Entities.Auth.User user, CancellationToken ct = default)
+        => await _context.Users.AddAsync(user, ct);
+
+    public Task UpdateAsync(Domain.Entities.Auth.User user, CancellationToken ct = default)
+    {
+        _context.Users.Update(user);
+        return Task.CompletedTask;
+    }
 }


### PR DESCRIPTION
## Resumo
- `POST /api/v1/admin/users` — cria usuário com role padrão User
- `PUT /api/v1/admin/users/{id}` — atualiza nome do usuário
- Frontend: modal de criação (nome, e-mail, senha) e modal de edição (nome + toggle de roles inline)
- Roles gerenciadas pelos endpoints existentes de assign/remove

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)