### PR TITLE
fix(deps): remove ng-apexcharts e apexcharts não utilizados

### DIFF
--- a/personal-finance/package-lock.json
+++ b/personal-finance/package-lock.json
@@ -17,9 +17,7 @@
         "@angular/platform-browser": "^21.0.0",
         "@angular/platform-browser-dynamic": "^21.0.0",
         "@angular/router": "^21.0.0",
-        "apexcharts": "^3.54.0",
         "echarts": "^5.5.1",
-        "ng-apexcharts": "^1.11.0",
         "ngx-echarts": "^18.0.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.7.0",
@@ -6063,11 +6061,6 @@
       "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
       "dev": true
     },
-    "node_modules/@yr/monotone-cubic-spline": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@yr/monotone-cubic-spline/-/monotone-cubic-spline-1.0.3.tgz",
-      "integrity": "sha512-FQXkOta0XBSUPHndIKON2Y9JeQz5ZeMqLYZVVK93FliNBFm7LNMIZmY6FrMEB9XPcDbE2bekMbZD6kzDkxwYjA=="
-    },
     "node_modules/abbrev": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
@@ -6309,20 +6302,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/apexcharts": {
-      "version": "3.54.1",
-      "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-3.54.1.tgz",
-      "integrity": "sha512-E4et0h/J1U3r3EwS/WlqJCQIbepKbp6wGUmaAwJOMjHUP4Ci0gxanLa7FR3okx6p9coi4st6J853/Cb1NP0vpA==",
-      "dependencies": {
-        "@yr/monotone-cubic-spline": "^1.0.3",
-        "svg.draggable.js": "^2.2.2",
-        "svg.easing.js": "^2.0.0",
-        "svg.filter.js": "^2.0.2",
-        "svg.pathmorphing.js": "^0.1.3",
-        "svg.resize.js": "^1.4.3",
-        "svg.select.js": "^3.0.1"
       }
     },
     "node_modules/arg": {
@@ -10791,20 +10770,6 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
-    "node_modules/ng-apexcharts": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/ng-apexcharts/-/ng-apexcharts-1.17.1.tgz",
-      "integrity": "sha512-4CqkO0IPZD6lDMMDRZ5cm7HXGGDEQZVRQvRDMSrNFKWJStAV01WvUPT90Tkf8eVr/rs3hPKvTR+p8Pnvd+hubQ==",
-      "dependencies": {
-        "tslib": "^2.8.1"
-      },
-      "peerDependencies": {
-        "@angular/common": "^20.0.0",
-        "@angular/core": "^20.0.0",
-        "apexcharts": "^5.3.2",
-        "rxjs": "^7.8.2"
-      }
-    },
     "node_modules/ngx-echarts": {
       "version": "18.0.0",
       "resolved": "https://registry.npmjs.org/ngx-echarts/-/ngx-echarts-18.0.0.tgz",
@@ -13264,89 +13229,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/svg.draggable.js": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/svg.draggable.js/-/svg.draggable.js-2.2.2.tgz",
-      "integrity": "sha512-JzNHBc2fLQMzYCZ90KZHN2ohXL0BQJGQimK1kGk6AvSeibuKcIdDX9Kr0dT9+UJ5O8nYA0RB839Lhvk4CY4MZw==",
-      "dependencies": {
-        "svg.js": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/svg.easing.js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/svg.easing.js/-/svg.easing.js-2.0.0.tgz",
-      "integrity": "sha512-//ctPdJMGy22YoYGV+3HEfHbm6/69LJUTAqI2/5qBvaNHZ9uUFVC82B0Pl299HzgH13rKrBgi4+XyXXyVWWthA==",
-      "dependencies": {
-        "svg.js": ">=2.3.x"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/svg.filter.js": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/svg.filter.js/-/svg.filter.js-2.0.2.tgz",
-      "integrity": "sha512-xkGBwU+dKBzqg5PtilaTb0EYPqPfJ9Q6saVldX+5vCRy31P6TlRCP3U9NxH3HEufkKkpNgdTLBJnmhDHeTqAkw==",
-      "dependencies": {
-        "svg.js": "^2.2.5"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/svg.js": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/svg.js/-/svg.js-2.7.1.tgz",
-      "integrity": "sha512-ycbxpizEQktk3FYvn/8BH+6/EuWXg7ZpQREJvgacqn46gIddG24tNNe4Son6omdXCnSOaApnpZw6MPCBA1dODA=="
-    },
-    "node_modules/svg.pathmorphing.js": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/svg.pathmorphing.js/-/svg.pathmorphing.js-0.1.3.tgz",
-      "integrity": "sha512-49HWI9X4XQR/JG1qXkSDV8xViuTLIWm/B/7YuQELV5KMOPtXjiwH4XPJvr/ghEDibmLQ9Oc22dpWpG0vUDDNww==",
-      "dependencies": {
-        "svg.js": "^2.4.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/svg.resize.js": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/svg.resize.js/-/svg.resize.js-1.4.3.tgz",
-      "integrity": "sha512-9k5sXJuPKp+mVzXNvxz7U0uC9oVMQrrf7cFsETznzUDDm0x8+77dtZkWdMfRlmbkEEYvUn9btKuZ3n41oNA+uw==",
-      "dependencies": {
-        "svg.js": "^2.6.5",
-        "svg.select.js": "^2.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/svg.resize.js/node_modules/svg.select.js": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/svg.select.js/-/svg.select.js-2.1.2.tgz",
-      "integrity": "sha512-tH6ABEyJsAOVAhwcCjF8mw4crjXSI1aa7j2VQR8ZuJ37H2MBUbyeqYr5nEO7sSN3cy9AR9DUwNg0t/962HlDbQ==",
-      "dependencies": {
-        "svg.js": "^2.2.5"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/svg.select.js": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/svg.select.js/-/svg.select.js-3.0.1.tgz",
-      "integrity": "sha512-h5IS/hKkuVCbKSieR9uQCj9w+zLHoPh+ce19bBYyqF53g6mnPB8sAtIbe1s9dh2S2fCmYX2xel1Ln3PJBbK4kw==",
-      "dependencies": {
-        "svg.js": "^2.6.5"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "node_modules/tailwindcss": {

--- a/personal-finance/package.json
+++ b/personal-finance/package.json
@@ -21,9 +21,7 @@
     "@angular/router": "^21.0.0",
     "echarts": "^5.5.1",
     "ngx-echarts": "^18.0.0",
-    "apexcharts": "^3.54.0",
-    "ng-apexcharts": "^1.11.0",
-    "rxjs": "~7.8.0",
+"rxjs": "~7.8.0",
     "tslib": "^2.7.0",
     "zone.js": "~0.15.0"
   },


### PR DESCRIPTION
Closes #91

## Alterações
- Remove `ng-apexcharts@^1.11.0` e `apexcharts@^3.54.0` do `package.json`
- Atualiza `package-lock.json`

## Motivo
Pacotes causavam `ERESOLVE` na build da Vercel por incompatibilidade de peer dependency com Angular 21. Nenhum componente usa essas bibliotecas — o dashboard usa `ngx-echarts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)