### PR TITLE
fix(expenses): corrige deslocamento de -1 dia na data de vencimento

### DIFF
--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.ts
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.ts
@@ -411,7 +411,7 @@ export class ExpensesComponent implements OnInit {
   sourceLabel(type: SourceType): string           { return SOURCE_TYPE_LABELS[type];     }
   fortnightLabel(type: FortnightType): string     { return FORTNIGHT_TYPE_LABELS[type];  }
   monthName(month: number): string               { return MONTH_NAMES[month - 1].substring(0, 3); }
-  formatDate(d: string): string                  { return new Date(d).toLocaleDateString('pt-BR'); }
+  formatDate(d: string): string                  { const [y, m, day] = d.substring(0, 10).split('-').map(Number); return new Date(y, m - 1, day).toLocaleDateString('pt-BR'); }
 
   statusBadgeClass(status: PaymentStatus): string {
     const map: Record<PaymentStatus, string> = {


### PR DESCRIPTION
Closes #83

## Causa raiz
`new Date("YYYY-MM-DD")` interpreta a string como UTC midnight. `toLocaleDateString('pt-BR')` converte para UTC-3, resultando em -1 dia exibido no grid.

## Fix
Parsear os segmentos da data diretamente com `new Date(y, m-1, day)`, forçando construção em hora local independente do formato recebido (date-only ou datetime).

## Arquivo alterado
- `personal-finance/src/app/features/expenses/components/expenses/expenses.component.ts:414`