### PR TITLE
test(coverage): adiciona testes unitários para use cases sem cobertura

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ Thumbs.db
 .claude/worktrees/
 /.claire
 /personal-finance/dist/
+/TestResults/

--- a/tests/PersonalFinance.Application.Tests/Unit/Admin/CreateUserByAdminUseCaseTests.cs
+++ b/tests/PersonalFinance.Application.Tests/Unit/Admin/CreateUserByAdminUseCaseTests.cs
@@ -1,0 +1,68 @@
+using FluentAssertions;
+using Moq;
+using PersonalFinance.Application.DTOs.Admin;
+using PersonalFinance.Application.UseCases.Admin;
+using PersonalFinance.Domain.Entities.Auth;
+using PersonalFinance.Domain.Exceptions;
+using PersonalFinance.Domain.Interfaces.Repositories;
+using PersonalFinance.Domain.Interfaces.Services;
+using Xunit;
+
+namespace PersonalFinance.Application.Tests.Unit.Admin;
+
+public class CreateUserByAdminUseCaseTests
+{
+    private readonly Mock<IAdminUserRepository> _userRepo = new();
+    private readonly Mock<IUserRoleRepository>  _roleRepo = new();
+    private readonly Mock<IPasswordHasher>      _hasher   = new();
+    private readonly Mock<IUnitOfWork>          _uow      = new();
+    private readonly CreateUserByAdminUseCase   _sut;
+
+    public CreateUserByAdminUseCaseTests()
+    {
+        _sut = new CreateUserByAdminUseCase(_userRepo.Object, _roleRepo.Object, _hasher.Object, _uow.Object);
+    }
+
+    [Fact(DisplayName = "Deve criar usuário e atribuir role User padrão")]
+    public async Task Execute_WithValidData_ShouldCreateUser()
+    {
+        var dto = new CreateUserByAdminDto("Caique", "caique@x.com", "senha123");
+        _userRepo.Setup(r => r.ExistsByEmailAsync(dto.Email, default)).ReturnsAsync(false);
+        _hasher.Setup(h => h.Hash(dto.Password)).Returns("hash");
+
+        var result = await _sut.ExecuteAsync(dto);
+
+        result.Name.Should().Be("Caique");
+        result.Email.Should().Be("caique@x.com");
+        result.Roles.Should().Contain("User");
+        _userRepo.Verify(r => r.AddAsync(It.IsAny<User>(), default), Times.Once);
+        _roleRepo.Verify(r => r.AssignAsync(It.Is<UserRole>(ur => ur.RoleId == 2), default), Times.Once);
+        _uow.Verify(u => u.CommitAsync(default), Times.Once);
+    }
+
+    [Fact(DisplayName = "Deve lançar exceção se e-mail já existe")]
+    public async Task Execute_WithDuplicateEmail_ShouldThrow()
+    {
+        var dto = new CreateUserByAdminDto("Caique", "caique@x.com", "senha123");
+        _userRepo.Setup(r => r.ExistsByEmailAsync(dto.Email, default)).ReturnsAsync(true);
+
+        var act = () => _sut.ExecuteAsync(dto);
+
+        await act.Should().ThrowAsync<DomainException>().WithMessage("*e-mail*");
+        _uow.Verify(u => u.CommitAsync(default), Times.Never);
+    }
+
+    [Theory(DisplayName = "Deve lançar exceção para senha com menos de 8 caracteres")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("123")]
+    public async Task Execute_WithShortPassword_ShouldThrow(string password)
+    {
+        var dto = new CreateUserByAdminDto("Caique", "caique@x.com", password);
+
+        var act = () => _sut.ExecuteAsync(dto);
+
+        await act.Should().ThrowAsync<DomainException>().WithMessage("*8 caracteres*");
+        _uow.Verify(u => u.CommitAsync(default), Times.Never);
+    }
+}

--- a/tests/PersonalFinance.Application.Tests/Unit/Admin/UpdateUserByAdminUseCaseTests.cs
+++ b/tests/PersonalFinance.Application.Tests/Unit/Admin/UpdateUserByAdminUseCaseTests.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using Moq;
+using PersonalFinance.Application.DTOs.Admin;
+using PersonalFinance.Application.UseCases.Admin;
+using PersonalFinance.Domain.Entities.Auth;
+using PersonalFinance.Domain.Interfaces.Repositories;
+using Xunit;
+
+namespace PersonalFinance.Application.Tests.Unit.Admin;
+
+public class UpdateUserByAdminUseCaseTests
+{
+    private readonly Mock<IAdminUserRepository> _userRepo = new();
+    private readonly Mock<IUserRoleRepository>  _roleRepo = new();
+    private readonly Mock<IUnitOfWork>          _uow      = new();
+    private readonly UpdateUserByAdminUseCase   _sut;
+
+    public UpdateUserByAdminUseCaseTests()
+    {
+        _sut = new UpdateUserByAdminUseCase(_userRepo.Object, _roleRepo.Object, _uow.Object);
+    }
+
+    [Fact(DisplayName = "Deve atualizar nome do usuário")]
+    public async Task Execute_WithExistingUser_ShouldUpdateName()
+    {
+        var userId = Guid.NewGuid();
+        var user   = User.Create("Antigo", "caique@x.com", "hash");
+        var dto    = new UpdateUserByAdminDto(userId, "Novo Nome");
+
+        _userRepo.Setup(r => r.GetByIdAsync(userId, default)).ReturnsAsync(user);
+        _roleRepo.Setup(r => r.GetRoleNamesByUserIdAsync(user.Id, default)).ReturnsAsync(["User"]);
+
+        var result = await _sut.ExecuteAsync(dto);
+
+        result.Name.Should().Be("Novo Nome");
+        _userRepo.Verify(r => r.UpdateAsync(user, default), Times.Once);
+        _uow.Verify(u => u.CommitAsync(default), Times.Once);
+    }
+
+    [Fact(DisplayName = "Deve lançar exceção se usuário não encontrado")]
+    public async Task Execute_WithNotFoundUser_ShouldThrow()
+    {
+        var dto = new UpdateUserByAdminDto(Guid.NewGuid(), "Novo Nome");
+        _userRepo.Setup(r => r.GetByIdAsync(dto.UserId, default)).ReturnsAsync((User?)null);
+
+        var act = () => _sut.ExecuteAsync(dto);
+
+        await act.Should().ThrowAsync<KeyNotFoundException>();
+        _uow.Verify(u => u.CommitAsync(default), Times.Never);
+    }
+}

--- a/tests/PersonalFinance.Application.Tests/Unit/Config/GetCategoryUseCaseTests.cs
+++ b/tests/PersonalFinance.Application.Tests/Unit/Config/GetCategoryUseCaseTests.cs
@@ -1,0 +1,79 @@
+using FluentAssertions;
+using Moq;
+using PersonalFinance.Application.UseCases.Config;
+using PersonalFinance.Domain.Entities.Config;
+using PersonalFinance.Domain.Interfaces.Repositories;
+using Xunit;
+
+namespace PersonalFinance.Application.Tests.Unit.Config;
+
+public class GetCategoriesUseCaseTests
+{
+    private readonly Mock<ICategoryRepository> _repo = new();
+    private readonly GetCategoriesUseCase      _sut;
+
+    public GetCategoriesUseCaseTests()
+        => _sut = new GetCategoriesUseCase(_repo.Object);
+
+    [Fact(DisplayName = "Deve retornar categorias do usuário e globais")]
+    public async Task Execute_ShouldReturnCategories()
+    {
+        var userId = Guid.NewGuid();
+        var categories = new List<Category>
+        {
+            Category.Create("Alimentação", "#FF0000", null, userId),
+            Category.CreateGlobal("Moradia", "#00FF00", null)
+        };
+        _repo.Setup(r => r.GetByUserAsync(userId, default)).ReturnsAsync(categories);
+
+        var result = await _sut.ExecuteAsync(userId);
+
+        result.Should().HaveCount(2);
+    }
+
+    [Fact(DisplayName = "Deve retornar lista vazia se não houver categorias")]
+    public async Task Execute_WithNoCategories_ShouldReturnEmpty()
+    {
+        var userId = Guid.NewGuid();
+        _repo.Setup(r => r.GetByUserAsync(userId, default)).ReturnsAsync([]);
+
+        var result = await _sut.ExecuteAsync(userId);
+
+        result.Should().BeEmpty();
+    }
+}
+
+public class GetCategoryByIdUseCaseTests
+{
+    private readonly Mock<ICategoryRepository> _repo = new();
+    private readonly GetCategoryByIdUseCase    _sut;
+
+    public GetCategoryByIdUseCaseTests()
+        => _sut = new GetCategoryByIdUseCase(_repo.Object);
+
+    [Fact(DisplayName = "Deve retornar categoria pelo Id")]
+    public async Task Execute_WithExistingCategory_ShouldReturn()
+    {
+        var userId     = Guid.NewGuid();
+        var categoryId = Guid.NewGuid();
+        var category   = Category.Create("Lazer", "#0000FF", null, userId);
+
+        _repo.Setup(r => r.GetByIdAndUserAsync(categoryId, userId, default)).ReturnsAsync(category);
+
+        var result = await _sut.ExecuteAsync(categoryId, userId);
+
+        result.Name.Should().Be("Lazer");
+    }
+
+    [Fact(DisplayName = "Deve lançar exceção se categoria não encontrada")]
+    public async Task Execute_WithNotFoundCategory_ShouldThrow()
+    {
+        var categoryId = Guid.NewGuid();
+        var userId     = Guid.NewGuid();
+        _repo.Setup(r => r.GetByIdAndUserAsync(categoryId, userId, default)).ReturnsAsync((Category?)null);
+
+        var act = () => _sut.ExecuteAsync(categoryId, userId);
+
+        await act.Should().ThrowAsync<KeyNotFoundException>();
+    }
+}

--- a/tests/PersonalFinance.Application.Tests/Unit/Financial/GetExpenseByIdUseCaseTests.cs
+++ b/tests/PersonalFinance.Application.Tests/Unit/Financial/GetExpenseByIdUseCaseTests.cs
@@ -1,0 +1,49 @@
+using FluentAssertions;
+using Moq;
+using PersonalFinance.Application.UseCases.Financial.Expenses;
+using PersonalFinance.Domain.Entities.Financial;
+using PersonalFinance.Domain.Enums;
+using PersonalFinance.Domain.Interfaces.Repositories;
+using Xunit;
+
+namespace PersonalFinance.Application.Tests.Unit.Financial;
+
+public class GetExpenseByIdUseCaseTests
+{
+    private readonly Mock<IExpenseRepository> _repo = new();
+    private readonly GetExpenseByIdUseCase    _sut;
+
+    public GetExpenseByIdUseCaseTests()
+        => _sut = new GetExpenseByIdUseCase(_repo.Object);
+
+    [Fact(DisplayName = "Deve retornar despesa pelo Id")]
+    public async Task Execute_WithExistingExpense_ShouldReturn()
+    {
+        var expenseId  = Guid.NewGuid();
+        var userId     = Guid.NewGuid();
+        var categoryId = Guid.NewGuid();
+        var expense    = Expense.Create(
+            Guid.NewGuid(), userId, categoryId,
+            SourceType.Personal, FortnightType.First, PaymentStatus.Pending,
+            "Mercado", 150m, DateOnly.FromDateTime(DateTime.UtcNow), null, null);
+
+        _repo.Setup(r => r.GetByIdAndUserAsync(expenseId, userId, default)).ReturnsAsync(expense);
+
+        var result = await _sut.ExecuteAsync(expenseId, userId);
+
+        result.Description.Should().Be("Mercado");
+        result.Amount.Should().Be(150m);
+    }
+
+    [Fact(DisplayName = "Deve lançar exceção se despesa não encontrada")]
+    public async Task Execute_WithNotFoundExpense_ShouldThrow()
+    {
+        var expenseId = Guid.NewGuid();
+        var userId    = Guid.NewGuid();
+        _repo.Setup(r => r.GetByIdAndUserAsync(expenseId, userId, default)).ReturnsAsync((Expense?)null);
+
+        var act = () => _sut.ExecuteAsync(expenseId, userId);
+
+        await act.Should().ThrowAsync<KeyNotFoundException>();
+    }
+}

--- a/tests/PersonalFinance.Application.Tests/Unit/Financial/GetExpensesByPeriodUseCaseTests.cs
+++ b/tests/PersonalFinance.Application.Tests/Unit/Financial/GetExpensesByPeriodUseCaseTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using Moq;
+using PersonalFinance.Application.DTOs.Financial;
+using PersonalFinance.Application.UseCases.Financial.Expenses;
+using PersonalFinance.Domain.Entities.Financial;
+using PersonalFinance.Domain.Enums;
+using PersonalFinance.Domain.Exceptions;
+using PersonalFinance.Domain.Interfaces.Repositories;
+using Xunit;
+
+namespace PersonalFinance.Application.Tests.Unit.Financial;
+
+public class GetExpensesByPeriodUseCaseTests
+{
+    private readonly Mock<IExpenseRepository> _expenseRepo = new();
+    private readonly Mock<IPeriodRepository>  _periodRepo  = new();
+    private readonly GetExpensesByPeriodUseCase _sut;
+
+    public GetExpensesByPeriodUseCaseTests()
+        => _sut = new GetExpensesByPeriodUseCase(_expenseRepo.Object, _periodRepo.Object);
+
+    [Fact(DisplayName = "Deve retornar despesas paginadas do período")]
+    public async Task Execute_WithValidPeriod_ShouldReturnPaged()
+    {
+        var periodId   = Guid.NewGuid();
+        var userId     = Guid.NewGuid();
+        var categoryId = Guid.NewGuid();
+        var filter     = new ExpenseFilterDto();
+        var expense    = Expense.Create(
+            periodId, userId, categoryId,
+            SourceType.Personal, FortnightType.First, PaymentStatus.Pending,
+            "Aluguel", 1000m, DateOnly.FromDateTime(DateTime.UtcNow), null, null);
+
+        _periodRepo.Setup(r => r.ExistsByIdAndUserAsync(periodId, userId, default)).ReturnsAsync(true);
+        _expenseRepo.Setup(r => r.GetPagedByPeriodAsync(
+            periodId, userId, filter.PageNumber, filter.PageSize,
+            filter.Description, filter.CategoryId,
+            filter.PaymentStatus, filter.FortnightType, filter.SourceType, default))
+            .ReturnsAsync((new List<Expense> { expense }, 1));
+
+        var result = await _sut.ExecuteAsync(periodId, userId, filter);
+
+        result.Items.Should().HaveCount(1);
+        result.TotalCount.Should().Be(1);
+    }
+
+    [Fact(DisplayName = "Deve lançar exceção se período não pertence ao usuário")]
+    public async Task Execute_WithUnauthorizedPeriod_ShouldThrow()
+    {
+        var periodId = Guid.NewGuid();
+        var userId   = Guid.NewGuid();
+        _periodRepo.Setup(r => r.ExistsByIdAndUserAsync(periodId, userId, default)).ReturnsAsync(false);
+
+        var act = () => _sut.ExecuteAsync(periodId, userId, new ExpenseFilterDto());
+
+        await act.Should().ThrowAsync<DomainException>().WithMessage("*Período*");
+    }
+}

--- a/tests/PersonalFinance.Application.Tests/Unit/Financial/GetIncomeByIdUseCaseTests.cs
+++ b/tests/PersonalFinance.Application.Tests/Unit/Financial/GetIncomeByIdUseCaseTests.cs
@@ -1,0 +1,47 @@
+using FluentAssertions;
+using Moq;
+using PersonalFinance.Application.UseCases.Financial.Incomes;
+using PersonalFinance.Domain.Entities.Financial;
+using PersonalFinance.Domain.Enums;
+using PersonalFinance.Domain.Interfaces.Repositories;
+using Xunit;
+
+namespace PersonalFinance.Application.Tests.Unit.Financial;
+
+public class GetIncomeByIdUseCaseTests
+{
+    private readonly Mock<IIncomeRepository> _repo = new();
+    private readonly GetIncomeByIdUseCase    _sut;
+
+    public GetIncomeByIdUseCaseTests()
+        => _sut = new GetIncomeByIdUseCase(_repo.Object);
+
+    [Fact(DisplayName = "Deve retornar receita pelo Id")]
+    public async Task Execute_WithExistingIncome_ShouldReturn()
+    {
+        var incomeId = Guid.NewGuid();
+        var userId   = Guid.NewGuid();
+        var income   = Income.Create(
+            Guid.NewGuid(), userId, FortnightType.First,
+            "Salário", 5000m, DateOnly.FromDateTime(DateTime.UtcNow), null);
+
+        _repo.Setup(r => r.GetByIdAndUserAsync(incomeId, userId, default)).ReturnsAsync(income);
+
+        var result = await _sut.ExecuteAsync(incomeId, userId);
+
+        result.Description.Should().Be("Salário");
+        result.Amount.Should().Be(5000m);
+    }
+
+    [Fact(DisplayName = "Deve lançar exceção se receita não encontrada")]
+    public async Task Execute_WithNotFoundIncome_ShouldThrow()
+    {
+        var incomeId = Guid.NewGuid();
+        var userId   = Guid.NewGuid();
+        _repo.Setup(r => r.GetByIdAndUserAsync(incomeId, userId, default)).ReturnsAsync((Income?)null);
+
+        var act = () => _sut.ExecuteAsync(incomeId, userId);
+
+        await act.Should().ThrowAsync<KeyNotFoundException>();
+    }
+}

--- a/tests/PersonalFinance.Application.Tests/Unit/Financial/GetIncomesByPeriodUseCaseTests.cs
+++ b/tests/PersonalFinance.Application.Tests/Unit/Financial/GetIncomesByPeriodUseCaseTests.cs
@@ -1,0 +1,55 @@
+using FluentAssertions;
+using Moq;
+using PersonalFinance.Application.DTOs.Financial;
+using PersonalFinance.Application.UseCases.Financial.Incomes;
+using PersonalFinance.Domain.Entities.Financial;
+using PersonalFinance.Domain.Enums;
+using PersonalFinance.Domain.Exceptions;
+using PersonalFinance.Domain.Interfaces.Repositories;
+using Xunit;
+
+namespace PersonalFinance.Application.Tests.Unit.Financial;
+
+public class GetIncomesByPeriodUseCaseTests
+{
+    private readonly Mock<IIncomeRepository>  _incomeRepo = new();
+    private readonly Mock<IPeriodRepository>  _periodRepo = new();
+    private readonly GetIncomesByPeriodUseCase _sut;
+
+    public GetIncomesByPeriodUseCaseTests()
+        => _sut = new GetIncomesByPeriodUseCase(_incomeRepo.Object, _periodRepo.Object);
+
+    [Fact(DisplayName = "Deve retornar receitas paginadas do período")]
+    public async Task Execute_WithValidPeriod_ShouldReturnPaged()
+    {
+        var periodId = Guid.NewGuid();
+        var userId   = Guid.NewGuid();
+        var filter   = new IncomeFilterDto();
+        var income   = Income.Create(
+            periodId, userId, FortnightType.First,
+            "Salário", 5000m, DateOnly.FromDateTime(DateTime.UtcNow), null);
+
+        _periodRepo.Setup(r => r.ExistsByIdAndUserAsync(periodId, userId, default)).ReturnsAsync(true);
+        _incomeRepo.Setup(r => r.GetPagedByPeriodAsync(
+            periodId, userId, filter.PageNumber, filter.PageSize,
+            filter.Description, filter.FortnightType, default))
+            .ReturnsAsync((new List<Income> { income }, 1));
+
+        var result = await _sut.ExecuteAsync(periodId, userId, filter);
+
+        result.Items.Should().HaveCount(1);
+        result.TotalCount.Should().Be(1);
+    }
+
+    [Fact(DisplayName = "Deve lançar exceção se período não pertence ao usuário")]
+    public async Task Execute_WithUnauthorizedPeriod_ShouldThrow()
+    {
+        var periodId = Guid.NewGuid();
+        var userId   = Guid.NewGuid();
+        _periodRepo.Setup(r => r.ExistsByIdAndUserAsync(periodId, userId, default)).ReturnsAsync(false);
+
+        var act = () => _sut.ExecuteAsync(periodId, userId, new IncomeFilterDto());
+
+        await act.Should().ThrowAsync<DomainException>().WithMessage("*Período*");
+    }
+}

--- a/tests/PersonalFinance.Application.Tests/Unit/Financial/GetPeriodByIdUseCaseTests.cs
+++ b/tests/PersonalFinance.Application.Tests/Unit/Financial/GetPeriodByIdUseCaseTests.cs
@@ -1,0 +1,44 @@
+using FluentAssertions;
+using Moq;
+using PersonalFinance.Application.UseCases.Financial.Periods;
+using PersonalFinance.Domain.Entities.Financial;
+using PersonalFinance.Domain.Interfaces.Repositories;
+using Xunit;
+
+namespace PersonalFinance.Application.Tests.Unit.Financial;
+
+public class GetPeriodByIdUseCaseTests
+{
+    private readonly Mock<IPeriodRepository> _repo = new();
+    private readonly GetPeriodByIdUseCase    _sut;
+
+    public GetPeriodByIdUseCaseTests()
+        => _sut = new GetPeriodByIdUseCase(_repo.Object);
+
+    [Fact(DisplayName = "Deve retornar período pelo Id")]
+    public async Task Execute_WithExistingPeriod_ShouldReturn()
+    {
+        var periodId = Guid.NewGuid();
+        var userId   = Guid.NewGuid();
+        var period   = Period.Create(userId, 2026, 4);
+
+        _repo.Setup(r => r.GetByIdAndUserAsync(periodId, userId, default)).ReturnsAsync(period);
+
+        var result = await _sut.ExecuteAsync(periodId, userId);
+
+        result.Year.Should().Be(2026);
+        result.Month.Should().Be(4);
+    }
+
+    [Fact(DisplayName = "Deve lançar exceção se período não encontrado")]
+    public async Task Execute_WithNotFoundPeriod_ShouldThrow()
+    {
+        var periodId = Guid.NewGuid();
+        var userId   = Guid.NewGuid();
+        _repo.Setup(r => r.GetByIdAndUserAsync(periodId, userId, default)).ReturnsAsync((Period?)null);
+
+        var act = () => _sut.ExecuteAsync(periodId, userId);
+
+        await act.Should().ThrowAsync<KeyNotFoundException>();
+    }
+}

--- a/tests/PersonalFinance.Application.Tests/Unit/Financial/GetPeriodsByUserUseCaseTests.cs
+++ b/tests/PersonalFinance.Application.Tests/Unit/Financial/GetPeriodsByUserUseCaseTests.cs
@@ -1,0 +1,44 @@
+using FluentAssertions;
+using Moq;
+using PersonalFinance.Application.UseCases.Financial.Periods;
+using PersonalFinance.Domain.Entities.Financial;
+using PersonalFinance.Domain.Interfaces.Repositories;
+using Xunit;
+
+namespace PersonalFinance.Application.Tests.Unit.Financial;
+
+public class GetPeriodsByUserUseCaseTests
+{
+    private readonly Mock<IPeriodRepository>  _repo = new();
+    private readonly GetPeriodsByUserUseCase  _sut;
+
+    public GetPeriodsByUserUseCaseTests()
+        => _sut = new GetPeriodsByUserUseCase(_repo.Object);
+
+    [Fact(DisplayName = "Deve retornar todos os períodos do usuário")]
+    public async Task Execute_WithPeriods_ShouldReturnAll()
+    {
+        var userId = Guid.NewGuid();
+        var periods = new List<Period>
+        {
+            Period.Create(userId, 2026, 4),
+            Period.Create(userId, 2026, 3)
+        };
+        _repo.Setup(r => r.GetByUserAsync(userId, default)).ReturnsAsync(periods);
+
+        var result = await _sut.ExecuteAsync(userId);
+
+        result.Should().HaveCount(2);
+    }
+
+    [Fact(DisplayName = "Deve retornar lista vazia se não houver períodos")]
+    public async Task Execute_WithNoPeriods_ShouldReturnEmpty()
+    {
+        var userId = Guid.NewGuid();
+        _repo.Setup(r => r.GetByUserAsync(userId, default)).ReturnsAsync([]);
+
+        var result = await _sut.ExecuteAsync(userId);
+
+        result.Should().BeEmpty();
+    }
+}

--- a/tests/PersonalFinance.Application.Tests/Unit/Reports/GetExpensesReportUseCaseTests.cs
+++ b/tests/PersonalFinance.Application.Tests/Unit/Reports/GetExpensesReportUseCaseTests.cs
@@ -1,0 +1,48 @@
+using FluentAssertions;
+using Moq;
+using PersonalFinance.Application.DTOs.Reports;
+using PersonalFinance.Application.Interfaces;
+using PersonalFinance.Application.UseCases.Reports;
+using Xunit;
+
+namespace PersonalFinance.Application.Tests.Unit.Reports;
+
+public class GetExpensesReportUseCaseTests
+{
+    private readonly Mock<IReportRepository>    _repo = new();
+    private readonly GetExpensesReportUseCase   _sut;
+
+    public GetExpensesReportUseCaseTests()
+        => _sut = new GetExpensesReportUseCase(_repo.Object);
+
+    [Fact(DisplayName = "Deve retornar relatório anual agrupado por categoria")]
+    public async Task Execute_AnnualReport_ShouldReturnDto()
+    {
+        var userId = Guid.NewGuid();
+        var expected = new ExpensesReportDto(2026, null, [
+            new ExpenseByCategoryItemDto(Guid.NewGuid(), "Alimentação", "#F00", 500m)
+        ]);
+        _repo.Setup(r => r.GetExpensesReportAsync(userId, 2026, null, default)).ReturnsAsync(expected);
+
+        var result = await _sut.ExecuteAsync(userId, 2026, null);
+
+        result.Year.Should().Be(2026);
+        result.Month.Should().BeNull();
+        result.Items.Should().HaveCount(1);
+    }
+
+    [Fact(DisplayName = "Deve retornar relatório mensal agrupado por categoria")]
+    public async Task Execute_MonthlyReport_ShouldReturnDto()
+    {
+        var userId = Guid.NewGuid();
+        var expected = new ExpensesReportDto(2026, 4, [
+            new ExpenseByCategoryItemDto(Guid.NewGuid(), "Moradia", "#0F0", 1200m)
+        ]);
+        _repo.Setup(r => r.GetExpensesReportAsync(userId, 2026, 4, default)).ReturnsAsync(expected);
+
+        var result = await _sut.ExecuteAsync(userId, 2026, 4);
+
+        result.Month.Should().Be(4);
+        result.Items.Should().HaveCount(1);
+    }
+}


### PR DESCRIPTION
Closes #101

## Resumo
- Testes unitários para `CreateUserByAdminUseCase` e `UpdateUserByAdminUseCase`
- Testes unitários para `GetCategoriesUseCase` e `GetCategoryByIdUseCase`
- Testes unitários para `GetExpenseByIdUseCase` e `GetExpensesByPeriodUseCase`
- Testes unitários para `GetIncomeByIdUseCase` e `GetIncomesByPeriodUseCase`
- Testes unitários para `GetPeriodByIdUseCase` e `GetPeriodsByUserUseCase`
- Testes unitários para `GetExpensesReportUseCase`

**Total:** 174 testes aprovados (Application.Tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)