### PR TITLE
fix(period-detail): busca todas as receitas do período ao abrir modal Mario

### DIFF
--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.spec.ts
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.spec.ts
@@ -136,7 +136,7 @@ describe('PeriodDetailComponent', () => {
     });
 
     it('target "receitas" — lista vazia', () => {
-      component.incomes.set([]);
+      apiSpy.getIncomesByPeriod.and.returnValue(of({ items: [], totalCount: 0, pageNumber: 1, pageSize: 1000 }));
       component.openMario('receitas');
       expect(component.marioContent()).toContain('Nenhuma receita');
     });
@@ -166,12 +166,13 @@ describe('PeriodDetailComponent', () => {
     });
 
     it('target "apagar" — sem pendentes (tudo pago)', () => {
+      apiSpy.getExpensesByPeriod.and.returnValue(of({ items: [], totalCount: 0, pageNumber: 1, pageSize: 1000 }));
       component.openMario('apagar');
       expect(component.marioContent()).toContain('Nenhuma despesa');
     });
 
     it('target "apagar" — com despesa parcial mostra sufixo', () => {
-      component.expenses.set([{ ...EXPENSE, paymentStatus: PaymentStatus.Partial }]);
+      apiSpy.getExpensesByPeriod.and.returnValue(of({ items: [{ ...EXPENSE, paymentStatus: PaymentStatus.Partial }], totalCount: 1, pageNumber: 1, pageSize: 1000 }));
       component.openMario('apagar');
       expect(component.marioContent()).toContain('parcial');
     });

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.ts
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.ts
@@ -296,20 +296,25 @@ export class PeriodDetailComponent implements OnInit {
   openMario(target: MarioTarget): void {
     const s = this.summary()!;
     const exps = this.expenses();
-    const incs = this.incomes();
     let title = '';
     let lines: string[] = [];
 
     switch (target) {
       case 'receitas': {
-        title = 'RECEITAS DO PERIODO';
-        if (incs.length === 0) {
-          lines = ['Nenhuma receita\nregistrada neste periodo.'];
-        } else {
-          lines = incs.map(i => `• ${i.description}\n  ${this.fmt(i.amount)}`);
-          lines.push('', `TOTAL: ${this.fmt(s.totalIncome)}`);
-        }
-        break;
+        this.api.getIncomesByPeriod(this.id(), { pageNumber: 1, pageSize: 1000 })
+          .subscribe(result => {
+            const receitas = result.items;
+            if (receitas.length === 0) {
+              lines = ['Nenhuma receita\nregistrada neste periodo.'];
+            } else {
+              lines = receitas.map(i => `• ${i.description}\n  ${this.fmt(i.amount)}`);
+              lines.push('', `TOTAL: ${this.fmt(s.totalIncome)}`);
+            }
+            this.marioTitle.set('RECEITAS DO PERIODO');
+            this.marioContent.set(lines.join('\n'));
+            this.marioOpen.set(true);
+          });
+        return;
       }
       case 'despesas': {
         title = 'DESPESAS DO PERIODO';
@@ -339,7 +344,10 @@ export class PeriodDetailComponent implements OnInit {
             if (pendentes.length === 0) {
               lines = ['Nenhuma despesa\npendente neste periodo.'];
             } else {
-              lines = pendentes.map(e => `• ${e.description}\n  ${this.fmt(e.amount)}`);
+              lines = pendentes.map(e => {
+                const suffix = e.paymentStatus === PaymentStatus.Partial ? ' (parcial)' : '';
+                return `• ${e.description}${suffix}\n  ${this.fmt(e.amount)}`;
+              });
               lines.push('', `TOTAL A PAGAR: ${this.fmt(s.totalOwed)}`);
             }
             this.marioTitle.set('DESPESAS A PAGAR');


### PR DESCRIPTION
Closes #119

## Resumo
- `openMario('receitas')` agora chama `getIncomesByPeriod` com `pageSize: 1000` ao invés de filtrar o signal paginado local
- Adicionado sufixo `(parcial)` para despesas com `PaymentStatus.Partial` no modal `apagar`
- Testes atualizados: `receitas — lista vazia`, `apagar — sem pendentes`, `apagar — com despesa parcial`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)