### PR TITLE
fix(period-detail): busca todas as despesas do período ao abrir modal Mario

### DIFF
--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.spec.ts
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.spec.ts
@@ -141,17 +141,21 @@ describe('PeriodDetailComponent', () => {
       expect(component.marioContent()).toContain('Nenhuma receita');
     });
 
-    it('target "despesas" — define titulo e conteúdo', () => {
+    it('target "despesas" — define titulo e conteúdo', fakeAsync(() => {
+      apiSpy.getExpensesByPeriod.and.returnValue(of({ items: [EXPENSE], totalCount: 1, pageNumber: 1, pageSize: 1000 }));
       component.openMario('despesas');
+      tick();
       expect(component.marioTitle()).toBe('DESPESAS DO PERIODO');
       expect(component.marioContent()).toContain('Aluguel');
-    });
+      expect(component.marioOpen()).toBeTrue();
+    }));
 
-    it('target "despesas" — lista vazia', () => {
-      component.expenses.set([]);
+    it('target "despesas" — lista vazia', fakeAsync(() => {
+      apiSpy.getExpensesByPeriod.and.returnValue(of({ items: [], totalCount: 0, pageNumber: 1, pageSize: 1000 }));
       component.openMario('despesas');
+      tick();
       expect(component.marioContent()).toContain('Nenhuma despesa');
-    });
+    }));
 
     it('target "pago" — lista despesas pagas', () => {
       component.openMario('pago');

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.ts
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.ts
@@ -317,14 +317,20 @@ export class PeriodDetailComponent implements OnInit {
         return;
       }
       case 'despesas': {
-        title = 'DESPESAS DO PERIODO';
-        if (exps.length === 0) {
-          lines = ['Nenhuma despesa\nregistrada neste periodo.'];
-        } else {
-          lines = exps.map(e => `• ${e.description}\n  ${this.fmt(e.amount)}`);
-          lines.push('', `TOTAL: ${this.fmt(s.totalExpense)}`);
-        }
-        break;
+        this.api.getExpensesByPeriod(this.id(), { pageNumber: 1, pageSize: 1000 })
+          .subscribe(result => {
+            const despesas = result.items;
+            if (despesas.length === 0) {
+              lines = ['Nenhuma despesa\nregistrada neste periodo.'];
+            } else {
+              lines = despesas.map(e => `• ${e.description}\n  ${this.fmt(e.amount)}`);
+              lines.push('', `TOTAL: ${this.fmt(s.totalExpense)}`);
+            }
+            this.marioTitle.set('DESPESAS DO PERIODO');
+            this.marioContent.set(lines.join('\n'));
+            this.marioOpen.set(true);
+          });
+        return;
       }
       case 'pago': {
         title = 'DESPESAS PAGAS';


### PR DESCRIPTION
Closes #120

## Resumo
- `openMario('despesas')` agora chama `getExpensesByPeriod` com `pageSize: 1000` ao invés de filtrar o signal paginado local
- Testes atualizados: `despesas — define titulo e conteúdo` e `despesas — lista vazia` convertidos para `fakeAsync`

🤖 Generated with [Claude Code](https://claude.com/claude-code)