### PR TITLE
fix(period-detail): busca todas as despesas pagas do período ao abrir modal Mario

### DIFF
--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.spec.ts
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.spec.ts
@@ -157,17 +157,21 @@ describe('PeriodDetailComponent', () => {
       expect(component.marioContent()).toContain('Nenhuma despesa');
     }));
 
-    it('target "pago" — lista despesas pagas', () => {
+    it('target "pago" — lista despesas pagas', fakeAsync(() => {
+      apiSpy.getExpensesByPeriod.and.returnValue(of({ items: [EXPENSE], totalCount: 1, pageNumber: 1, pageSize: 1000 }));
       component.openMario('pago');
+      tick();
       expect(component.marioTitle()).toBe('DESPESAS PAGAS');
       expect(component.marioContent()).toContain('Aluguel');
-    });
+      expect(component.marioOpen()).toBeTrue();
+    }));
 
-    it('target "pago" — sem despesas pagas', () => {
-      component.expenses.set([{ ...EXPENSE, paymentStatus: PaymentStatus.Pending }]);
+    it('target "pago" — sem despesas pagas', fakeAsync(() => {
+      apiSpy.getExpensesByPeriod.and.returnValue(of({ items: [], totalCount: 0, pageNumber: 1, pageSize: 1000 }));
       component.openMario('pago');
+      tick();
       expect(component.marioContent()).toContain('Nenhuma despesa');
-    });
+    }));
 
     it('target "apagar" — sem pendentes (tudo pago)', () => {
       apiSpy.getExpensesByPeriod.and.returnValue(of({ items: [], totalCount: 0, pageNumber: 1, pageSize: 1000 }));

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.ts
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.ts
@@ -333,15 +333,20 @@ export class PeriodDetailComponent implements OnInit {
         return;
       }
       case 'pago': {
-        title = 'DESPESAS PAGAS';
-        const pagas = exps.filter(e => e.paymentStatus === PaymentStatus.Paid);
-        if (pagas.length === 0) {
-          lines = ['Nenhuma despesa\npaga neste periodo.'];
-        } else {
-          lines = pagas.map(e => `• ${e.description}\n  ${this.fmt(e.amount)}`);
-          lines.push('', `TOTAL PAGO: ${this.fmt(s.totalPaid)}`);
-        }
-        break;
+        this.api.getExpensesByPeriod(this.id(), { pageNumber: 1, pageSize: 1000, paymentStatus: PaymentStatus.Paid })
+          .subscribe(result => {
+            const pagas = result.items;
+            if (pagas.length === 0) {
+              lines = ['Nenhuma despesa\npaga neste periodo.'];
+            } else {
+              lines = pagas.map(e => `• ${e.description}\n  ${this.fmt(e.amount)}`);
+              lines.push('', `TOTAL PAGO: ${this.fmt(s.totalPaid)}`);
+            }
+            this.marioTitle.set('DESPESAS PAGAS');
+            this.marioContent.set(lines.join('\n'));
+            this.marioOpen.set(true);
+          });
+        return;
       }
       case 'apagar': {
         this.api.getExpensesByPeriod(this.id(), { pageNumber: 1, pageSize: 1000, paymentStatus: PaymentStatus.Pending })


### PR DESCRIPTION
Closes #121

Substitui o filtro local do signal paginado por chamada dedicada à API com `paymentStatus: Paid` e `pageSize: 1000`, garantindo que o modal Mario exiba todas as despesas pagas do período independente da página atual.

Testes atualizados para refletir o novo comportamento assíncrono.