### PR TITLE
feat(#86): Drag and Drop ordering for expenses

### DIFF
--- a/personal-finance/src/app/core/models/models.ts
+++ b/personal-finance/src/app/core/models/models.ts
@@ -135,6 +135,11 @@ export interface MarkAsPaidRequest {
   paymentDate: string;
 }
 
+export interface ExpenseOrderItem {
+  expenseId: string;
+  order: number;
+}
+
 // ── Pagination ────────────────────────────────────────────────────────────────
 
 export interface PagedResult<T> {

--- a/personal-finance/src/app/core/services/api.service.ts
+++ b/personal-finance/src/app/core/services/api.service.ts
@@ -5,7 +5,7 @@ import { environment } from '../../../environments/environment';
 import {
   CategoryResponse, CreateCategoryRequest, UpdateCategoryRequest,
   PeriodResponse, CreatePeriodRequest, PeriodSummary,
-  ExpenseResponse, CreateExpenseRequest, UpdateExpenseRequest, MarkAsPaidRequest,
+  ExpenseResponse, CreateExpenseRequest, UpdateExpenseRequest, MarkAsPaidRequest, ExpenseOrderItem,
   PagedResult, ExpenseFilterParams, IncomeFilterParams,
   IncomeResponse, CreateIncomeRequest,
   LookupItem,
@@ -109,6 +109,10 @@ export class ApiService {
 
   deleteExpense(id: string): Observable<void> {
     return this.http.delete<void>(`${this.base}/expenses/${id}`);
+  }
+
+  saveExpenseOrder(items: ExpenseOrderItem[]): Observable<void> {
+    return this.http.post<void>(`${this.base}/expenses/order`, items);
   }
 
   // ── Incomes ───────────────────────────────────────────────────────────────

--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.css
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.css
@@ -150,3 +150,17 @@
   margin-top: 20px; padding-top: 16px;
   border-top: 1px solid var(--border);
 }
+
+/* ── Drag and Drop ── */
+.drag-col { width: 32px; padding: 0 8px !important; }
+.drag-handle {
+  cursor: grab; font-size: 1.1rem; color: var(--ink3);
+  display: block; text-align: center; user-select: none;
+}
+.drag-handle:active { cursor: grabbing; }
+.table tbody tr[draggable="true"]:hover { cursor: grab; }
+
+.order-save-bar {
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border);
+}

--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.html
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.html
@@ -90,9 +90,17 @@
     </div>
   } @else {
     <div class="table-wrap card">
+      @if (hasPendingOrder()) {
+        <div class="order-save-bar">
+          <button class="btn btn-primary btn-sm" (click)="saveOrder()" [disabled]="savingOrder()">
+            {{ savingOrder() ? 'Salvando...' : 'Salvar ordem' }}
+          </button>
+        </div>
+      }
       <table class="table">
         <thead>
           <tr>
+            <th class="drag-col"></th>
             <th class="sortable" (click)="toggleSort('description')">
               Descrição {{ sortIcon('description') }}
             </th>
@@ -118,8 +126,16 @@
           </tr>
         </thead>
         <tbody>
-          @for (expense of displayedExpenses(); track expense.id) {
-            <tr>
+          @for (expense of displayedExpenses(); track expense.id; let i = $index) {
+            <tr
+              draggable="true"
+              (dragstart)="onDragStart(i)"
+              (dragover)="onDragOver($event)"
+              (drop)="onDrop(i)"
+            >
+              <td class="drag-col">
+                <span class="drag-handle" title="Arrastar para reordenar">⠿</span>
+              </td>
               <td>
                 <div class="cell-primary">{{ expense.description }}</div>
                 @if (expense.notes) {

--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.spec.ts
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.spec.ts
@@ -27,7 +27,8 @@ describe('ExpensesComponent', () => {
   beforeEach(async () => {
     apiSpy = jasmine.createSpyObj('ApiService', [
       'getPeriods', 'getCategories', 'getExpensesByPeriod',
-      'createExpense', 'updateExpense', 'markExpenseAsPaid', 'deleteExpense'
+      'createExpense', 'updateExpense', 'markExpenseAsPaid', 'deleteExpense',
+      'saveExpenseOrder'
     ]);
     apiSpy.getPeriods.and.returnValue(of([PERIOD]));
     apiSpy.getCategories.and.returnValue(of([CATEGORY]));
@@ -171,6 +172,51 @@ describe('ExpensesComponent', () => {
       (window.confirm as jasmine.Spy).and.returnValue(false);
       component.deleteExpense('e-1');
       expect(apiSpy.deleteExpense).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('drag and drop', () => {
+    const EXPENSE_B: ExpenseResponse = { ...EXPENSE, id: 'e-2', description: 'Internet' };
+
+    beforeEach(() => {
+      component.expenses.set([EXPENSE, EXPENSE_B]);
+    });
+
+    it('onDrop reordena a lista de despesas', () => {
+      component.onDragStart(0);
+      component.onDrop(1);
+      expect(component.expenses()[0].id).toBe('e-2');
+      expect(component.expenses()[1].id).toBe('e-1');
+    });
+
+    it('onDrop popula pendingOrders', () => {
+      component.onDragStart(0);
+      component.onDrop(1);
+      expect(component.pendingOrders().length).toBe(2);
+      expect(component.hasPendingOrder()).toBeTrue();
+    });
+
+    it('onDrop não altera lista quando origem = destino', () => {
+      component.onDragStart(0);
+      component.onDrop(0);
+      expect(component.expenses()[0].id).toBe('e-1');
+      expect(component.pendingOrders().length).toBe(0);
+    });
+
+    it('saveOrder chama saveExpenseOrder e limpa pendingOrders', fakeAsync(() => {
+      apiSpy.saveExpenseOrder.and.returnValue(of(undefined));
+      component.onDragStart(0);
+      component.onDrop(1);
+      component.saveOrder();
+      tick();
+      expect(apiSpy.saveExpenseOrder).toHaveBeenCalled();
+      expect(component.pendingOrders().length).toBe(0);
+      expect(component.hasPendingOrder()).toBeFalse();
+    }));
+
+    it('saveOrder não faz nada quando pendingOrders está vazio', () => {
+      component.saveOrder();
+      expect(apiSpy.saveExpenseOrder).not.toHaveBeenCalled();
     });
   });
 

--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.ts
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.ts
@@ -9,7 +9,7 @@ import { CurrencyBrlPipe } from '../../../../shared/pipes/currency-brl.pipe';
 import {
   ExpenseResponse, PeriodResponse, CategoryResponse,
   MONTH_NAMES, PAYMENT_STATUS_LABELS, FORTNIGHT_TYPE_LABELS, SOURCE_TYPE_LABELS,
-  PaymentStatus, SourceType, FortnightType
+  PaymentStatus, SourceType, FortnightType, ExpenseOrderItem
 } from '../../../../core/models/models';
 
 type SortCol = 'description' | 'category' | 'sourceType' | 'fortnightType' | 'dueDate' | 'amount' | 'paymentStatus';
@@ -82,6 +82,12 @@ export class ExpensesComponent implements OnInit {
 
   // Debounce para busca por descrição
   private descriptionDebounce: ReturnType<typeof setTimeout> | null = null;
+
+  // Drag and drop
+  private draggedIndex: number | null = null;
+  readonly pendingOrders = signal<ExpenseOrderItem[]>([]);
+  readonly savingOrder   = signal(false);
+  readonly hasPendingOrder = computed(() => this.pendingOrders().length > 0);
 
   /** Pré-seleção via query param: /expenses?periodId=xxx */
   readonly periodId = input<string>();
@@ -394,6 +400,45 @@ export class ExpensesComponent implements OnInit {
         this.expenses.update(list => list.filter(e => e.id !== id));
         this.totalCount.update(n => n - 1);
       }
+    });
+  }
+
+  // ── Drag and drop ─────────────────────────────────────────────────────────
+
+  onDragStart(index: number): void {
+    this.draggedIndex = index;
+  }
+
+  onDragOver(event: DragEvent): void {
+    event.preventDefault();
+  }
+
+  onDrop(targetIndex: number): void {
+    if (this.draggedIndex === null || this.draggedIndex === targetIndex) return;
+
+    this.expenses.update(list => {
+      const reordered = [...list];
+      const [moved] = reordered.splice(this.draggedIndex!, 1);
+      reordered.splice(targetIndex, 0, moved);
+      return reordered;
+    });
+
+    // Registra todos os items da lista atual com a nova ordem
+    const newOrders: ExpenseOrderItem[] = this.expenses().map((e, i) => ({ expenseId: e.id, order: i }));
+    this.pendingOrders.set(newOrders);
+    this.draggedIndex = null;
+  }
+
+  saveOrder(): void {
+    const items = this.pendingOrders();
+    if (!items.length) return;
+    this.savingOrder.set(true);
+    this.api.saveExpenseOrder(items).subscribe({
+      next: () => {
+        this.pendingOrders.set([]);
+        this.savingOrder.set(false);
+      },
+      error: () => this.savingOrder.set(false)
     });
   }
 

--- a/src/PersonalFinance.Api/Controllers/V1/Financial/ExpensesController.cs
+++ b/src/PersonalFinance.Api/Controllers/V1/Financial/ExpensesController.cs
@@ -16,6 +16,7 @@ public sealed class ExpensesController(
     CreateExpenseUseCase createUseCase,
     UpdateExpenseUseCase updateUseCase,
     DeleteExpenseUseCase deleteUseCase,
+    SaveExpenseOrderUseCase saveOrderUseCase,
     IExpenseRepository expenseRepository,
     IUnitOfWork unitOfWork) : ApiControllerBase
 {
@@ -24,6 +25,7 @@ public sealed class ExpensesController(
     private readonly CreateExpenseUseCase _createUseCase = createUseCase;
     private readonly UpdateExpenseUseCase _updateUseCase = updateUseCase;
     private readonly DeleteExpenseUseCase _deleteUseCase = deleteUseCase;
+    private readonly SaveExpenseOrderUseCase _saveOrderUseCase = saveOrderUseCase;
     private readonly IExpenseRepository _expenseRepository = expenseRepository;
     private readonly IUnitOfWork _unitOfWork = unitOfWork;
 
@@ -118,6 +120,18 @@ public sealed class ExpensesController(
         expense.MarkAsPartial();
         await _expenseRepository.UpdateAsync(expense, ct);
         await _unitOfWork.CommitAsync(ct);
+        return NoContent();
+    }
+
+    /// <summary>Persiste a ordenação de despesas definida via drag and drop.</summary>
+    [HttpPost("order")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> SaveOrder(
+        [FromBody] IEnumerable<ExpenseOrderItemDto> items, CancellationToken ct)
+    {
+        var dto = new SaveExpenseOrderDto(CurrentUserId, items);
+        await _saveOrderUseCase.ExecuteAsync(dto, ct);
         return NoContent();
     }
 

--- a/src/PersonalFinance.Api/Extensions/ApplicationExtensions.cs
+++ b/src/PersonalFinance.Api/Extensions/ApplicationExtensions.cs
@@ -62,6 +62,7 @@ public static class ApplicationExtensions
         services.AddScoped<CreateExpenseUseCase>();
         services.AddScoped<UpdateExpenseUseCase>();
         services.AddScoped<DeleteExpenseUseCase>();
+        services.AddScoped<SaveExpenseOrderUseCase>();
 
         // ── Financial — Incomes ───────────────────────────────────────────────
         services.AddScoped<GetIncomesByPeriodUseCase>();

--- a/src/PersonalFinance.Application/DTOs/Financial/FinancialDtos.cs
+++ b/src/PersonalFinance.Application/DTOs/Financial/FinancialDtos.cs
@@ -102,6 +102,12 @@ public sealed record IncomeResponseDto(
     bool          IsActive
 );
 
+// ── Expense Order ─────────────────────────────────────────────────────────────
+
+public sealed record ExpenseOrderItemDto(Guid ExpenseId, int Order);
+
+public sealed record SaveExpenseOrderDto(Guid UserId, IEnumerable<ExpenseOrderItemDto> Items);
+
 // ── Period Summary (view) ─────────────────────────────────────────────────────
 
 /// <summary>

--- a/src/PersonalFinance.Application/UseCases/Financial/Expenses/SaveExpenseOrderUseCase.cs
+++ b/src/PersonalFinance.Application/UseCases/Financial/Expenses/SaveExpenseOrderUseCase.cs
@@ -1,0 +1,63 @@
+using PersonalFinance.Application.DTOs.Financial;
+using PersonalFinance.Domain.Entities.Financial;
+using PersonalFinance.Domain.Exceptions;
+using PersonalFinance.Domain.Interfaces.Repositories;
+
+namespace PersonalFinance.Application.UseCases.Financial.Expenses;
+
+/// <summary>
+/// Persiste a ordenação de despesas definida pelo usuário via drag and drop.
+/// Upsert: cria ExpenseOrder se não existir, atualiza se já existir.
+/// Valida que cada ExpenseId pertence ao usuário.
+/// </summary>
+public sealed class SaveExpenseOrderUseCase
+{
+    private readonly IExpenseOrderRepository _orderRepository;
+    private readonly IExpenseRepository      _expenseRepository;
+    private readonly IUnitOfWork             _unitOfWork;
+
+    public SaveExpenseOrderUseCase(
+        IExpenseOrderRepository orderRepository,
+        IExpenseRepository      expenseRepository,
+        IUnitOfWork             unitOfWork)
+    {
+        _orderRepository   = orderRepository;
+        _expenseRepository = expenseRepository;
+        _unitOfWork        = unitOfWork;
+    }
+
+    public async Task ExecuteAsync(SaveExpenseOrderDto dto, CancellationToken ct = default)
+    {
+        var items = dto.Items.ToList();
+
+        if (items.Count == 0)
+            throw new DomainException("A lista de ordenação não pode estar vazia.");
+
+        // Valida que todos os IDs pertencem ao usuário
+        foreach (var item in items)
+        {
+            var expense = await _expenseRepository.GetByIdAndUserAsync(item.ExpenseId, dto.UserId, ct);
+            if (expense is null)
+                throw new DomainException(
+                    $"Despesa {item.ExpenseId} não encontrada ou sem permissão de acesso.");
+        }
+
+        // Upsert de cada item
+        foreach (var item in items)
+        {
+            var existing = await _orderRepository.GetByExpenseIdAsync(item.ExpenseId, ct);
+            if (existing is null)
+            {
+                var order = ExpenseOrder.Create(item.ExpenseId, item.Order);
+                await _orderRepository.AddAsync(order, ct);
+            }
+            else
+            {
+                existing.UpdateOrder(item.Order);
+                await _orderRepository.UpdateAsync(existing, ct);
+            }
+        }
+
+        await _unitOfWork.CommitAsync(ct);
+    }
+}

--- a/src/PersonalFinance.Domain/Entities/Financial/ExpenseOrder.cs
+++ b/src/PersonalFinance.Domain/Entities/Financial/ExpenseOrder.cs
@@ -1,0 +1,32 @@
+using PersonalFinance.Domain.Entities.Shared;
+using PersonalFinance.Domain.Exceptions;
+
+namespace PersonalFinance.Domain.Entities.Financial;
+
+public sealed class ExpenseOrder : EntityBase
+{
+    public Guid ExpenseId { get; private set; }
+    public int Order { get; private set; }
+
+    private ExpenseOrder() { }
+
+    public static ExpenseOrder Create(Guid expenseId, int order)
+    {
+        if (expenseId == Guid.Empty)
+            throw new DomainException("O ExpenseId é obrigatório.");
+
+        if (order < 0)
+            throw new DomainException("A ordem deve ser maior ou igual a zero.");
+
+        return new ExpenseOrder { ExpenseId = expenseId, Order = order };
+    }
+
+    public void UpdateOrder(int order)
+    {
+        if (order < 0)
+            throw new DomainException("A ordem deve ser maior ou igual a zero.");
+
+        Order = order;
+        SetUpdatedAt();
+    }
+}

--- a/src/PersonalFinance.Domain/Interfaces/Repositories/IExpenseOrderRepository.cs
+++ b/src/PersonalFinance.Domain/Interfaces/Repositories/IExpenseOrderRepository.cs
@@ -1,0 +1,11 @@
+using PersonalFinance.Domain.Entities.Financial;
+
+namespace PersonalFinance.Domain.Interfaces.Repositories;
+
+public interface IExpenseOrderRepository
+{
+    Task<IEnumerable<ExpenseOrder>> GetByExpenseIdsAsync(IEnumerable<Guid> expenseIds, CancellationToken ct = default);
+    Task<ExpenseOrder?> GetByExpenseIdAsync(Guid expenseId, CancellationToken ct = default);
+    Task AddAsync(ExpenseOrder order, CancellationToken ct = default);
+    Task UpdateAsync(ExpenseOrder order, CancellationToken ct = default);
+}

--- a/src/PersonalFinance.Infrastructure/Extensions/InfrastructureExtensions.cs
+++ b/src/PersonalFinance.Infrastructure/Extensions/InfrastructureExtensions.cs
@@ -40,6 +40,7 @@ public static class InfrastructureExtensions
         services.AddScoped<ICategoryRepository, CategoryRepository>();
         services.AddScoped<IPeriodRepository, PeriodRepository>();
         services.AddScoped<IExpenseRepository, ExpenseRepository>();
+        services.AddScoped<IExpenseOrderRepository, ExpenseOrderRepository>();
         services.AddScoped<IIncomeRepository, IncomeRepository>();
         services.AddScoped<IReportRepository, ReportRepository>();
 

--- a/src/PersonalFinance.Infrastructure/Migrations/20260426000247_AddExpenseOrder.Designer.cs
+++ b/src/PersonalFinance.Infrastructure/Migrations/20260426000247_AddExpenseOrder.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using PersonalFinance.Infrastructure.Persistence.Context;
 
@@ -11,9 +12,11 @@ using PersonalFinance.Infrastructure.Persistence.Context;
 namespace PersonalFinance.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260426000247_AddExpenseOrder")]
+    partial class AddExpenseOrder
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/PersonalFinance.Infrastructure/Migrations/20260426000247_AddExpenseOrder.cs
+++ b/src/PersonalFinance.Infrastructure/Migrations/20260426000247_AddExpenseOrder.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PersonalFinance.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExpenseOrder : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ExpenseOrder",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ExpenseId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Order = table.Column<int>(type: "int", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2(7)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime2(7)", nullable: false),
+                    DeletedAt = table.Column<DateTime>(type: "datetime2(7)", nullable: true),
+                    IsActive = table.Column<bool>(type: "bit", nullable: false, defaultValue: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ExpenseOrder", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ExpenseOrder_Expense_ExpenseId",
+                        column: x => x.ExpenseId,
+                        principalTable: "Expense",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "UQ_ExpenseOrder_ExpenseId",
+                table: "ExpenseOrder",
+                column: "ExpenseId",
+                unique: true,
+                filter: "[DeletedAt] IS NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ExpenseOrder");
+        }
+    }
+}

--- a/src/PersonalFinance.Infrastructure/Persistence/Configurations/Financial/FinancialConfigurations.cs
+++ b/src/PersonalFinance.Infrastructure/Persistence/Configurations/Financial/FinancialConfigurations.cs
@@ -183,6 +183,40 @@ public sealed class ExpenseConfiguration : IEntityTypeConfiguration<Expense>
 }
 
 // ══════════════════════════════════════════════════════════════════════════════
+// EXPENSE ORDER
+// ══════════════════════════════════════════════════════════════════════════════
+
+public sealed class ExpenseOrderConfiguration : IEntityTypeConfiguration<ExpenseOrder>
+{
+    public void Configure(EntityTypeBuilder<ExpenseOrder> builder)
+    {
+        builder.ToTable("ExpenseOrder");
+
+        builder.ApplyEntityBaseConfiguration();
+
+        builder.Property(o => o.ExpenseId)
+               .HasColumnName("ExpenseId")
+               .HasColumnType("uniqueidentifier")
+               .IsRequired();
+
+        builder.Property(o => o.Order)
+               .HasColumnName("Order")
+               .HasColumnType("int")
+               .IsRequired();
+
+        builder.HasOne<Expense>()
+               .WithMany()
+               .HasForeignKey(o => o.ExpenseId)
+               .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasIndex(o => o.ExpenseId)
+               .IsUnique()
+               .HasFilter("[DeletedAt] IS NULL")
+               .HasDatabaseName("UQ_ExpenseOrder_ExpenseId");
+    }
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
 // INCOME
 // ══════════════════════════════════════════════════════════════════════════════
 

--- a/src/PersonalFinance.Infrastructure/Persistence/Context/AppDbContext.cs
+++ b/src/PersonalFinance.Infrastructure/Persistence/Context/AppDbContext.cs
@@ -22,6 +22,7 @@ public sealed class AppDbContext : DbContext
     public DbSet<Category> Categories { get; set; } = default!;
     public DbSet<Period> Periods { get; set; } = default!;
     public DbSet<Expense> Expenses { get; set; } = default!;
+    public DbSet<ExpenseOrder> ExpenseOrders { get; set; } = default!;
     public DbSet<Income> Incomes { get; set; } = default!;
 
     // ── Lookup tables (seed) ──────────────────────────────────────────────────
@@ -42,6 +43,7 @@ public sealed class AppDbContext : DbContext
         modelBuilder.Entity<Category>().HasQueryFilter(e => e.DeletedAt == null);
         modelBuilder.Entity<Period>().HasQueryFilter(e => e.DeletedAt == null);
         modelBuilder.Entity<Expense>().HasQueryFilter(e => e.DeletedAt == null);
+        modelBuilder.Entity<ExpenseOrder>().HasQueryFilter(e => e.DeletedAt == null);
         modelBuilder.Entity<Income>().HasQueryFilter(e => e.DeletedAt == null);
     }
 

--- a/src/PersonalFinance.Infrastructure/Persistence/Repositories/Financial/ExpenseOrderRepository.cs
+++ b/src/PersonalFinance.Infrastructure/Persistence/Repositories/Financial/ExpenseOrderRepository.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using PersonalFinance.Domain.Entities.Financial;
+using PersonalFinance.Domain.Interfaces.Repositories;
+using PersonalFinance.Infrastructure.Persistence.Context;
+
+namespace PersonalFinance.Infrastructure.Persistence.Repositories.Financial;
+
+public sealed class ExpenseOrderRepository : IExpenseOrderRepository
+{
+    private readonly AppDbContext _context;
+    public ExpenseOrderRepository(AppDbContext context) => _context = context;
+
+    public async Task<IEnumerable<ExpenseOrder>> GetByExpenseIdsAsync(
+        IEnumerable<Guid> expenseIds, CancellationToken ct = default)
+        => await _context.ExpenseOrders
+               .Where(o => expenseIds.Contains(o.ExpenseId))
+               .ToListAsync(ct);
+
+    public async Task<ExpenseOrder?> GetByExpenseIdAsync(
+        Guid expenseId, CancellationToken ct = default)
+        => await _context.ExpenseOrders
+               .FirstOrDefaultAsync(o => o.ExpenseId == expenseId, ct);
+
+    public async Task AddAsync(ExpenseOrder order, CancellationToken ct = default)
+        => await _context.ExpenseOrders.AddAsync(order, ct);
+
+    public Task UpdateAsync(ExpenseOrder order, CancellationToken ct = default)
+    {
+        _context.ExpenseOrders.Update(order);
+        return Task.CompletedTask;
+    }
+}

--- a/src/PersonalFinance.Infrastructure/Persistence/Repositories/Financial/ExpenseRepository.cs
+++ b/src/PersonalFinance.Infrastructure/Persistence/Repositories/Financial/ExpenseRepository.cs
@@ -67,31 +67,41 @@ public sealed class ExpenseRepository : IExpenseRepository
         SourceType?    sourceType,
         CancellationToken ct = default)
     {
-        var query = _context.Expenses
+        var baseQuery = _context.Expenses
             .Where(e => e.PeriodId == periodId && e.UserId == userId);
 
         if (!string.IsNullOrWhiteSpace(description))
-            query = query.Where(e => e.Description.Contains(description));
+            baseQuery = baseQuery.Where(e => e.Description.Contains(description));
 
         if (categoryId.HasValue)
-            query = query.Where(e => e.CategoryId == categoryId.Value);
+            baseQuery = baseQuery.Where(e => e.CategoryId == categoryId.Value);
 
         if (paymentStatus.HasValue)
-            query = query.Where(e => e.PaymentStatus == paymentStatus.Value);
+            baseQuery = baseQuery.Where(e => e.PaymentStatus == paymentStatus.Value);
 
         if (fortnightType.HasValue)
-            query = query.Where(e => e.FortnightType == fortnightType.Value);
+            baseQuery = baseQuery.Where(e => e.FortnightType == fortnightType.Value);
 
         if (sourceType.HasValue)
-            query = query.Where(e => e.SourceType == sourceType.Value);
+            baseQuery = baseQuery.Where(e => e.SourceType == sourceType.Value);
 
-        var totalCount = await query.CountAsync(ct);
+        var totalCount = await baseQuery.CountAsync(ct);
 
-        var items = await query
-            .OrderBy(e => e.FortnightType)
-            .ThenBy(e => e.DueDate)
+        // LEFT JOIN com ExpenseOrders — ordena pelo campo Order quando disponível,
+        // itens sem ordem ficam ao final (ordenados por FortnightType/DueDate)
+        var joined = from e in baseQuery
+                     join eo in _context.ExpenseOrders on e.Id equals eo.ExpenseId into og
+                     from eo in og.DefaultIfEmpty()
+                     select new { Expense = e, Order = (int?)eo.Order };
+
+        var items = await joined
+            .OrderBy(x => x.Order == null ? 1 : 0)
+            .ThenBy(x => x.Order)
+            .ThenBy(x => x.Expense.FortnightType)
+            .ThenBy(x => x.Expense.DueDate)
             .Skip((pageNumber - 1) * pageSize)
             .Take(pageSize)
+            .Select(x => x.Expense)
             .ToListAsync(ct);
 
         return (items, totalCount);

--- a/tests/PersonalFinance.Api.Tests/Integration/ExpensesControllerTests.cs
+++ b/tests/PersonalFinance.Api.Tests/Integration/ExpensesControllerTests.cs
@@ -215,5 +215,40 @@ namespace PersonalFinance.Api.Tests.Integration
             var getById = await client.GetAsync($"/api/v1/expenses/{id}");
             getById.StatusCode.Should().Be(HttpStatusCode.NotFound);
         }
+
+        [Fact(DisplayName = "POST /expenses/order deve retornar 204 e persistir ordenação")]
+        public async Task SaveOrder_ShouldReturn204()
+        {
+            var (client, pid, cid) = await SetupAsync();
+
+            var e1 = await client.PostAsJsonAsync("/api/v1/expenses", new
+            {
+                periodId = pid, categoryId = cid, sourceType = 2, fortnightType = 1,
+                description = "Despesa A", amount = 100, dueDate = "2026-08-10"
+            });
+            var id1 = (await e1.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("id").GetString()!;
+
+            var e2 = await client.PostAsJsonAsync("/api/v1/expenses", new
+            {
+                periodId = pid, categoryId = cid, sourceType = 2, fortnightType = 1,
+                description = "Despesa B", amount = 200, dueDate = "2026-08-11"
+            });
+            var id2 = (await e2.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("id").GetString()!;
+
+            var order = await client.PostAsJsonAsync("/api/v1/expenses/order", new[]
+            {
+                new { expenseId = id2, order = 0 },
+                new { expenseId = id1, order = 1 }
+            });
+            order.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        }
+
+        [Fact(DisplayName = "POST /expenses/order com lista vazia deve retornar 400")]
+        public async Task SaveOrder_WithEmptyList_ShouldReturn400()
+        {
+            var (client, _, _) = await SetupAsync();
+            var r = await client.PostAsJsonAsync("/api/v1/expenses/order", Array.Empty<object>());
+            r.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        }
     }
 }

--- a/tests/PersonalFinance.Application.Tests/Unit/Financial/SaveExpenseOrderUseCaseTests.cs
+++ b/tests/PersonalFinance.Application.Tests/Unit/Financial/SaveExpenseOrderUseCaseTests.cs
@@ -1,0 +1,87 @@
+using FluentAssertions;
+using Moq;
+using PersonalFinance.Application.DTOs.Financial;
+using PersonalFinance.Application.UseCases.Financial.Expenses;
+using PersonalFinance.Domain.Entities.Financial;
+using PersonalFinance.Domain.Enums;
+using PersonalFinance.Domain.Exceptions;
+using PersonalFinance.Domain.Interfaces.Repositories;
+using Xunit;
+
+namespace PersonalFinance.Application.Tests.Unit.Financial;
+
+public class SaveExpenseOrderUseCaseTests
+{
+    private readonly Mock<IExpenseOrderRepository> _orderRepo   = new();
+    private readonly Mock<IExpenseRepository>      _expenseRepo = new();
+    private readonly Mock<IUnitOfWork>             _uow         = new();
+    private readonly SaveExpenseOrderUseCase       _sut;
+
+    private static readonly Guid UserId    = Guid.NewGuid();
+    private static readonly Guid ExpenseId = Guid.NewGuid();
+
+    public SaveExpenseOrderUseCaseTests() =>
+        _sut = new SaveExpenseOrderUseCase(_orderRepo.Object, _expenseRepo.Object, _uow.Object);
+
+    private static Expense BuildExpense() => Expense.Create(
+        Guid.NewGuid(), UserId, Guid.NewGuid(),
+        SourceType.Personal, FortnightType.First, PaymentStatus.Pending,
+        "Aluguel", 1000m, DateOnly.FromDateTime(DateTime.UtcNow), null, null);
+
+    [Fact(DisplayName = "Deve criar nova ExpenseOrder quando não existe")]
+    public async Task Execute_WhenNoExistingOrder_ShouldCreate()
+    {
+        var expense = BuildExpense();
+        _expenseRepo.Setup(r => r.GetByIdAndUserAsync(ExpenseId, UserId, default))
+                    .ReturnsAsync(expense);
+        _orderRepo.Setup(r => r.GetByExpenseIdAsync(ExpenseId, default))
+                  .ReturnsAsync((ExpenseOrder?)null);
+
+        var dto = new SaveExpenseOrderDto(UserId, [new ExpenseOrderItemDto(ExpenseId, 0)]);
+        await _sut.ExecuteAsync(dto);
+
+        _orderRepo.Verify(r => r.AddAsync(It.Is<ExpenseOrder>(o => o.ExpenseId == ExpenseId && o.Order == 0), default), Times.Once);
+        _uow.Verify(u => u.CommitAsync(default), Times.Once);
+    }
+
+    [Fact(DisplayName = "Deve atualizar ExpenseOrder existente")]
+    public async Task Execute_WhenOrderExists_ShouldUpdate()
+    {
+        var expense = BuildExpense();
+        var existingOrder = ExpenseOrder.Create(ExpenseId, 0);
+
+        _expenseRepo.Setup(r => r.GetByIdAndUserAsync(ExpenseId, UserId, default))
+                    .ReturnsAsync(expense);
+        _orderRepo.Setup(r => r.GetByExpenseIdAsync(ExpenseId, default))
+                  .ReturnsAsync(existingOrder);
+
+        var dto = new SaveExpenseOrderDto(UserId, [new ExpenseOrderItemDto(ExpenseId, 3)]);
+        await _sut.ExecuteAsync(dto);
+
+        existingOrder.Order.Should().Be(3);
+        _orderRepo.Verify(r => r.UpdateAsync(existingOrder, default), Times.Once);
+        _uow.Verify(u => u.CommitAsync(default), Times.Once);
+    }
+
+    [Fact(DisplayName = "Deve lançar exceção para lista vazia")]
+    public async Task Execute_WithEmptyList_ShouldThrow()
+    {
+        var dto = new SaveExpenseOrderDto(UserId, []);
+        var act = () => _sut.ExecuteAsync(dto);
+        await act.Should().ThrowAsync<DomainException>().WithMessage("*vazia*");
+        _uow.Verify(u => u.CommitAsync(default), Times.Never);
+    }
+
+    [Fact(DisplayName = "Deve lançar exceção quando despesa não pertence ao usuário")]
+    public async Task Execute_WithUnauthorizedExpense_ShouldThrow()
+    {
+        _expenseRepo.Setup(r => r.GetByIdAndUserAsync(ExpenseId, UserId, default))
+                    .ReturnsAsync((Expense?)null);
+
+        var dto = new SaveExpenseOrderDto(UserId, [new ExpenseOrderItemDto(ExpenseId, 0)]);
+        var act = () => _sut.ExecuteAsync(dto);
+
+        await act.Should().ThrowAsync<DomainException>().WithMessage("*permissão*");
+        _uow.Verify(u => u.CommitAsync(default), Times.Never);
+    }
+}

--- a/tests/PersonalFinance.Domain.Tests/Unit/Financial/ExpenseOrderTests.cs
+++ b/tests/PersonalFinance.Domain.Tests/Unit/Financial/ExpenseOrderTests.cs
@@ -1,0 +1,52 @@
+using FluentAssertions;
+using PersonalFinance.Domain.Entities.Financial;
+using PersonalFinance.Domain.Exceptions;
+using Xunit;
+
+namespace PersonalFinance.Domain.Tests.Unit.Financial;
+
+public class ExpenseOrderTests
+{
+    private static readonly Guid ExpenseId = Guid.NewGuid();
+
+    [Fact(DisplayName = "Deve criar ExpenseOrder com dados válidos")]
+    public void Create_WithValidData_ShouldSucceed()
+    {
+        var order = ExpenseOrder.Create(ExpenseId, 0);
+
+        order.ExpenseId.Should().Be(ExpenseId);
+        order.Order.Should().Be(0);
+        order.IsActive.Should().BeTrue();
+        order.Id.Should().NotBeEmpty();
+    }
+
+    [Fact(DisplayName = "Deve lançar exceção para ExpenseId vazio")]
+    public void Create_WithEmptyExpenseId_ShouldThrow()
+    {
+        var act = () => ExpenseOrder.Create(Guid.Empty, 0);
+        act.Should().Throw<DomainException>().WithMessage("*ExpenseId*");
+    }
+
+    [Fact(DisplayName = "Deve lançar exceção para Order negativo")]
+    public void Create_WithNegativeOrder_ShouldThrow()
+    {
+        var act = () => ExpenseOrder.Create(ExpenseId, -1);
+        act.Should().Throw<DomainException>().WithMessage("*ordem*");
+    }
+
+    [Fact(DisplayName = "Deve atualizar Order com valor válido")]
+    public void UpdateOrder_WithValidValue_ShouldUpdate()
+    {
+        var order = ExpenseOrder.Create(ExpenseId, 0);
+        order.UpdateOrder(5);
+        order.Order.Should().Be(5);
+    }
+
+    [Fact(DisplayName = "Deve lançar exceção ao atualizar Order com valor negativo")]
+    public void UpdateOrder_WithNegativeValue_ShouldThrow()
+    {
+        var order = ExpenseOrder.Create(ExpenseId, 0);
+        var act = () => order.UpdateOrder(-1);
+        act.Should().Throw<DomainException>().WithMessage("*ordem*");
+    }
+}


### PR DESCRIPTION
Closes #86

Drag and drop vertical para ordenação de despesas no grid.

- Backend: entidade `ExpenseOrder`, migration, endpoint `POST /api/v1/expenses/order`, ordenação default por `ExpenseOrder` na listagem
- Frontend: DnD nativo, botão "Salvar ordem", integração com API

🤖 Generated with [Claude Code](https://claude.com/claude-code)