### PR TITLE
chore(ci): trigger Render deploy on master push via deploy hook

### DIFF
--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -35,3 +35,6 @@ jobs:
           git checkout release
           git merge --ff-only origin/master || git merge -m "chore(ci): sync release ← master [skip ci]" origin/master
           git push origin release
+
+      - name: Trigger Render deploy
+        run: curl -s "${{ secrets.RENDER_DEPLOY_HOOK_URL }}"


### PR DESCRIPTION
Adiciona step no workflow `sync-branches.yml` para disparar o deploy no Render via deploy hook após cada push no master.

**Pré-requisito:** secret `RENDER_DEPLOY_HOOK_URL` já configurado no repositório.

🤖 Generated with [Claude Code](https://claude.com/claude-code)