### PR TITLE
chore(ci): tests gate before deploy (Render + Vercel)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI — Tests & Deploy
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  backend-tests:
+    name: Backend tests (.NET)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore
+        run: dotnet restore PersonalFinance.sln
+
+      - name: Build
+        run: dotnet build PersonalFinance.sln --no-restore --configuration Release
+
+      - name: Test
+        run: dotnet test PersonalFinance.sln --no-build --configuration Release
+
+  frontend-tests:
+    name: Frontend tests (Angular)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: personal-finance
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: personal-finance/package-lock.json
+
+      - name: Install
+        run: npm ci
+
+      - name: Test
+        run: npm test -- --watch=false --browsers=ChromeHeadless --no-progress
+
+  deploy:
+    name: Deploy
+    needs: [backend-tests, frontend-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to Render
+        run: curl -s "${{ secrets.RENDER_DEPLOY_HOOK_URL }}"
+
+      - name: Deploy to Vercel
+        run: curl -s "${{ secrets.VERCEL_DEPLOY_HOOK_URL }}"

--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -36,5 +36,3 @@ jobs:
           git merge --ff-only origin/master || git merge -m "chore(ci): sync release ← master [skip ci]" origin/master
           git push origin release
 
-      - name: Trigger Render deploy
-        run: curl -s "${{ secrets.RENDER_DEPLOY_HOOK_URL }}"

--- a/personal-finance/vercel.json
+++ b/personal-finance/vercel.json
@@ -1,4 +1,7 @@
 {
+  "github": {
+    "enabled": false
+  },
   "rewrites": [
     { "source": "/((?!api/).*)", "destination": "/index.html" }
   ]


### PR DESCRIPTION
Adiciona workflow `ci.yml` que roda testes backend (.NET) e frontend (Angular) em paralelo no push para `master`. Deploy para Render e Vercel só ocorre se ambos passarem.

## Fluxo
1. `backend-tests` — `dotnet test` (build Release + todos os projetos de teste)
2. `frontend-tests` — `npm test` (ChromeHeadless, no-watch)
3. `deploy` (depende de 1+2) — aciona deploy hooks do Render e Vercel

## Pré-requisitos
- Secret `RENDER_DEPLOY_HOOK_URL` — já configurado ✅
- Secret `VERCEL_DEPLOY_HOOK_URL` — criar em Vercel → projeto → Settings → Git → Deploy Hooks (branch `master`)

Remove o deploy hook do `sync-branches.yml` (centralizado aqui).

🤖 Generated with [Claude Code](https://claude.com/claude-code)