### PR TITLE
fix(ci): use npm install instead of npm ci (cross-platform lock file)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           cache-dependency-path: personal-finance/package-lock.json
 
       - name: Install
-        run: npm ci
+        run: npm install
 
       - name: Test
         run: npm test -- --watch=false --browsers=ChromeHeadless --no-progress


### PR DESCRIPTION
`package-lock.json` gerado no Windows não inclui dependências opcionais do Linux (`@emnapi/core`, `@emnapi/runtime`, `@emnapi/wasi-threads`). O `npm ci` é estrito e rejeita o lock file incompleto na action Ubuntu.

Troca `npm ci` por `npm install`, que tolera dependências opcionais ausentes no lock file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)