### PR TITLE
feat(expenses): batch operations — delete, pay, cancel (backend #87a)

### DIFF
--- a/src/PersonalFinance.Api/Controllers/V1/Financial/ExpensesController.cs
+++ b/src/PersonalFinance.Api/Controllers/V1/Financial/ExpensesController.cs
@@ -16,6 +16,9 @@ public sealed class ExpensesController(
     CreateExpenseUseCase createUseCase,
     UpdateExpenseUseCase updateUseCase,
     DeleteExpenseUseCase deleteUseCase,
+    DeleteExpensesBatchUseCase deleteBatchUseCase,
+    PayExpensesBatchUseCase payBatchUseCase,
+    CancelExpensesBatchUseCase cancelBatchUseCase,
     SaveExpenseOrderUseCase saveOrderUseCase,
     IExpenseRepository expenseRepository,
     IUnitOfWork unitOfWork) : ApiControllerBase
@@ -25,6 +28,9 @@ public sealed class ExpensesController(
     private readonly CreateExpenseUseCase _createUseCase = createUseCase;
     private readonly UpdateExpenseUseCase _updateUseCase = updateUseCase;
     private readonly DeleteExpenseUseCase _deleteUseCase = deleteUseCase;
+    private readonly DeleteExpensesBatchUseCase _deleteBatchUseCase = deleteBatchUseCase;
+    private readonly PayExpensesBatchUseCase _payBatchUseCase = payBatchUseCase;
+    private readonly CancelExpensesBatchUseCase _cancelBatchUseCase = cancelBatchUseCase;
     private readonly SaveExpenseOrderUseCase _saveOrderUseCase = saveOrderUseCase;
     private readonly IExpenseRepository _expenseRepository = expenseRepository;
     private readonly IUnitOfWork _unitOfWork = unitOfWork;
@@ -120,6 +126,39 @@ public sealed class ExpensesController(
         expense.MarkAsPartial();
         await _expenseRepository.UpdateAsync(expense, ct);
         await _unitOfWork.CommitAsync(ct);
+        return NoContent();
+    }
+
+    /// <summary>Exclui logicamente múltiplas despesas em lote.</summary>
+    [HttpDelete("batch")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> DeleteBatch(
+        [FromBody] BatchExpenseActionDto dto, CancellationToken ct)
+    {
+        await _deleteBatchUseCase.ExecuteAsync(dto, CurrentUserId, ct);
+        return NoContent();
+    }
+
+    /// <summary>Marca múltiplas despesas como pagas em lote. Data de pagamento = hoje (UTC).</summary>
+    [HttpPatch("batch/pay")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> PayBatch(
+        [FromBody] BatchExpenseActionDto dto, CancellationToken ct)
+    {
+        await _payBatchUseCase.ExecuteAsync(dto, CurrentUserId, ct);
+        return NoContent();
+    }
+
+    /// <summary>Marca múltiplas despesas como canceladas em lote.</summary>
+    [HttpPatch("batch/cancel")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> CancelBatch(
+        [FromBody] BatchExpenseActionDto dto, CancellationToken ct)
+    {
+        await _cancelBatchUseCase.ExecuteAsync(dto, CurrentUserId, ct);
         return NoContent();
     }
 

--- a/src/PersonalFinance.Api/Extensions/ApplicationExtensions.cs
+++ b/src/PersonalFinance.Api/Extensions/ApplicationExtensions.cs
@@ -62,6 +62,9 @@ public static class ApplicationExtensions
         services.AddScoped<CreateExpenseUseCase>();
         services.AddScoped<UpdateExpenseUseCase>();
         services.AddScoped<DeleteExpenseUseCase>();
+        services.AddScoped<DeleteExpensesBatchUseCase>();
+        services.AddScoped<PayExpensesBatchUseCase>();
+        services.AddScoped<CancelExpensesBatchUseCase>();
         services.AddScoped<SaveExpenseOrderUseCase>();
 
         // ── Financial — Incomes ───────────────────────────────────────────────

--- a/src/PersonalFinance.Application/DTOs/Financial/BatchExpenseActionDto.cs
+++ b/src/PersonalFinance.Application/DTOs/Financial/BatchExpenseActionDto.cs
@@ -1,0 +1,5 @@
+namespace PersonalFinance.Application.DTOs.Financial;
+
+public sealed record BatchExpenseActionDto(
+    IReadOnlyList<Guid> ExpenseIds
+);

--- a/src/PersonalFinance.Application/UseCases/Financial/Expenses/ExpenseUseCases.cs
+++ b/src/PersonalFinance.Application/UseCases/Financial/Expenses/ExpenseUseCases.cs
@@ -198,3 +198,124 @@ public sealed class DeleteExpenseUseCase
         await _unitOfWork.CommitAsync(ct);
     }
 }
+
+// ══════════════════════════════════════════════════════════════════════════════
+// DELETE EXPENSES BATCH
+// ══════════════════════════════════════════════════════════════════════════════
+
+public sealed class DeleteExpensesBatchUseCase
+{
+    private readonly IExpenseRepository _expenseRepository;
+    private readonly IUnitOfWork        _unitOfWork;
+
+    public DeleteExpensesBatchUseCase(
+        IExpenseRepository expenseRepository,
+        IUnitOfWork        unitOfWork)
+    {
+        _expenseRepository = expenseRepository;
+        _unitOfWork        = unitOfWork;
+    }
+
+    public async Task ExecuteAsync(
+        BatchExpenseActionDto dto,
+        Guid userId,
+        CancellationToken ct = default)
+    {
+        if (dto.ExpenseIds.Count == 0)
+            throw new DomainException("A lista de despesas não pode ser vazia.");
+
+        var expenses = (await _expenseRepository
+            .GetByIdsAndUserAsync(dto.ExpenseIds, userId, ct)).ToList();
+
+        if (expenses.Count == 0)
+            throw new DomainException(
+                "Nenhuma despesa encontrada ou sem permissão de acesso.");
+
+        foreach (var expense in expenses)
+            expense.SoftDelete();
+
+        await _expenseRepository.UpdateRangeAsync(expenses, ct);
+        await _unitOfWork.CommitAsync(ct);
+    }
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// PAY EXPENSES BATCH
+// ══════════════════════════════════════════════════════════════════════════════
+
+public sealed class PayExpensesBatchUseCase
+{
+    private readonly IExpenseRepository _expenseRepository;
+    private readonly IUnitOfWork        _unitOfWork;
+
+    public PayExpensesBatchUseCase(
+        IExpenseRepository expenseRepository,
+        IUnitOfWork        unitOfWork)
+    {
+        _expenseRepository = expenseRepository;
+        _unitOfWork        = unitOfWork;
+    }
+
+    public async Task ExecuteAsync(
+        BatchExpenseActionDto dto,
+        Guid userId,
+        CancellationToken ct = default)
+    {
+        if (dto.ExpenseIds.Count == 0)
+            throw new DomainException("A lista de despesas não pode ser vazia.");
+
+        var expenses = (await _expenseRepository
+            .GetByIdsAndUserAsync(dto.ExpenseIds, userId, ct)).ToList();
+
+        if (expenses.Count == 0)
+            throw new DomainException(
+                "Nenhuma despesa encontrada ou sem permissão de acesso.");
+
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        foreach (var expense in expenses)
+            expense.MarkAsPaid(today);
+
+        await _expenseRepository.UpdateRangeAsync(expenses, ct);
+        await _unitOfWork.CommitAsync(ct);
+    }
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// CANCEL EXPENSES BATCH
+// ══════════════════════════════════════════════════════════════════════════════
+
+public sealed class CancelExpensesBatchUseCase
+{
+    private readonly IExpenseRepository _expenseRepository;
+    private readonly IUnitOfWork        _unitOfWork;
+
+    public CancelExpensesBatchUseCase(
+        IExpenseRepository expenseRepository,
+        IUnitOfWork        unitOfWork)
+    {
+        _expenseRepository = expenseRepository;
+        _unitOfWork        = unitOfWork;
+    }
+
+    public async Task ExecuteAsync(
+        BatchExpenseActionDto dto,
+        Guid userId,
+        CancellationToken ct = default)
+    {
+        if (dto.ExpenseIds.Count == 0)
+            throw new DomainException("A lista de despesas não pode ser vazia.");
+
+        var expenses = (await _expenseRepository
+            .GetByIdsAndUserAsync(dto.ExpenseIds, userId, ct)).ToList();
+
+        if (expenses.Count == 0)
+            throw new DomainException(
+                "Nenhuma despesa encontrada ou sem permissão de acesso.");
+
+        foreach (var expense in expenses)
+            expense.MarkAsCancelled();
+
+        await _expenseRepository.UpdateRangeAsync(expenses, ct);
+        await _unitOfWork.CommitAsync(ct);
+    }
+}

--- a/src/PersonalFinance.Domain/Interfaces/Repositories/IExpenseRepository.cs
+++ b/src/PersonalFinance.Domain/Interfaces/Repositories/IExpenseRepository.cs
@@ -35,6 +35,12 @@ public interface IExpenseRepository
 
     Task AddAsync(Expense expense, CancellationToken ct = default);
     Task UpdateAsync(Expense expense, CancellationToken ct = default);
+    Task UpdateRangeAsync(IEnumerable<Expense> expenses, CancellationToken ct = default);
+
+    Task<IEnumerable<Expense>> GetByIdsAndUserAsync(
+        IReadOnlyList<Guid> ids,
+        Guid userId,
+        CancellationToken ct = default);
 
     /// <summary>
     /// Retorna true se existir qualquer despesa ativa vinculada à categoria informada.

--- a/src/PersonalFinance.Infrastructure/Persistence/Repositories/Financial/ExpenseRepository.cs
+++ b/src/PersonalFinance.Infrastructure/Persistence/Repositories/Financial/ExpenseRepository.cs
@@ -55,6 +55,20 @@ public sealed class ExpenseRepository : IExpenseRepository
         return Task.CompletedTask;
     }
 
+    public Task UpdateRangeAsync(IEnumerable<Expense> expenses, CancellationToken ct = default)
+    {
+        _context.Expenses.UpdateRange(expenses);
+        return Task.CompletedTask;
+    }
+
+    public async Task<IEnumerable<Expense>> GetByIdsAndUserAsync(
+        IReadOnlyList<Guid> ids,
+        Guid userId,
+        CancellationToken ct = default)
+        => await _context.Expenses
+               .Where(e => ids.Contains(e.Id) && e.UserId == userId)
+               .ToListAsync(ct);
+
     public async Task<(IEnumerable<Expense> Items, int TotalCount)> GetPagedByPeriodAsync(
         Guid          periodId,
         Guid          userId,

--- a/tests/PersonalFinance.Api.Tests/Integration/ExpensesBatchControllerTests.cs
+++ b/tests/PersonalFinance.Api.Tests/Integration/ExpensesBatchControllerTests.cs
@@ -1,0 +1,131 @@
+using FluentAssertions;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Xunit;
+
+namespace PersonalFinance.Api.Tests.Integration
+{
+    public class ExpensesBatchControllerTests : ApiIntegrationTestBase
+    {
+        public ExpensesBatchControllerTests(TestWebApplicationFactory f) : base(f) { }
+
+        private async Task<(HttpClient client, string periodId, string categoryId)> SetupAsync()
+        {
+            var (client, _) = await GetAuthenticatedClientAsync();
+
+            var period = await client.PostAsJsonAsync("/api/v1/periods", new { year = 2026, month = 9 });
+            var pBody  = await period.Content.ReadFromJsonAsync<JsonElement>();
+            var pid    = pBody.GetProperty("id").GetString()!;
+
+            var cat   = await client.PostAsJsonAsync("/api/v1/categories", new
+            { name = $"CatBatch_{Guid.NewGuid():N}", color = "#1E4D2B" });
+            var cBody = await cat.Content.ReadFromJsonAsync<JsonElement>();
+            var cid   = cBody.GetProperty("id").GetString()!;
+
+            return (client, pid, cid);
+        }
+
+        private async Task<string> CreateExpenseAsync(
+            HttpClient client, string pid, string cid, string description)
+        {
+            var r = await client.PostAsJsonAsync("/api/v1/expenses", new
+            {
+                periodId = pid, categoryId = cid, sourceType = 2, fortnightType = 1,
+                description, amount = 50.00, dueDate = "2026-09-10"
+            });
+            var body = await r.Content.ReadFromJsonAsync<JsonElement>();
+            return body.GetProperty("id").GetString()!;
+        }
+
+        [Fact(DisplayName = "DELETE /expenses/batch deve soft-deletar todos os itens e retornar 204")]
+        public async Task DeleteBatch_ShouldReturn204AndRemoveFromList()
+        {
+            var (client, pid, cid) = await SetupAsync();
+            var id1 = await CreateExpenseAsync(client, pid, cid, "Batch Del 1");
+            var id2 = await CreateExpenseAsync(client, pid, cid, "Batch Del 2");
+
+            var r = await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete, "/api/v1/expenses/batch")
+            {
+                Content = JsonContent.Create(new { expenseIds = new[] { id1, id2 } })
+            });
+
+            r.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+            var list = await client.GetAsync($"/api/v1/expenses?periodId={pid}");
+            var body = await list.Content.ReadFromJsonAsync<JsonElement>();
+            body.GetProperty("items").GetArrayLength().Should().Be(0);
+        }
+
+        [Fact(DisplayName = "PATCH /expenses/batch/pay deve marcar todos como Paid e retornar 204")]
+        public async Task PayBatch_ShouldReturn204AndStatusPaid()
+        {
+            var (client, pid, cid) = await SetupAsync();
+            var id1 = await CreateExpenseAsync(client, pid, cid, "Batch Pay 1");
+            var id2 = await CreateExpenseAsync(client, pid, cid, "Batch Pay 2");
+
+            var r = await client.PatchAsJsonAsync("/api/v1/expenses/batch/pay",
+                new { expenseIds = new[] { id1, id2 } });
+
+            r.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+            var e1 = await (await client.GetAsync($"/api/v1/expenses/{id1}"))
+                .Content.ReadFromJsonAsync<JsonElement>();
+            e1.GetProperty("paymentStatus").GetInt32().Should().Be(2); // Paid = 2
+
+            var e2 = await (await client.GetAsync($"/api/v1/expenses/{id2}"))
+                .Content.ReadFromJsonAsync<JsonElement>();
+            e2.GetProperty("paymentStatus").GetInt32().Should().Be(2);
+        }
+
+        [Fact(DisplayName = "PATCH /expenses/batch/cancel deve marcar todos como Cancelled e retornar 204")]
+        public async Task CancelBatch_ShouldReturn204AndStatusCancelled()
+        {
+            var (client, pid, cid) = await SetupAsync();
+            var id1 = await CreateExpenseAsync(client, pid, cid, "Batch Cancel 1");
+            var id2 = await CreateExpenseAsync(client, pid, cid, "Batch Cancel 2");
+
+            var r = await client.PatchAsJsonAsync("/api/v1/expenses/batch/cancel",
+                new { expenseIds = new[] { id1, id2 } });
+
+            r.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+            var e1 = await (await client.GetAsync($"/api/v1/expenses/{id1}"))
+                .Content.ReadFromJsonAsync<JsonElement>();
+            e1.GetProperty("paymentStatus").GetInt32().Should().Be(3); // Cancelled = 3
+
+            var e2 = await (await client.GetAsync($"/api/v1/expenses/{id2}"))
+                .Content.ReadFromJsonAsync<JsonElement>();
+            e2.GetProperty("paymentStatus").GetInt32().Should().Be(3);
+        }
+
+        [Fact(DisplayName = "DELETE /expenses/batch com lista vazia deve retornar 400")]
+        public async Task DeleteBatch_EmptyList_ShouldReturn400()
+        {
+            var (client, _, _) = await SetupAsync();
+            var r = await client.SendAsync(new HttpRequestMessage(HttpMethod.Delete, "/api/v1/expenses/batch")
+            {
+                Content = JsonContent.Create(new { expenseIds = Array.Empty<string>() })
+            });
+            r.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        }
+
+        [Fact(DisplayName = "PATCH /expenses/batch/pay com lista vazia deve retornar 400")]
+        public async Task PayBatch_EmptyList_ShouldReturn400()
+        {
+            var (client, _, _) = await SetupAsync();
+            var r = await client.PatchAsJsonAsync("/api/v1/expenses/batch/pay",
+                new { expenseIds = Array.Empty<string>() });
+            r.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        }
+
+        [Fact(DisplayName = "PATCH /expenses/batch/cancel com lista vazia deve retornar 400")]
+        public async Task CancelBatch_EmptyList_ShouldReturn400()
+        {
+            var (client, _, _) = await SetupAsync();
+            var r = await client.PatchAsJsonAsync("/api/v1/expenses/batch/cancel",
+                new { expenseIds = Array.Empty<string>() });
+            r.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        }
+    }
+}

--- a/tests/PersonalFinance.Application.Tests/Unit/Financial/BatchExpenseUseCaseTests.cs
+++ b/tests/PersonalFinance.Application.Tests/Unit/Financial/BatchExpenseUseCaseTests.cs
@@ -1,0 +1,141 @@
+using FluentAssertions;
+using Moq;
+using PersonalFinance.Application.DTOs.Financial;
+using PersonalFinance.Application.UseCases.Financial.Expenses;
+using PersonalFinance.Domain.Entities.Financial;
+using PersonalFinance.Domain.Enums;
+using PersonalFinance.Domain.Exceptions;
+using PersonalFinance.Domain.Interfaces.Repositories;
+using Xunit;
+
+namespace PersonalFinance.Application.Tests.Unit.Financial;
+
+public class BatchExpenseUseCaseTests
+{
+    private readonly Mock<IExpenseRepository> _repo = new();
+    private readonly Mock<IUnitOfWork>        _uow  = new();
+
+    private static Expense MakeExpense(Guid userId) =>
+        Expense.Create(
+            Guid.NewGuid(), userId, Guid.NewGuid(),
+            SourceType.Personal, FortnightType.First, PaymentStatus.Pending,
+            "Teste", 100m, DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-1)), null, null);
+
+    // ── DeleteExpensesBatchUseCase ────────────────────────────────────────────
+
+    [Fact(DisplayName = "DeleteBatch: deve soft-deletar todos os itens encontrados")]
+    public async Task DeleteBatch_ShouldSoftDeleteAll()
+    {
+        var userId = Guid.NewGuid();
+        var ids    = new List<Guid> { Guid.NewGuid(), Guid.NewGuid() };
+        var expenses = ids.Select(_ => MakeExpense(userId)).ToList();
+
+        _repo.Setup(r => r.GetByIdsAndUserAsync(ids, userId, default))
+             .ReturnsAsync(expenses);
+
+        var sut = new DeleteExpensesBatchUseCase(_repo.Object, _uow.Object);
+        await sut.ExecuteAsync(new BatchExpenseActionDto(ids), userId);
+
+        expenses.Should().AllSatisfy(e => e.IsDeleted.Should().BeTrue());
+        _repo.Verify(r => r.UpdateRangeAsync(expenses, default), Times.Once);
+        _uow.Verify(u => u.CommitAsync(default), Times.Once);
+    }
+
+    [Fact(DisplayName = "DeleteBatch: lista vazia deve lançar DomainException")]
+    public async Task DeleteBatch_EmptyList_ShouldThrow()
+    {
+        var sut = new DeleteExpensesBatchUseCase(_repo.Object, _uow.Object);
+        var act = () => sut.ExecuteAsync(new BatchExpenseActionDto([]), Guid.NewGuid());
+        await act.Should().ThrowAsync<DomainException>();
+    }
+
+    [Fact(DisplayName = "DeleteBatch: nenhuma despesa encontrada deve lançar DomainException")]
+    public async Task DeleteBatch_NoneFound_ShouldThrow()
+    {
+        var ids = new List<Guid> { Guid.NewGuid() };
+        _repo.Setup(r => r.GetByIdsAndUserAsync(ids, It.IsAny<Guid>(), default))
+             .ReturnsAsync([]);
+
+        var sut = new DeleteExpensesBatchUseCase(_repo.Object, _uow.Object);
+        var act = () => sut.ExecuteAsync(new BatchExpenseActionDto(ids), Guid.NewGuid());
+        await act.Should().ThrowAsync<DomainException>();
+    }
+
+    // ── PayExpensesBatchUseCase ───────────────────────────────────────────────
+
+    [Fact(DisplayName = "PayBatch: deve marcar todos como Paid")]
+    public async Task PayBatch_ShouldMarkAllAsPaid()
+    {
+        var userId   = Guid.NewGuid();
+        var ids      = new List<Guid> { Guid.NewGuid() };
+        var expenses = ids.Select(_ => MakeExpense(userId)).ToList();
+
+        _repo.Setup(r => r.GetByIdsAndUserAsync(ids, userId, default))
+             .ReturnsAsync(expenses);
+
+        var sut = new PayExpensesBatchUseCase(_repo.Object, _uow.Object);
+        await sut.ExecuteAsync(new BatchExpenseActionDto(ids), userId);
+
+        expenses.Should().AllSatisfy(e => e.PaymentStatus.Should().Be(PaymentStatus.Paid));
+        _uow.Verify(u => u.CommitAsync(default), Times.Once);
+    }
+
+    [Fact(DisplayName = "PayBatch: lista vazia deve lançar DomainException")]
+    public async Task PayBatch_EmptyList_ShouldThrow()
+    {
+        var sut = new PayExpensesBatchUseCase(_repo.Object, _uow.Object);
+        var act = () => sut.ExecuteAsync(new BatchExpenseActionDto([]), Guid.NewGuid());
+        await act.Should().ThrowAsync<DomainException>();
+    }
+
+    [Fact(DisplayName = "PayBatch: nenhuma despesa encontrada deve lançar DomainException")]
+    public async Task PayBatch_NoneFound_ShouldThrow()
+    {
+        var ids = new List<Guid> { Guid.NewGuid() };
+        _repo.Setup(r => r.GetByIdsAndUserAsync(ids, It.IsAny<Guid>(), default))
+             .ReturnsAsync([]);
+
+        var sut = new PayExpensesBatchUseCase(_repo.Object, _uow.Object);
+        var act = () => sut.ExecuteAsync(new BatchExpenseActionDto(ids), Guid.NewGuid());
+        await act.Should().ThrowAsync<DomainException>();
+    }
+
+    // ── CancelExpensesBatchUseCase ────────────────────────────────────────────
+
+    [Fact(DisplayName = "CancelBatch: deve marcar todos como Cancelled")]
+    public async Task CancelBatch_ShouldMarkAllAsCancelled()
+    {
+        var userId   = Guid.NewGuid();
+        var ids      = new List<Guid> { Guid.NewGuid() };
+        var expenses = ids.Select(_ => MakeExpense(userId)).ToList();
+
+        _repo.Setup(r => r.GetByIdsAndUserAsync(ids, userId, default))
+             .ReturnsAsync(expenses);
+
+        var sut = new CancelExpensesBatchUseCase(_repo.Object, _uow.Object);
+        await sut.ExecuteAsync(new BatchExpenseActionDto(ids), userId);
+
+        expenses.Should().AllSatisfy(e => e.PaymentStatus.Should().Be(PaymentStatus.Cancelled));
+        _uow.Verify(u => u.CommitAsync(default), Times.Once);
+    }
+
+    [Fact(DisplayName = "CancelBatch: lista vazia deve lançar DomainException")]
+    public async Task CancelBatch_EmptyList_ShouldThrow()
+    {
+        var sut = new CancelExpensesBatchUseCase(_repo.Object, _uow.Object);
+        var act = () => sut.ExecuteAsync(new BatchExpenseActionDto([]), Guid.NewGuid());
+        await act.Should().ThrowAsync<DomainException>();
+    }
+
+    [Fact(DisplayName = "CancelBatch: nenhuma despesa encontrada deve lançar DomainException")]
+    public async Task CancelBatch_NoneFound_ShouldThrow()
+    {
+        var ids = new List<Guid> { Guid.NewGuid() };
+        _repo.Setup(r => r.GetByIdsAndUserAsync(ids, It.IsAny<Guid>(), default))
+             .ReturnsAsync([]);
+
+        var sut = new CancelExpensesBatchUseCase(_repo.Object, _uow.Object);
+        var act = () => sut.ExecuteAsync(new BatchExpenseActionDto(ids), Guid.NewGuid());
+        await act.Should().ThrowAsync<DomainException>();
+    }
+}


### PR DESCRIPTION
## Resumo
- DTO `BatchExpenseActionDto` com `IReadOnlyList<Guid> ExpenseIds`
- `IExpenseRepository`: novos métodos `GetByIdsAndUserAsync` e `UpdateRangeAsync`
- 3 use cases: `DeleteExpensesBatchUseCase`, `PayExpensesBatchUseCase`, `CancelExpensesBatchUseCase`
- 3 endpoints: `DELETE /api/v1/expenses/batch`, `PATCH /batch/pay`, `PATCH /batch/cancel`
- 9 testes unitários + 6 testes de integração (todos passando)

Closes #87