### PR TITLE
feat(expenses): UI de seleção em lote (batch)

### DIFF
--- a/personal-finance/src/app/core/services/api.service.ts
+++ b/personal-finance/src/app/core/services/api.service.ts
@@ -115,6 +115,18 @@ export class ApiService {
     return this.http.post<void>(`${this.base}/expenses/order`, items);
   }
 
+  batchPayExpenses(ids: string[]): Observable<void> {
+    return this.http.patch<void>(`${this.base}/expenses/batch/pay`, { expenseIds: ids });
+  }
+
+  batchCancelExpenses(ids: string[]): Observable<void> {
+    return this.http.patch<void>(`${this.base}/expenses/batch/cancel`, { expenseIds: ids });
+  }
+
+  batchDeleteExpenses(ids: string[]): Observable<void> {
+    return this.http.delete<void>(`${this.base}/expenses/batch`, { body: { expenseIds: ids } });
+  }
+
   // ── Incomes ───────────────────────────────────────────────────────────────
 
   getIncomesByPeriod(periodId: string, filters?: IncomeFilterParams): Observable<PagedResult<IncomeResponse>> {

--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.css
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.css
@@ -164,3 +164,15 @@
   padding: 10px 16px;
   border-bottom: 1px solid var(--border);
 }
+
+.check-col { width: 36px; padding: 0 8px !important; text-align: center; }
+
+.batch-action-bar {
+  display: flex; align-items: center; gap: 8px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface2);
+}
+.batch-count { font-size: 0.85rem; color: var(--ink2); margin-right: 4px; }
+
+.row-selected { background: color-mix(in srgb, var(--primary) 8%, transparent) !important; }

--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.html
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.html
@@ -97,9 +97,20 @@
           </button>
         </div>
       }
+      @if (selectedExpenseIds().length > 0) {
+        <div class="batch-action-bar">
+          <span class="batch-count">{{ selectedExpenseIds().length }} selecionado(s)</span>
+          <button class="btn btn-success btn-sm" (click)="batchPay()">Pagar</button>
+          <button class="btn btn-secondary btn-sm" (click)="batchCancel()">Cancelar</button>
+          <button class="btn btn-danger btn-sm" (click)="batchDelete()">Excluir</button>
+        </div>
+      }
       <table class="table">
         <thead>
           <tr>
+            <th class="check-col">
+              <input type="checkbox" [checked]="allSelected()" (change)="toggleSelectAll()" />
+            </th>
             <th class="drag-col"></th>
             <th class="sortable" (click)="toggleSort('description')">
               Descrição {{ sortIcon('description') }}
@@ -132,7 +143,11 @@
               (dragstart)="onDragStart(i)"
               (dragover)="onDragOver($event)"
               (drop)="onDrop(i)"
+              [class.row-selected]="isSelected(expense.id)"
             >
+              <td class="check-col">
+                <input type="checkbox" [checked]="isSelected(expense.id)" (change)="toggleSelect(expense.id)" />
+              </td>
               <td class="drag-col">
                 <span class="drag-handle" title="Arrastar para reordenar">⠿</span>
               </td>

--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.spec.ts
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.spec.ts
@@ -28,7 +28,7 @@ describe('ExpensesComponent', () => {
     apiSpy = jasmine.createSpyObj('ApiService', [
       'getPeriods', 'getCategories', 'getExpensesByPeriod',
       'createExpense', 'updateExpense', 'markExpenseAsPaid', 'deleteExpense',
-      'saveExpenseOrder'
+      'saveExpenseOrder', 'batchPayExpenses', 'batchCancelExpenses', 'batchDeleteExpenses'
     ]);
     apiSpy.getPeriods.and.returnValue(of([PERIOD]));
     apiSpy.getCategories.and.returnValue(of([CATEGORY]));
@@ -217,6 +217,77 @@ describe('ExpensesComponent', () => {
     it('saveOrder não faz nada quando pendingOrders está vazio', () => {
       component.saveOrder();
       expect(apiSpy.saveExpenseOrder).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('seleção em lote', () => {
+    const EXPENSE_B: ExpenseResponse = { ...EXPENSE, id: 'e-2', description: 'Internet' };
+
+    beforeEach(() => {
+      component.expenses.set([EXPENSE, EXPENSE_B]);
+    });
+
+    it('toggleSelect adiciona e remove id da seleção', () => {
+      component.toggleSelect('e-1');
+      expect(component.selectedExpenseIds()).toContain('e-1');
+      component.toggleSelect('e-1');
+      expect(component.selectedExpenseIds()).not.toContain('e-1');
+    });
+
+    it('toggleSelectAll seleciona todos os itens exibidos', () => {
+      component.toggleSelectAll();
+      expect(component.selectedExpenseIds().length).toBe(2);
+      expect(component.allSelected()).toBeTrue();
+    });
+
+    it('toggleSelectAll desmarca todos quando todos estão selecionados', () => {
+      component.selectedExpenseIds.set(['e-1', 'e-2']);
+      component.toggleSelectAll();
+      expect(component.selectedExpenseIds().length).toBe(0);
+    });
+
+    it('isSelected retorna true apenas para ids selecionados', () => {
+      component.selectedExpenseIds.set(['e-1']);
+      expect(component.isSelected('e-1')).toBeTrue();
+      expect(component.isSelected('e-2')).toBeFalse();
+    });
+
+    it('batchPay marca itens como Paid e limpa seleção', fakeAsync(() => {
+      apiSpy.batchPayExpenses.and.returnValue(of(undefined));
+      component.selectedExpenseIds.set(['e-1', 'e-2']);
+      component.batchPay();
+      tick();
+      expect(apiSpy.batchPayExpenses).toHaveBeenCalledWith(['e-1', 'e-2']);
+      expect(component.expenses().every(e => e.paymentStatus === PaymentStatus.Paid)).toBeTrue();
+      expect(component.selectedExpenseIds().length).toBe(0);
+    }));
+
+    it('batchCancel marca itens como Cancelled e limpa seleção', fakeAsync(() => {
+      apiSpy.batchCancelExpenses.and.returnValue(of(undefined));
+      component.selectedExpenseIds.set(['e-1']);
+      component.batchCancel();
+      tick();
+      expect(apiSpy.batchCancelExpenses).toHaveBeenCalledWith(['e-1']);
+      expect(component.expenses().find(e => e.id === 'e-1')?.paymentStatus).toBe(PaymentStatus.Cancelled);
+      expect(component.selectedExpenseIds().length).toBe(0);
+    }));
+
+    it('batchDelete remove itens da lista e limpa seleção', fakeAsync(() => {
+      spyOn(window, 'confirm').and.returnValue(true);
+      apiSpy.batchDeleteExpenses.and.returnValue(of(undefined));
+      component.selectedExpenseIds.set(['e-1', 'e-2']);
+      component.batchDelete();
+      tick();
+      expect(apiSpy.batchDeleteExpenses).toHaveBeenCalledWith(['e-1', 'e-2']);
+      expect(component.expenses().length).toBe(0);
+      expect(component.selectedExpenseIds().length).toBe(0);
+    }));
+
+    it('batchDelete não executa quando usuário cancela confirm', () => {
+      spyOn(window, 'confirm').and.returnValue(false);
+      component.selectedExpenseIds.set(['e-1']);
+      component.batchDelete();
+      expect(apiSpy.batchDeleteExpenses).not.toHaveBeenCalled();
     });
   });
 

--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.ts
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.ts
@@ -83,6 +83,13 @@ export class ExpensesComponent implements OnInit {
   // Debounce para busca por descrição
   private descriptionDebounce: ReturnType<typeof setTimeout> | null = null;
 
+  // Seleção em lote
+  readonly selectedExpenseIds = signal<string[]>([]);
+  readonly allSelected = computed(() => {
+    const displayed = this.displayedExpenses();
+    return displayed.length > 0 && displayed.every(e => this.selectedExpenseIds().includes(e.id));
+  });
+
   // Drag and drop
   private draggedIndex: number | null = null;
   readonly pendingOrders = signal<ExpenseOrderItem[]>([]);
@@ -399,6 +406,72 @@ export class ExpensesComponent implements OnInit {
       next: () => {
         this.expenses.update(list => list.filter(e => e.id !== id));
         this.totalCount.update(n => n - 1);
+      }
+    });
+  }
+
+  // ── Seleção em lote ───────────────────────────────────────────────────────
+
+  isSelected(id: string): boolean {
+    return this.selectedExpenseIds().includes(id);
+  }
+
+  toggleSelect(id: string): void {
+    this.selectedExpenseIds.update(ids =>
+      ids.includes(id) ? ids.filter(x => x !== id) : [...ids, id]
+    );
+  }
+
+  toggleSelectAll(): void {
+    if (this.allSelected()) {
+      this.selectedExpenseIds.set([]);
+    } else {
+      this.selectedExpenseIds.set(this.displayedExpenses().map(e => e.id));
+    }
+  }
+
+  batchPay(): void {
+    const ids = this.selectedExpenseIds();
+    if (!ids.length) return;
+    const today = new Date().toISOString().split('T')[0];
+    this.api.batchPayExpenses(ids).subscribe({
+      next: () => {
+        this.expenses.update(list =>
+          list.map(e => ids.includes(e.id)
+            ? { ...e, paymentStatus: PaymentStatus.Paid, paymentDate: today }
+            : e
+          )
+        );
+        this.selectedExpenseIds.set([]);
+      }
+    });
+  }
+
+  batchCancel(): void {
+    const ids = this.selectedExpenseIds();
+    if (!ids.length) return;
+    this.api.batchCancelExpenses(ids).subscribe({
+      next: () => {
+        this.expenses.update(list =>
+          list.map(e => ids.includes(e.id)
+            ? { ...e, paymentStatus: PaymentStatus.Cancelled }
+            : e
+          )
+        );
+        this.selectedExpenseIds.set([]);
+      }
+    });
+  }
+
+  batchDelete(): void {
+    const ids = this.selectedExpenseIds();
+    if (!ids.length) return;
+    if (!confirm(`Confirma a exclusão de ${ids.length} despesa(s)?`)) return;
+    this.api.batchDeleteExpenses(ids).subscribe({
+      next: () => {
+        this.expenses.update(list => list.filter(e => !ids.includes(e.id)));
+        this.totalCount.update(n => n - ids.length);
+        this.selectedExpenseIds.set([]);
       }
     });
   }


### PR DESCRIPTION
## Resumo

- Coluna de checkbox em cada linha + select-all no cabeçalho
- Barra de ações (Pagar / Cancelar / Excluir) exibida quando ≥1 item selecionado
- 3 novos métodos em `ApiService`: `batchPayExpenses`, `batchCancelExpenses`, `batchDeleteExpenses`
- Linha selecionada recebe highlight visual (`row-selected`)
- 8 specs novos — total 247 SUCCESS

Closes #123