### PR TITLE
fix(ci): curl -sf para expor erros nos webhooks de deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Deploy to Render
-        run: curl -s "${{ secrets.RENDER_DEPLOY_HOOK_URL }}"
+        run: curl -sf "${{ secrets.RENDER_DEPLOY_HOOK_URL }}"
 
       - name: Deploy to Vercel
-        run: curl -s "${{ secrets.VERCEL_DEPLOY_HOOK_URL }}"
+        run: curl -sf "${{ secrets.VERCEL_DEPLOY_HOOK_URL }}"


### PR DESCRIPTION
Adiciona flag `-f` ao `curl` nos steps de deploy (Render e Vercel) para que o job falhe quando o webhook retornar 4xx/5xx, em vez de passar silenciosamente.