### PR TITLE
fix(ci/vercel): curl -sf no webhook e remover github.enabled:false

### DIFF
--- a/personal-finance/vercel.json
+++ b/personal-finance/vercel.json
@@ -1,7 +1,4 @@
 {
-  "github": {
-    "enabled": false
-  },
   "rewrites": [
     { "source": "/((?!api/).*)", "destination": "/index.html" }
   ]


### PR DESCRIPTION
- `curl -sf` expõe erros 4xx/5xx nos steps de deploy
- Remove `github.enabled: false` do `vercel.json` que bloqueava o deploy hook