### PR TITLE
fix(ci/vercel/theme): webhooks, vercel.json e matchMedia no CI

### DIFF
--- a/personal-finance/src/app/core/services/theme.service.spec.ts
+++ b/personal-finance/src/app/core/services/theme.service.spec.ts
@@ -31,17 +31,17 @@ describe('ThemeService', () => {
     });
 
     it('usa preferência do sistema quando localStorage está vazio', () => {
-      spyOn(window, 'matchMedia').and.returnValue({
-        matches: true,
-        media: '',
-        onchange: null,
-        addListener: () => {},
-        removeListener: () => {},
-        addEventListener: () => {},
-        removeEventListener: () => {},
+      const mql = {
+        matches: true, media: '', onchange: null,
+        addListener: () => {}, removeListener: () => {},
+        addEventListener: () => {}, removeEventListener: () => {},
         dispatchEvent: () => false,
-      } as MediaQueryList);
-      const svc = createService();
+      } as MediaQueryList;
+      // spyOn antes do configureTestingModule — signal é avaliado na instanciação
+      spyOn(window, 'matchMedia').and.returnValue(mql);
+      TestBed.configureTestingModule({ providers: [ThemeService] });
+      const svc = TestBed.inject(ThemeService);
+      TestBed.flushEffects();
       expect(svc.isDark()).toBeTrue();
     });
 

--- a/personal-finance/src/app/core/services/theme.service.ts
+++ b/personal-finance/src/app/core/services/theme.service.ts
@@ -7,6 +7,7 @@ export class ThemeService {
   readonly isDark = signal<boolean>(
     localStorage.getItem(THEME_KEY) === 'dark' ||
     (!localStorage.getItem(THEME_KEY) &&
+      typeof window.matchMedia === 'function' &&
       window.matchMedia('(prefers-color-scheme: dark)').matches)
   );
 


### PR DESCRIPTION
- `curl -sf` expõe erros 4xx/5xx nos steps de deploy
- Remove `github.enabled: false` do `vercel.json` que bloqueava o deploy hook
- Guard `typeof window.matchMedia === 'function'` no ThemeService
- Corrige ordem do `spyOn` no spec para rodar antes da instanciação do signal