### PR TITLE
feat(#126): layout dashboard — sidebar, KPI cards, widgets drag-drop, tweaks panel

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -160,4 +160,29 @@
 
 ---
 
+## Estratégia de migração CSS (Option C) — issues #126–#133
+
+As issues de layout são implementadas de forma gradual. Para evitar quebrar pages ainda não migradas, seguir esta convenção:
+
+### Tokens sem conflito — adicionar direto ao `:root`
+`--terracotta`, `--purple`, `--amber`, `--slate`, `--rose`, `--gold`, `--font-b`, `--font-d`, `--ease`, `--t`, `--text`, `--text-muted`, `--text-subtle`, `--radius-xs`, `--surface-solid`
+
+### Tokens conflitantes — usar prefixo `--v2-` até migração completa
+| Token design system | Nome transitório |
+|---------------------|-----------------|
+| `--bg`              | `--v2-bg`       |
+| `--sidebar-bg`      | `--v2-sidebar-bg` |
+| `--surface`         | `--v2-surface`  |
+| `--border`          | `--v2-border`   |
+| `--radius`          | `--v2-radius`   |
+| `--radius-sm`       | `--v2-radius-sm`|
+| `--shadow`          | `--v2-shadow`   |
+
+### Regra de uso
+- **Novos componentes** (issues #126–#133): usar `--v2-*` e tokens novos sem prefixo.
+- **Pages já migradas**: já usam `--v2-*`.
+- **Após todas as pages migrarem**: commit único renomeia `--v2-*` → nome canônico do design system.
+
+---
+
 *Referência: issue #105 — Refactory Layout Sistema*

--- a/personal-finance/src/app/app.component.ts
+++ b/personal-finance/src/app/app.component.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { TweaksService } from './core/services/tweaks.service';
 
 @Component({
   selector: 'app-root',
@@ -7,4 +8,10 @@ import { RouterOutlet } from '@angular/router';
   imports: [RouterOutlet],
   template: `<router-outlet />`
 })
-export class AppComponent {}
+export class AppComponent implements OnInit {
+  private readonly tweaks = inject(TweaksService);
+
+  ngOnInit(): void {
+    this.tweaks.apply();
+  }
+}

--- a/personal-finance/src/app/core/services/theme.service.ts
+++ b/personal-finance/src/app/core/services/theme.service.ts
@@ -16,6 +16,7 @@ export class ThemeService {
     effect(() => {
       const dark = this.isDark();
       document.documentElement.classList.toggle('dark', dark);
+      document.documentElement.setAttribute('data-dark', String(dark));
       localStorage.setItem(THEME_KEY, dark ? 'dark' : 'light');
     });
   }

--- a/personal-finance/src/app/core/services/tweaks.service.ts
+++ b/personal-finance/src/app/core/services/tweaks.service.ts
@@ -1,0 +1,50 @@
+import { Injectable, signal } from '@angular/core';
+import { Density } from '../../shared/components/tweaks-panel/tweaks-panel.component';
+
+const KEY_ACCENT  = 'pf_accent';
+const KEY_DENSITY = 'pf_density';
+
+const DENSITY_GAPS: Record<Density, string> = {
+  compact:     '12px',
+  normal:      '24px',
+  comfortable: '36px',
+};
+
+const DENSITY_PADDING: Record<Density, string> = {
+  compact:     '16px',
+  normal:      '28px',
+  comfortable: '40px',
+};
+
+@Injectable({ providedIn: 'root' })
+export class TweaksService {
+  readonly accent  = signal<string>(localStorage.getItem(KEY_ACCENT)  ?? '#C4674A');
+  readonly density = signal<Density>((localStorage.getItem(KEY_DENSITY) as Density) ?? 'normal');
+
+  setAccent(color: string): void {
+    this.accent.set(color);
+    localStorage.setItem(KEY_ACCENT, color);
+    this.applyAccent(color);
+  }
+
+  setDensity(density: Density): void {
+    this.density.set(density);
+    localStorage.setItem(KEY_DENSITY, density);
+    this.applyDensity(density);
+  }
+
+  /** Aplica os valores persistidos no DOM (chamar no bootstrap). */
+  apply(): void {
+    this.applyAccent(this.accent());
+    this.applyDensity(this.density());
+  }
+
+  private applyAccent(color: string): void {
+    document.documentElement.style.setProperty('--terracotta', color);
+  }
+
+  private applyDensity(density: Density): void {
+    document.documentElement.style.setProperty('--density-gap',     DENSITY_GAPS[density]);
+    document.documentElement.style.setProperty('--density-padding', DENSITY_PADDING[density]);
+  }
+}

--- a/personal-finance/src/app/features/dashboard/components/dashboard/dashboard.component.css
+++ b/personal-finance/src/app/features/dashboard/components/dashboard/dashboard.component.css
@@ -1,8 +1,8 @@
 .page-content {
-  padding: 28px;
+  padding: var(--density-padding, 28px);
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: var(--density-gap, 24px);
   flex: 1;
 }
 
@@ -13,132 +13,254 @@
   gap: 10px;
 }
 
-.period-selector-header {
+.period-selector-top {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 14px;
 }
 
-.year-dropdown {
+.period-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-subtle);
+}
+
+.year-select {
   padding: 4px 10px;
-  border-radius: 20px;
-  border: 1px solid var(--border);
-  background: var(--surface-raised);
-  color: var(--ink2);
-  font-size: 0.8125rem;
+  border-radius: var(--v2-radius-sm);
+  border: 1px solid var(--v2-border);
+  background: var(--v2-surface);
+  color: var(--text-muted);
+  font-size: 12px;
   font-weight: 500;
   cursor: pointer;
   outline: none;
-  transition: border-color var(--transition);
+  backdrop-filter: blur(24px);
+  transition: var(--t);
 }
 
-.year-dropdown:focus { border-color: var(--sage2); }
-
-.period-tabs {
+.month-chips {
   display: flex;
   gap: 6px;
   flex-wrap: wrap;
 }
 
-.period-tab {
-  padding: 6px 14px;
-  border-radius: 20px;
-  border: 1px solid var(--border);
-  background: var(--surface-raised);
-  color: var(--ink2);
-  font-size: 0.8125rem;
+.month-chip {
+  padding: 7px 15px;
+  border-radius: var(--v2-radius-sm);
+  border: none;
+  background: var(--v2-surface);
+  color: var(--text-muted);
+  font-size: 12px;
   font-weight: 500;
   cursor: pointer;
-  transition: all var(--transition);
+  transition: var(--t);
+  backdrop-filter: blur(24px);
 }
 
-.period-tab:hover { background: var(--bg2); }
+.month-chip:hover { color: var(--text); }
 
-.period-tab.active {
-  background: var(--sage2);
-  border-color: var(--sage2);
+.month-chip.active {
+  background: var(--terracotta);
   color: #fff;
+  font-weight: 600;
+  box-shadow: 0 2px 12px rgba(196,103,74,0.3);
 }
 
-/* ── Grid de stats ── */
-.stats-grid {
+/* ── KPI Grid ── */
+.kpi-grid {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 16px;
+  animation: fadeUp 0.5s var(--ease) both;
 }
 
-@media (max-width: 1200px) { .stats-grid { grid-template-columns: repeat(2, 1fr); } }
-@media (max-width: 640px)  { .stats-grid { grid-template-columns: 1fr; } }
+@media (max-width: 1200px) { .kpi-grid { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 640px)  { .kpi-grid { grid-template-columns: 1fr; } }
 
-/* ── Grid de detalhes ── */
-.detail-grid {
+.kpi-card {
+  background: var(--v2-surface);
+  backdrop-filter: blur(24px);
+  border-radius: var(--v2-radius);
+  padding: 22px 24px;
+  box-shadow: var(--v2-shadow);
+  border: 1px solid var(--v2-border);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  position: relative;
+  overflow: hidden;
+  animation: fadeUp 0.5s var(--ease) both;
+}
+
+.kpi-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+
+.kpi-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-subtle);
+}
+
+.kpi-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--kpi-accent);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--kpi-accent) 50%, transparent);
+}
+
+.kpi-value {
+  font-family: var(--font-d);
+  font-size: 26px;
+  font-weight: 500;
+  color: var(--text);
+  line-height: 1.2;
+}
+
+.kpi-sub {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.kpi-bar {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  border-radius: 1px;
+  background: linear-gradient(to right, color-mix(in srgb, var(--kpi-accent) 70%, transparent), color-mix(in srgb, var(--kpi-accent) 10%, transparent));
+}
+
+/* ── Widgets grid (drag-drop) ── */
+.widgets-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 16px;
+  align-items: start;
 }
 
-@media (max-width: 960px) { .detail-grid { grid-template-columns: 1fr; } }
+@media (max-width: 1100px) { .widgets-grid { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 640px)  { .widgets-grid { grid-template-columns: 1fr; } }
 
-.detail-card { padding: 20px; }
+.widget-card {
+  background: var(--v2-surface);
+  backdrop-filter: blur(24px);
+  border-radius: var(--v2-radius);
+  padding: 22px;
+  box-shadow: var(--v2-shadow);
+  border: 1px solid var(--v2-border);
+  position: relative;
+  animation: fadeUp 0.5s var(--ease) both;
+}
 
-.detail-card-title {
-  font-size: 0.9375rem;
+/* CDK drag preview / placeholder */
+.cdk-drag-preview {
+  opacity: 0.9;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.24);
+  border-radius: var(--v2-radius);
+}
+
+.cdk-drag-placeholder {
+  opacity: 0.3;
+  border: 2px dashed var(--terracotta);
+  border-radius: var(--v2-radius);
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
+.cdk-drag-animating { transition: transform 200ms var(--ease); }
+
+.widget-drag-handle {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  color: var(--text-subtle);
+  cursor: grab;
+  padding: 4px;
+  border-radius: 6px;
+  transition: var(--t);
+  display: flex;
+  align-items: center;
+}
+
+.widget-drag-handle:hover {
+  background: var(--v2-surface);
+  color: var(--text-muted);
+}
+
+.widget-drag-handle:active { cursor: grabbing; }
+
+.widget-title {
+  font-size: 13px;
   font-weight: 600;
+  color: var(--text);
   margin-bottom: 16px;
-  color: var(--ink);
+  padding-right: 28px;
 }
 
+/* ── Detail rows ── */
 .detail-row {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 6px 0;
+  padding: 5px 0;
 }
 
 .detail-label {
-  font-size: 0.875rem;
-  color: var(--ink2);
+  font-size: 13px;
+  color: var(--text-muted);
   display: flex;
   align-items: center;
   gap: 6px;
 }
 
 .detail-value {
-  font-size: 0.9375rem;
+  font-size: 13px;
   font-weight: 600;
-  color: var(--ink);
+  color: var(--text);
 }
 
-.detail-value.paid  { color: var(--sage2); }
-.detail-value.owed  { color: var(--color-warning); }
+.detail-value.paid { color: var(--olive); }
+.detail-value.owed { color: var(--amber); }
 
 .status-dot {
-  width: 8px;
-  height: 8px;
+  width: 7px;
+  height: 7px;
   border-radius: 50%;
   display: inline-block;
+  flex-shrink: 0;
 }
 
-.status-dot.paid { background: var(--sage2); }
-.status-dot.owed { background: var(--color-warning); }
+.status-dot.paid { background: var(--olive); }
+.status-dot.owed { background: var(--amber); }
 
-/* Progress bar */
-.progress-bar-wrap {
-  height: 6px;
-  background: var(--bg3);
+/* ── Progress bar ── */
+.progress-wrap {
+  height: 5px;
+  background: var(--v2-border);
   border-radius: 3px;
   overflow: hidden;
-  margin-bottom: 6px;
+  margin: 10px 0 6px;
 }
 
-.progress-bar-fill {
+.progress-fill {
   height: 100%;
-  background: var(--sage2);
+  background: var(--olive);
   border-radius: 3px;
-  transition: width 0.5s ease;
+  transition: width 1.3s cubic-bezier(0.4,0,0.2,1);
 }
 
-/* Quick actions */
+/* ── Quick actions ── */
 .quick-actions {
   display: flex;
   flex-direction: column;
@@ -149,22 +271,71 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 10px;
-  border-radius: var(--radius);
-  color: var(--ink2);
-  font-size: 0.875rem;
+  padding: 12px 15px;
+  border-radius: 13px;
+  color: var(--text-muted);
+  font-size: 13px;
+  font-weight: 500;
   text-decoration: none;
-  transition: all var(--transition);
+  transition: var(--t);
+  background: transparent;
 }
 
 .quick-action:hover {
-  background: var(--bg2);
-  color: var(--ink);
+  background: var(--v2-surface);
+  color: var(--text);
 }
 
-.quick-action-icon { font-size: 16px; }
+.quick-action-icon { font-size: 15px; }
 
-/* States */
+/* ── Chart widgets ── */
+.chart-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+  padding-right: 28px;
+}
+
+/* Segmented control */
+.segmented {
+  display: flex;
+  background: var(--v2-border);
+  border-radius: 10px;
+  padding: 3px;
+  gap: 2px;
+}
+
+.seg-btn {
+  padding: 4px 9px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 11px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: var(--t);
+}
+
+.seg-btn.active {
+  background: var(--surface-solid);
+  box-shadow: var(--v2-shadow);
+  color: var(--text);
+  font-weight: 600;
+}
+
+.echart { width: 100%; height: 260px; }
+
+.chart-loading, .chart-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 260px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+/* ── States ── */
 .loading-state, .empty-state {
   display: flex;
   flex-direction: column;
@@ -172,58 +343,21 @@
   justify-content: center;
   gap: 12px;
   padding: 64px;
-  color: var(--ink3);
+  color: var(--text-muted);
 }
 
-.spinner-lg {
-  width: 32px;
-  height: 32px;
-  border: 3px solid var(--border);
-  border-top-color: var(--sage2);
+.spinner-v2 {
+  width: 28px;
+  height: 28px;
+  border: 2.5px solid var(--v2-border);
+  border-top-color: var(--terracotta);
   border-radius: 50%;
   animation: spin .8s linear infinite;
   display: block;
 }
 
-@keyframes spin { to { transform: rotate(360deg); } }
-
-/* ── Gráficos ── */
-.charts-section {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-.charts-section-title {
-  font-size: 1rem;
-  font-weight: 600;
-  color: var(--ink);
-}
-
-.charts-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 16px;
-}
-
-@media (max-width: 960px) { .charts-grid { grid-template-columns: 1fr; } }
-
-.chart-card { padding: 20px; }
-
-.chart-card-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 16px;
-}
-
-.echart { width: 100%; height: 300px; }
-
-.chart-loading, .chart-empty {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 300px;
-  color: var(--ink3);
-  font-size: 0.875rem;
+@keyframes spin    { to { transform: rotate(360deg); } }
+@keyframes fadeUp  {
+  from { opacity: 0; transform: translateY(14px); }
+  to   { opacity: 1; transform: translateY(0);    }
 }

--- a/personal-finance/src/app/features/dashboard/components/dashboard/dashboard.component.html
+++ b/personal-finance/src/app/features/dashboard/components/dashboard/dashboard.component.html
@@ -1,204 +1,207 @@
-<app-header
-  title="Dashboard"
-  [subtitle]="headerSubtitle()"
->
-  <button class="btn btn-primary btn-sm" routerLink="/periods">
-    Ver períodos
-  </button>
+<app-header title="Dashboard" [subtitle]="headerSubtitle()">
+  <button class="btn btn-primary btn-sm" routerLink="/periods">Ver períodos</button>
 </app-header>
 
 <div class="page-content">
 
   <!-- Seletor de período -->
   <div class="period-selector">
-    <div class="period-selector-header">
-      <span class="section-title">Período</span>
+    <div class="period-selector-top">
+      <span class="period-label">Período</span>
       @if (availableYears().length > 1) {
-        <select
-          class="year-dropdown"
-          [value]="selectedYear()"
-          (change)="selectYear(+$any($event.target).value)"
-        >
+        <select class="year-select" [value]="selectedYear()" (change)="selectYear(+$any($event.target).value)">
           @for (year of availableYears(); track year) {
             <option [value]="year">{{ year }}</option>
           }
         </select>
       }
     </div>
-    <div class="period-tabs">
+    <div class="month-chips">
       @for (period of filteredPeriods(); track period.id) {
         <button
-          class="period-tab"
+          class="month-chip"
           [class.active]="selectedPeriodId() === period.id"
           (click)="selectPeriod(period.id)"
-        >
-          {{ monthName(period.month) }}/{{ period.year }}
-        </button>
+        >{{ monthName(period.month) }}/{{ period.year }}</button>
       }
       @if (filteredPeriods().length === 0 && !loadingPeriods()) {
-        <span class="text-muted" style="font-size: 0.875rem">
-          Nenhum período cadastrado.
-          <a routerLink="/periods">Criar período</a>
+        <span class="text-muted" style="font-size:0.875rem">
+          Nenhum período. <a routerLink="/periods">Criar</a>
         </span>
       }
     </div>
   </div>
 
+  <!-- KPI Cards -->
   @if (loadingSummary()) {
     <div class="loading-state">
-      <span class="spinner-lg"></span>
-      <span class="text-muted">Carregando resumo...</span>
+      <span class="spinner-v2"></span>
+      <span class="text-muted">Carregando...</span>
     </div>
   } @else if (summary()) {
-    <!-- Cards de resumo -->
-    <div class="stats-grid">
-      <app-stat-card
-        label="Saldo"
-        [value]="summary()!.balance"
-        [variant]="summary()!.balance >= 0 ? 'success' : 'danger'"
-        [subtitle]="summary()!.balance >= 0 ? 'Positivo no período' : 'Negativo no período'"
-        [icon]="balanceIcon()"
-      />
-      <app-stat-card
-        label="Receitas"
-        [value]="summary()!.totalIncome"
-        variant="success"
-        subtitle="Total recebido"
-        [icon]="incomeIcon"
-      />
-      <app-stat-card
-        label="Despesas"
-        [value]="summary()!.totalExpense"
-        variant="danger"
-        subtitle="Total de gastos"
-        [icon]="expenseIcon"
-      />
-      <app-stat-card
-        label="A pagar"
-        [value]="summary()!.totalOwed"
-        variant="warning"
-        subtitle="Pendente + Parcial"
-        [icon]="owedIcon"
-      />
-    </div>
-
-    <!-- Detalhes por quinzena e pagamento -->
-    <div class="detail-grid">
-      <!-- Por quinzena -->
-      <div class="card detail-card">
-        <h3 class="detail-card-title">Por quinzena</h3>
-        <div class="detail-row">
-          <span class="detail-label">1ª Quinzena</span>
-          <span class="detail-value">{{ summary()!.totalFirstFortnight | currencyBrl }}</span>
+    <div class="kpi-grid">
+      <!-- Saldo -->
+      <div class="kpi-card" style="--kpi-accent: {{ balancePositive() ? 'var(--olive)' : 'var(--terracotta)' }}">
+        <div class="kpi-top">
+          <span class="kpi-label">Saldo</span>
+          <span class="kpi-dot"></span>
         </div>
-        <div class="detail-row">
-          <span class="detail-label">2ª Quinzena</span>
-          <span class="detail-value">{{ summary()!.totalSecondFortnight | currencyBrl }}</span>
-        </div>
-        <hr class="divider" style="margin: 12px 0">
-        <div class="detail-row">
-          <span class="detail-label" style="font-weight: 600">Total</span>
-          <span class="detail-value" style="font-weight: 700">{{ summary()!.totalExpense | currencyBrl }}</span>
-        </div>
+        <span class="kpi-value">{{ summary()!.balance | currencyBrl }}</span>
+        <span class="kpi-sub">{{ balancePositive() ? 'Positivo no período' : 'Negativo no período' }}</span>
+        <div class="kpi-bar"></div>
       </div>
-
-      <!-- Por status -->
-      <div class="card detail-card">
-        <h3 class="detail-card-title">Status de pagamento</h3>
-        <div class="detail-row">
-          <span class="detail-label">
-            <span class="status-dot paid"></span>
-            Pago
-          </span>
-          <span class="detail-value paid">{{ summary()!.totalPaid | currencyBrl }}</span>
+      <!-- Receitas -->
+      <div class="kpi-card" style="--kpi-accent: var(--purple)">
+        <div class="kpi-top">
+          <span class="kpi-label">Receitas</span>
+          <span class="kpi-dot"></span>
         </div>
-        <div class="detail-row">
-          <span class="detail-label">
-            <span class="status-dot owed"></span>
-            Pendente
-          </span>
-          <span class="detail-value owed">{{ summary()!.totalOwed | currencyBrl }}</span>
-        </div>
-        <hr class="divider" style="margin: 12px 0">
-        <div class="progress-bar-wrap">
-          <div
-            class="progress-bar-fill"
-            [style.width.%]="paymentProgress()"
-          ></div>
-        </div>
-        <span class="detail-label" style="font-size:0.75rem">
-          {{ paymentProgress() | number:'1.0-0' }}% pago
-        </span>
+        <span class="kpi-value">{{ summary()!.totalIncome | currencyBrl }}</span>
+        <span class="kpi-sub">Total recebido</span>
+        <div class="kpi-bar"></div>
       </div>
-
-      <!-- Atalhos rápidos -->
-      <div class="card detail-card">
-        <h3 class="detail-card-title">Ações rápidas</h3>
-        <div class="quick-actions">
-          <a [routerLink]="['/periods', selectedPeriodId()]" class="quick-action">
-            <span class="quick-action-icon">📋</span>
-            <span>Ver lançamentos</span>
-          </a>
-          <a routerLink="/expenses" class="quick-action">
-            <span class="quick-action-icon">➕</span>
-            <span>Nova despesa</span>
-          </a>
-          <a routerLink="/incomes" class="quick-action">
-            <span class="quick-action-icon">💰</span>
-            <span>Nova receita</span>
-          </a>
+      <!-- Despesas -->
+      <div class="kpi-card" style="--kpi-accent: var(--terracotta)">
+        <div class="kpi-top">
+          <span class="kpi-label">Despesas</span>
+          <span class="kpi-dot"></span>
         </div>
+        <span class="kpi-value">{{ summary()!.totalExpense | currencyBrl }}</span>
+        <span class="kpi-sub">Total de gastos</span>
+        <div class="kpi-bar"></div>
+      </div>
+      <!-- A pagar -->
+      <div class="kpi-card" style="--kpi-accent: var(--amber)">
+        <div class="kpi-top">
+          <span class="kpi-label">A pagar</span>
+          <span class="kpi-dot"></span>
+        </div>
+        <span class="kpi-value">{{ summary()!.totalOwed | currencyBrl }}</span>
+        <span class="kpi-sub">Pendente + Parcial</span>
+        <div class="kpi-bar"></div>
       </div>
     </div>
-  } @else if (!loadingPeriods() && filteredPeriods().length > 0) {
-    <div class="empty-state">
-      <span>Selecione um período para ver o resumo</span>
-    </div>
-  }
 
-  <!-- Gráficos de despesas -->
-  @if (availableYears().length > 0) {
-    <div class="charts-section">
-      <h2 class="charts-section-title">Análise de Despesas — {{ selectedYear() }}</h2>
-      <div class="charts-grid">
-
-        <!-- Gráfico 1 — Pizza por categoria (anual) -->
-        <div class="card chart-card">
-          <h3 class="detail-card-title">Despesas por Categoria (Anual)</h3>
-          @if (loadingChart1()) {
-            <div class="chart-loading"><span class="spinner-lg"></span></div>
-          } @else if (chart1Options()) {
-            <div echarts [options]="chart1Options()!" class="echart"></div>
-          } @else {
-            <div class="chart-empty">Sem dados para o período</div>
-          }
-        </div>
-
-        <!-- Gráfico 2 — Barras por categoria (mensal) -->
-        <div class="card chart-card">
-          <div class="chart-card-header">
-            <h3 class="detail-card-title" style="margin-bottom:0">Despesas por Categoria</h3>
-            <select
-              class="year-dropdown"
-              [value]="selectedMonth()"
-              (change)="selectMonth(+$any($event.target).value)"
-            >
-              @for (m of MONTH_NAMES; track $index) {
-                <option [value]="$index + 1">{{ m }}</option>
-              }
-            </select>
+    <!-- Widgets arrastáveis -->
+    <div
+      cdkDropList
+      cdkDropListOrientation="mixed"
+      class="widgets-grid"
+      (cdkDropListDropped)="dropWidget($event)"
+    >
+      @for (widget of widgets(); track widget.id) {
+        <div class="widget-card" cdkDrag>
+          <!-- Drag handle -->
+          <div class="widget-drag-handle" cdkDragHandle>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+              <circle cx="9"  cy="5"  r="1.5"/><circle cx="15" cy="5"  r="1.5"/>
+              <circle cx="9"  cy="12" r="1.5"/><circle cx="15" cy="12" r="1.5"/>
+              <circle cx="9"  cy="19" r="1.5"/><circle cx="15" cy="19" r="1.5"/>
+            </svg>
           </div>
-          @if (loadingChart2()) {
-            <div class="chart-loading"><span class="spinner-lg"></span></div>
-          } @else if (chart2Options()) {
-            <div echarts [options]="chart2Options()!" class="echart"></div>
-          } @else {
-            <div class="chart-empty">Sem dados para o período</div>
+
+          <!-- Conteúdo por widget.id -->
+          @switch (widget.id) {
+
+            @case ('fortnight') {
+              <h3 class="widget-title">Por quinzena</h3>
+              <div class="detail-row">
+                <span class="detail-label">1ª Quinzena</span>
+                <span class="detail-value">{{ summary()!.totalFirstFortnight | currencyBrl }}</span>
+              </div>
+              <div class="detail-row">
+                <span class="detail-label">2ª Quinzena</span>
+                <span class="detail-value">{{ summary()!.totalSecondFortnight | currencyBrl }}</span>
+              </div>
+              <hr class="divider" style="margin: 10px 0">
+              <div class="detail-row">
+                <span class="detail-label" style="font-weight:600">Total</span>
+                <span class="detail-value" style="font-weight:700">{{ summary()!.totalExpense | currencyBrl }}</span>
+              </div>
+            }
+
+            @case ('payment') {
+              <h3 class="widget-title">Status de pagamento</h3>
+              <div class="detail-row">
+                <span class="detail-label">
+                  <span class="status-dot paid"></span>Pago
+                </span>
+                <span class="detail-value paid">{{ summary()!.totalPaid | currencyBrl }}</span>
+              </div>
+              <div class="detail-row">
+                <span class="detail-label">
+                  <span class="status-dot owed"></span>Pendente
+                </span>
+                <span class="detail-value owed">{{ summary()!.totalOwed | currencyBrl }}</span>
+              </div>
+              <div class="progress-wrap">
+                <div class="progress-fill" [style.width.%]="paymentProgress()"></div>
+              </div>
+              <span class="detail-label" style="font-size:11px">
+                {{ paymentProgress() | number:'1.0-0' }}% pago
+              </span>
+            }
+
+            @case ('actions') {
+              <h3 class="widget-title">Ações rápidas</h3>
+              <div class="quick-actions">
+                <a [routerLink]="['/periods', selectedPeriodId()]" class="quick-action">
+                  <span class="quick-action-icon" style="--qa-color: var(--slate)">📋</span>
+                  <span>Ver lançamentos</span>
+                </a>
+                <a routerLink="/expenses" class="quick-action">
+                  <span class="quick-action-icon" style="--qa-color: var(--terracotta)">➕</span>
+                  <span>Nova despesa</span>
+                </a>
+                <a routerLink="/incomes" class="quick-action">
+                  <span class="quick-action-icon" style="--qa-color: var(--olive)">💰</span>
+                  <span>Nova receita</span>
+                </a>
+              </div>
+            }
+
+            @case ('chart1') {
+              <h3 class="widget-title">Despesas por categoria — {{ selectedYear() }}</h3>
+              @if (loadingChart1()) {
+                <div class="chart-loading"><span class="spinner-v2"></span></div>
+              } @else if (chart1Options()) {
+                <div echarts [options]="chart1Options()!" class="echart"></div>
+              } @else {
+                <div class="chart-empty">Sem dados para o período</div>
+              }
+            }
+
+            @case ('chart2') {
+              <div class="chart-header">
+                <h3 class="widget-title" style="margin-bottom:0">Despesas por categoria</h3>
+                <div class="segmented">
+                  @for (m of [selectedMonth() - 2, selectedMonth() - 1, selectedMonth()]; track m) {
+                    @if (m >= 1 && m <= 12) {
+                      <button
+                        class="seg-btn"
+                        [class.active]="selectedMonth() === m"
+                        (click)="selectMonth(m)"
+                      >{{ monthName(m) }}</button>
+                    }
+                  }
+                </div>
+              </div>
+              @if (loadingChart2()) {
+                <div class="chart-loading"><span class="spinner-v2"></span></div>
+              } @else if (chart2Options()) {
+                <div echarts [options]="chart2Options()!" class="echart"></div>
+              } @else {
+                <div class="chart-empty">Sem dados para o período</div>
+              }
+            }
+
           }
         </div>
-
-      </div>
+      }
     </div>
+
+  } @else if (!loadingPeriods() && filteredPeriods().length > 0) {
+    <div class="empty-state">Selecione um período para ver o resumo</div>
   }
 
 </div>

--- a/personal-finance/src/app/features/dashboard/components/dashboard/dashboard.component.ts
+++ b/personal-finance/src/app/features/dashboard/components/dashboard/dashboard.component.ts
@@ -1,20 +1,36 @@
 import { Component, inject, signal, computed, OnInit, effect, untracked } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { DecimalPipe } from '@angular/common';
+import { CdkDragDrop, CdkDropList, CdkDrag, moveItemInArray } from '@angular/cdk/drag-drop';
 import { NgxEchartsDirective } from 'ngx-echarts';
 import type { EChartsOption } from 'echarts';
 import { ApiService } from '../../../../core/services/api.service';
 import { AuthService } from '../../../../core/auth/auth.service';
 import { ThemeService } from '../../../../core/services/theme.service';
 import { HeaderComponent } from '../../../../shared/components/header/header.component';
-import { StatCardComponent } from '../../../../shared/components/stat-card/stat-card.component';
 import { CurrencyBrlPipe } from '../../../../shared/pipes/currency-brl.pipe';
-import { PeriodResponse, PeriodSummary, MONTH_NAMES, MONTH_NAMES as MONTHS, PaymentStatus, ExpensesReport } from '../../../../core/models/models';
+import { PeriodResponse, PeriodSummary, MONTH_NAMES, PaymentStatus, ExpensesReport } from '../../../../core/models/models';
+
+export interface DashWidget {
+  id: string;
+  label: string;
+}
+
+const DEFAULT_WIDGETS: DashWidget[] = [
+  { id: 'fortnight', label: 'Por quinzena'          },
+  { id: 'payment',   label: 'Status de pagamento'   },
+  { id: 'actions',   label: 'Ações rápidas'          },
+  { id: 'chart1',    label: 'Despesas anuais'        },
+  { id: 'chart2',    label: 'Despesas mensais'       },
+];
 
 @Component({
   selector: 'app-dashboard',
   standalone: true,
-  imports: [HeaderComponent, StatCardComponent, CurrencyBrlPipe, DecimalPipe, RouterLink, NgxEchartsDirective],
+  imports: [
+    HeaderComponent, CurrencyBrlPipe, DecimalPipe, RouterLink,
+    NgxEchartsDirective, CdkDropList, CdkDrag,
+  ],
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.css'],
 })
@@ -38,7 +54,9 @@ export class DashboardComponent implements OnInit {
   readonly chart1Options  = signal<EChartsOption | null>(null);
   readonly chart2Options  = signal<EChartsOption | null>(null);
 
-  private readonly chartTextColor = computed(() => this.theme.isDark() ? '#ccc' : '#444');
+  readonly widgets = signal<DashWidget[]>([...DEFAULT_WIDGETS]);
+
+  private readonly chartTextColor = computed(() => this.theme.isDark() ? '#F0E8DC' : '#3a2e22');
 
   readonly availableYears = computed(() =>
     [...new Set(this.periods().map(p => p.year))].sort((a, b) => b - a)
@@ -60,22 +78,11 @@ export class DashboardComponent implements OnInit {
     return Math.min((s.totalPaid / s.totalExpense) * 100, 100);
   });
 
-  readonly balanceIcon = computed(() => {
-    const pos = this.summary()?.balance ?? 0 >= 0;
-    return pos
-      ? `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg>`
-      : `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 18 13.5 8.5 8.5 13.5 1 6"/><polyline points="17 18 23 18 23 12"/></svg>`;
-  });
-
-  readonly incomeIcon = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>`;
-  readonly expenseIcon = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><polyline points="19 12 12 19 5 12"/></svg>`;
-  readonly owedIcon    = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>`;
+  readonly balancePositive = computed(() => (this.summary()?.balance ?? 0) >= 0);
 
   constructor() {
-    // Reconstrói os gráficos ao trocar de tema para aplicar cor de texto correta.
-    // untracked() evita dependência nos signals de opções, prevenindo loop.
     effect(() => {
-      this.theme.isDark(); // única dependência reativa: mudança de tema
+      this.theme.isDark();
       untracked(() => {
         if (this.chart1Options()) this.loadChart1(this.selectedYear());
         if (this.chart2Options()) this.loadChart2(this.selectedYear(), this.selectedMonth());
@@ -89,14 +96,9 @@ export class DashboardComponent implements OnInit {
         this.periods.set(periods);
         this.loadingPeriods.set(false);
         if (periods.length > 0) {
-          // Garante que o ano selecionado existe nos períodos carregados
           const years = [...new Set(periods.map(p => p.year))].sort((a, b) => b - a);
-          if (!years.includes(this.selectedYear())) {
-            this.selectedYear.set(years[0]);
-          }
-          // Seleciona o período mais recente por padrão
+          if (!years.includes(this.selectedYear())) this.selectedYear.set(years[0]);
           this.selectPeriod(periods[0].id);
-          // Carrega gráficos com o ano selecionado
           this.loadCharts(this.selectedYear(), this.selectedMonth());
         }
       },
@@ -108,12 +110,8 @@ export class DashboardComponent implements OnInit {
     this.selectedPeriodId.set(id);
     this.loadingSummary.set(true);
     this.summary.set(null);
-
     this.api.getPeriodSummary(id).subscribe({
-      next: s => {
-        this.summary.set(s);
-        this.loadingSummary.set(false);
-      },
+      next: s  => { this.summary.set(s);  this.loadingSummary.set(false); },
       error: () => this.loadingSummary.set(false)
     });
   }
@@ -134,6 +132,12 @@ export class DashboardComponent implements OnInit {
     return MONTH_NAMES[month - 1].substring(0, 3);
   }
 
+  dropWidget(event: CdkDragDrop<DashWidget[]>): void {
+    const list = [...this.widgets()];
+    moveItemInArray(list, event.previousIndex, event.currentIndex);
+    this.widgets.set(list);
+  }
+
   private loadCharts(year: number, month: number): void {
     this.loadChart1(year);
     this.loadChart2(year, month);
@@ -143,11 +147,8 @@ export class DashboardComponent implements OnInit {
     this.loadingChart1.set(true);
     this.chart1Options.set(null);
     this.api.getExpensesReport(year).subscribe({
-      next: report => {
-        this.chart1Options.set(this.buildPieOptions(report));
-        this.loadingChart1.set(false);
-      },
-      error: () => this.loadingChart1.set(false),
+      next:  report => { this.chart1Options.set(this.buildDonutOptions(report)); this.loadingChart1.set(false); },
+      error: ()     => this.loadingChart1.set(false),
     });
   }
 
@@ -155,42 +156,73 @@ export class DashboardComponent implements OnInit {
     this.loadingChart2.set(true);
     this.chart2Options.set(null);
     this.api.getExpensesReport(year, month).subscribe({
-      next: report => {
-        this.chart2Options.set(this.buildPieOptions(report));
-        this.loadingChart2.set(false);
-      },
-      error: () => this.loadingChart2.set(false),
+      next:  report => { this.chart2Options.set(this.buildDonutOptions(report)); this.loadingChart2.set(false); },
+      error: ()     => this.loadingChart2.set(false),
     });
   }
 
-  private buildPieOptions(report: ExpensesReport): EChartsOption | null {
+  private buildDonutOptions(report: ExpensesReport): EChartsOption | null {
     if (!report.items.length) return null;
     const textColor = this.chartTextColor();
+    const total = report.items.reduce((sum, i) => sum + i.total, 0);
     return {
       tooltip: {
         trigger: 'item',
+        backgroundColor: 'rgba(24,19,16,0.92)',
+        borderColor: 'transparent',
+        borderRadius: 12,
+        padding: 11,
+        textStyle: { color: '#F0E8DC', fontSize: 12 },
         formatter: (params: any) =>
           `${params.name}<br/><b>R$ ${params.value.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}</b> (${params.percent}%)`,
       },
-      legend: {
-        orient: 'vertical',
-        right: 10,
+      legend: { show: false },
+      graphic: [{
+        type: 'group',
+        left: 'center',
         top: 'center',
-        textStyle: { fontSize: 12, color: textColor },
-      },
+        children: [
+          {
+            type: 'text',
+            style: {
+              text: `R$ ${total.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}`,
+              textAlign: 'center',
+              fill: textColor,
+              fontSize: 14,
+              fontFamily: 'DM Serif Display, serif',
+              fontWeight: '500',
+            },
+            top: -12,
+          } as any,
+          {
+            type: 'text',
+            style: {
+              text: 'total',
+              textAlign: 'center',
+              fill: this.theme.isDark() ? '#9A8E81' : '#8a7a68',
+              fontSize: 10,
+            },
+            top: 10,
+          } as any,
+        ],
+      }],
       series: [{
         type: 'pie',
-        radius: ['40%', '70%'],
-        center: ['38%', '50%'],
+        radius: ['54%', '74%'],
+        center: ['50%', '50%'],
         avoidLabelOverlap: false,
         label: { show: false },
         emphasis: {
-          label: { show: true, fontSize: 13, fontWeight: 'bold', color: textColor },
+          label: { show: false },
+          scaleSize: 4,
         },
+        animationType: 'expansion',
+        animationDuration: 950,
+        animationEasing: 'cubicInOut',
         data: report.items.map(i => ({
           name: i.categoryName,
           value: i.total,
-          itemStyle: { color: i.categoryColor },
+          itemStyle: { color: i.categoryColor, borderRadius: 4 },
         })),
       }],
     };

--- a/personal-finance/src/app/shared/components/header/header.component.html
+++ b/personal-finance/src/app/shared/components/header/header.component.html
@@ -9,23 +9,17 @@
   <div class="header-actions">
     <ng-content />
 
-    <!-- Theme toggle -->
-    <button class="btn btn-ghost btn-sm theme-toggle" (click)="theme.toggle()" [title]="theme.isDark() ? 'Modo claro' : 'Modo escuro'">
-      @if (theme.isDark()) {
-        <!-- Sol -->
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <circle cx="12" cy="12" r="5"/>
-          <line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/>
-          <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
-          <line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/>
-          <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
-        </svg>
-      } @else {
-        <!-- Lua -->
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
-        </svg>
-      }
+    <!-- Tweaks panel toggle -->
+    <button class="btn btn-ghost btn-sm header-tweaks-btn" (click)="tweaksOpen.set(!tweaksOpen())" title="Personalizar">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <circle cx="12" cy="12" r="3"/>
+        <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/>
+      </svg>
     </button>
   </div>
 </header>
+
+<!-- Tweaks panel -->
+@if (tweaksOpen()) {
+  <app-tweaks-panel (close)="tweaksOpen.set(false)" />
+}

--- a/personal-finance/src/app/shared/components/header/header.component.ts
+++ b/personal-finance/src/app/shared/components/header/header.component.ts
@@ -1,14 +1,17 @@
-import { Component, inject, input } from '@angular/core';
+import { Component, inject, input, signal } from '@angular/core';
 import { ThemeService } from '../../../core/services/theme.service';
+import { TweaksPanelComponent } from '../tweaks-panel/tweaks-panel.component';
 
 @Component({
   selector: 'app-header',
   standalone: true,
+  imports: [TweaksPanelComponent],
   templateUrl: './header.component.html',
   styleUrls: ['./header.component.css']
 })
 export class HeaderComponent {
-  readonly title    = input<string>('');
-  readonly subtitle = input<string>('');
-  readonly theme    = inject(ThemeService);
+  readonly title      = input<string>('');
+  readonly subtitle   = input<string>('');
+  readonly theme      = inject(ThemeService);
+  readonly tweaksOpen = signal(false);
 }

--- a/personal-finance/src/app/shared/components/page-shell/page-shell.component.css
+++ b/personal-finance/src/app/shared/components/page-shell/page-shell.component.css
@@ -5,9 +5,14 @@
 
 .shell-main {
   flex: 1;
-  margin-left: var(--sidebar-width);
+  margin-left: 198px;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
   overflow-x: hidden;
+  transition: margin-left 0.34s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.shell-main.collapsed {
+  margin-left: 64px;
 }

--- a/personal-finance/src/app/shared/components/page-shell/page-shell.component.html
+++ b/personal-finance/src/app/shared/components/page-shell/page-shell.component.html
@@ -1,6 +1,6 @@
 <div class="shell">
-  <app-sidebar />
-  <main class="shell-main">
+  <app-sidebar (collapsedChange)="sidebarCollapsed.set($event)" />
+  <main class="shell-main" [class.collapsed]="sidebarCollapsed()">
     <router-outlet />
   </main>
 </div>

--- a/personal-finance/src/app/shared/components/page-shell/page-shell.component.ts
+++ b/personal-finance/src/app/shared/components/page-shell/page-shell.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { SidebarComponent } from '../sidebar/sidebar.component';
 
@@ -9,4 +9,6 @@ import { SidebarComponent } from '../sidebar/sidebar.component';
   templateUrl: './page-shell.component.html',
   styleUrls: ['./page-shell.component.css']
 })
-export class PageShellComponent {}
+export class PageShellComponent {
+  readonly sidebarCollapsed = signal(false);
+}

--- a/personal-finance/src/app/shared/components/sidebar/sidebar.component.css
+++ b/personal-finance/src/app/shared/components/sidebar/sidebar.component.css
@@ -1,29 +1,35 @@
 .sidebar {
-  width: var(--sidebar-width);
+  width: 198px;
   height: 100vh;
-  background: var(--sidebar-bg);
-  border-right: 1px solid var(--sidebar-border);
+  background: var(--v2-sidebar-bg);
+  border-right: 1px solid var(--v2-border);
   display: flex;
   flex-direction: column;
   position: fixed;
   left: 0; top: 0;
   z-index: 40;
+  transition: width 0.34s var(--ease);
+  overflow: hidden;
 }
 
+.sidebar.collapsed { width: 64px; }
+
+/* ── Logo ── */
 .sidebar-logo {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 20px 20px 16px;
-  border-bottom: 1px solid var(--border);
+  padding: 18px 16px 14px;
+  border-bottom: 1px solid var(--v2-border);
+  flex-shrink: 0;
 }
 
 .sidebar-logo-mark {
-  width: 32px;
-  height: 32px;
-  background: var(--sage2);
+  width: 33px;
+  height: 33px;
+  background: var(--terracotta);
   color: #fff;
-  border-radius: var(--radius);
+  border-radius: 11px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -33,123 +39,172 @@
 }
 
 .sidebar-logo-text {
-  font-size: 0.9375rem;
+  font-size: 0.9rem;
   font-weight: 600;
-  color: var(--ink);
+  color: var(--text);
+  white-space: nowrap;
+  opacity: 1;
+  transition: opacity 0.22s;
 }
 
+.collapsed .sidebar-logo-text { opacity: 0; }
+
+/* ── Toggle ── */
+.sidebar-toggle {
+  position: absolute;
+  top: 18px;
+  right: 10px;
+  width: 24px;
+  height: 24px;
+  border: none;
+  background: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  transition: var(--t);
+  flex-shrink: 0;
+  z-index: 1;
+}
+
+.collapsed .sidebar-toggle { right: 50%; transform: translateX(50%); }
+
+.sidebar-toggle:hover {
+  background: var(--v2-surface);
+  color: var(--text);
+}
+
+/* ── Nav ── */
 .sidebar-nav {
   flex: 1;
-  padding: 12px 10px;
+  padding: 10px 8px;
   display: flex;
   flex-direction: column;
   gap: 2px;
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .sidebar-item {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 9px 10px;
-  border-radius: var(--radius);
-  color: var(--ink2);
-  font-size: 0.875rem;
+  padding: 10px 13px;
+  border-radius: 13px;
+  color: var(--text-muted);
+  font-size: 13px;
   font-weight: 500;
-  transition: all var(--transition);
+  transition: background 0.22s, color 0.22s, box-shadow 0.22s;
   text-decoration: none;
+  white-space: nowrap;
 }
 
 .sidebar-item:hover {
-  background: var(--sidebar-item-hover);
-  color: var(--ink);
+  background: var(--v2-surface);
+  color: var(--text);
 }
 
 .sidebar-item.active {
-  background: var(--sidebar-item-active-bg);
-  color: var(--sidebar-item-active);
+  background: var(--terracotta);
+  color: #fff;
+  font-weight: 600;
+  box-shadow: 0 2px 12px rgba(196,103,74,0.28);
 }
 
 .sidebar-icon {
-  width: 18px;
-  height: 18px;
+  width: 16px;
+  height: 16px;
   display: flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  opacity: 0.7;
 }
 
-.sidebar-item.active .sidebar-icon { opacity: 1; }
+.sidebar-item-label {
+  opacity: 1;
+  transition: opacity 0.22s;
+}
 
+.collapsed .sidebar-item-label { opacity: 0; }
+
+/* ── Footer ── */
 .sidebar-footer {
-  padding: 12px;
-  border-top: 1px solid var(--border);
+  padding: 10px 8px;
+  border-top: 1px solid var(--v2-border);
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
+  flex-shrink: 0;
+  min-width: 0;
 }
 
-.sidebar-user {
-  flex: 1;
+.sidebar-footer-btn {
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: none;
+  color: var(--text-muted);
+  cursor: pointer;
   display: flex;
   align-items: center;
-  gap: 10px;
-  min-width: 0;
+  justify-content: center;
+  border-radius: 8px;
+  transition: var(--t);
+  flex-shrink: 0;
+}
+
+.sidebar-footer-btn:hover {
+  background: var(--v2-surface);
+  color: var(--text);
+}
+
+.sidebar-logout:hover {
+  background: rgba(196,103,74,0.15);
+  color: var(--terracotta);
 }
 
 .sidebar-avatar {
   width: 32px;
   height: 32px;
   border-radius: 50%;
-  background: var(--bg4);
-  color: var(--ink2);
-  font-size: 12px;
+  background: var(--v2-surface);
+  color: var(--text-muted);
+  font-size: 11px;
   font-weight: 600;
   display: flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
+  border: 1px solid var(--v2-border);
 }
 
 .sidebar-user-info {
+  flex: 1;
   display: flex;
   flex-direction: column;
   min-width: 0;
   overflow: hidden;
+  opacity: 1;
+  transition: opacity 0.22s;
 }
 
+.collapsed .sidebar-user-info { opacity: 0; width: 0; }
+
 .sidebar-user-name {
-  font-size: 0.8125rem;
+  font-size: 12px;
   font-weight: 600;
-  color: var(--ink);
+  color: var(--text);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
 .sidebar-user-email {
-  font-size: 0.75rem;
-  color: var(--ink3);
+  font-size: 11px;
+  color: var(--text-subtle);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.sidebar-logout {
-  padding: 6px;
-  border: none;
-  background: none;
-  color: var(--ink3);
-  border-radius: var(--radius);
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  transition: all var(--transition);
-  flex-shrink: 0;
-}
-
-.sidebar-logout:hover {
-  background: var(--color-danger-bg);
-  color: var(--color-danger);
 }

--- a/personal-finance/src/app/shared/components/sidebar/sidebar.component.html
+++ b/personal-finance/src/app/shared/components/sidebar/sidebar.component.html
@@ -1,9 +1,22 @@
-<aside class="sidebar">
+<aside class="sidebar" [class.collapsed]="collapsed()">
   <!-- Logo -->
   <div class="sidebar-logo">
     <span class="sidebar-logo-mark">₿</span>
     <span class="sidebar-logo-text">Personal Finance</span>
   </div>
+
+  <!-- Toggle collapse -->
+  <button class="sidebar-toggle" (click)="toggle()" [title]="collapsed() ? 'Expandir' : 'Recolher'">
+    @if (collapsed()) {
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="18" x2="21" y2="18"/>
+      </svg>
+    } @else {
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <polyline points="15 18 9 12 15 6"/>
+      </svg>
+    }
+  </button>
 
   <!-- Nav -->
   <nav class="sidebar-nav">
@@ -13,26 +26,47 @@
         routerLinkActive="active"
         [routerLinkActiveOptions]="{ exact: item.route === '/' }"
         class="sidebar-item"
+        [title]="collapsed() ? item.label : ''"
       >
         <span class="sidebar-icon" [innerHTML]="getIcon(item.icon)"></span>
-        <span>{{ item.label }}</span>
+        <span class="sidebar-item-label">{{ item.label }}</span>
       </a>
     }
   </nav>
 
-  <!-- User info -->
+  <!-- Footer -->
   <div class="sidebar-footer">
-    <div class="sidebar-user">
-      <div class="sidebar-avatar">
-        {{ userInitials() }}
-      </div>
-      <div class="sidebar-user-info">
-        <span class="sidebar-user-name">{{ auth.currentUser()?.name }}</span>
-        <span class="sidebar-user-email">{{ auth.currentUser()?.email }}</span>
-      </div>
+    <!-- Dark/light toggle -->
+    <button class="sidebar-footer-btn" (click)="theme.toggle()" [title]="theme.isDark() ? 'Modo claro' : 'Modo escuro'">
+      @if (theme.isDark()) {
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <circle cx="12" cy="12" r="5"/>
+          <line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/>
+          <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+          <line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/>
+          <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+        </svg>
+      } @else {
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+        </svg>
+      }
+    </button>
+
+    <!-- Avatar -->
+    <div class="sidebar-avatar" [title]="auth.currentUser()?.name ?? ''">
+      {{ userInitials() }}
     </div>
-    <button class="sidebar-logout" (click)="auth.logout()" title="Sair">
-      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+
+    <!-- User info (hidden when collapsed) -->
+    <div class="sidebar-user-info">
+      <span class="sidebar-user-name">{{ auth.currentUser()?.name }}</span>
+      <span class="sidebar-user-email">{{ auth.currentUser()?.email }}</span>
+    </div>
+
+    <!-- Logout -->
+    <button class="sidebar-footer-btn sidebar-logout" (click)="auth.logout()" title="Sair">
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
         <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/>
         <polyline points="16 17 21 12 16 7"/>
         <line x1="21" y1="12" x2="9" y2="12"/>

--- a/personal-finance/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/personal-finance/src/app/shared/components/sidebar/sidebar.component.ts
@@ -1,21 +1,22 @@
-import { Component, inject, computed } from '@angular/core';
+import { Component, inject, computed, signal, output } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import { AuthService } from '../../../core/auth/auth.service';
+import { ThemeService } from '../../../core/services/theme.service';
 
 interface NavItem {
-  label:    string;
-  route:    string;
-  icon:     string;
+  label:     string;
+  route:     string;
+  icon:      string;
   adminOnly?: boolean;
 }
 
 const NAV_ITEMS: NavItem[] = [
-  { label: 'Dashboard',  route: '/',          icon: 'grid'       },
-  { label: 'Períodos',   route: '/periods',   icon: 'calendar'   },
-  { label: 'Despesas',   route: '/expenses',  icon: 'arrow-down' },
-  { label: 'Receitas',   route: '/incomes',   icon: 'arrow-up'   },
-  { label: 'Importar',   route: '/import',    icon: 'upload'     },
-  { label: 'Config',     route: '/config',    icon: 'settings'   },
+  { label: 'Dashboard',  route: '/',            icon: 'grid'       },
+  { label: 'Períodos',   route: '/periods',     icon: 'calendar'   },
+  { label: 'Despesas',   route: '/expenses',    icon: 'arrow-down' },
+  { label: 'Receitas',   route: '/incomes',     icon: 'arrow-up'   },
+  { label: 'Importar',   route: '/import',      icon: 'upload'     },
+  { label: 'Config',     route: '/config',      icon: 'settings'   },
   { label: 'Usuários',   route: '/admin/users', icon: 'users', adminOnly: true },
 ];
 
@@ -27,7 +28,11 @@ const NAV_ITEMS: NavItem[] = [
   styleUrls: ['./sidebar.component.css']
 })
 export class SidebarComponent {
-  readonly auth = inject(AuthService);
+  readonly auth  = inject(AuthService);
+  readonly theme = inject(ThemeService);
+
+  readonly collapsed = signal(false);
+  readonly collapsedChange = output<boolean>();
 
   readonly visibleItems = computed(() =>
     NAV_ITEMS.filter(item => !item.adminOnly || this.auth.isAdmin())
@@ -38,15 +43,21 @@ export class SidebarComponent {
     return name.split(' ').slice(0, 2).map(n => n[0]).join('').toUpperCase();
   });
 
+  toggle(): void {
+    const next = !this.collapsed();
+    this.collapsed.set(next);
+    this.collapsedChange.emit(next);
+  }
+
   getIcon(name: string): string {
     const icons: Record<string, string> = {
-      grid:       `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>`,
-      calendar:   `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>`,
+      grid:        `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>`,
+      calendar:    `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>`,
       'arrow-down':`<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="8 12 12 16 16 12"/><line x1="12" y1="8" x2="12" y2="16"/></svg>`,
       'arrow-up':  `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="16 12 12 8 8 12"/><line x1="12" y1="16" x2="12" y2="8"/></svg>`,
-      settings:   `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>`,
-      upload:     `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>`,
-      users:      `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>`,
+      settings:    `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>`,
+      upload:      `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>`,
+      users:       `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>`,
     };
     return icons[name] ?? '';
   }

--- a/personal-finance/src/app/shared/components/tweaks-panel/tweaks-panel.component.css
+++ b/personal-finance/src/app/shared/components/tweaks-panel/tweaks-panel.component.css
@@ -1,0 +1,125 @@
+.tweaks-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 49;
+}
+
+.tweaks-panel {
+  position: fixed;
+  top: 68px;
+  right: 16px;
+  width: 260px;
+  background: var(--surface-solid);
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius);
+  box-shadow: var(--v2-shadow);
+  z-index: 50;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  animation: fadeUp 0.2s var(--ease) both;
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0);   }
+}
+
+.tweaks-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.tweaks-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.tweaks-close {
+  width: 24px;
+  height: 24px;
+  border: none;
+  background: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  transition: var(--t);
+}
+
+.tweaks-close:hover {
+  background: var(--v2-surface);
+  color: var(--text);
+}
+
+.tweaks-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.tweaks-section-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-subtle);
+}
+
+/* Accent swatches */
+.accent-swatches {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.accent-swatch {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  cursor: pointer;
+  transition: var(--t);
+  outline: none;
+}
+
+.accent-swatch:hover { transform: scale(1.12); }
+
+.accent-swatch.active {
+  border-color: var(--text);
+  box-shadow: 0 0 0 3px var(--v2-surface);
+}
+
+/* Density */
+.density-options {
+  display: flex;
+  background: var(--v2-border);
+  border-radius: 10px;
+  padding: 3px;
+  gap: 2px;
+}
+
+.density-btn {
+  flex: 1;
+  padding: 4px 6px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 11px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: var(--t);
+  white-space: nowrap;
+}
+
+.density-btn.active {
+  background: var(--surface-solid);
+  box-shadow: var(--v2-shadow);
+  color: var(--text);
+  font-weight: 600;
+}

--- a/personal-finance/src/app/shared/components/tweaks-panel/tweaks-panel.component.html
+++ b/personal-finance/src/app/shared/components/tweaks-panel/tweaks-panel.component.html
@@ -1,0 +1,42 @@
+<div class="tweaks-backdrop" (click)="close.emit()"></div>
+
+<div class="tweaks-panel">
+  <div class="tweaks-header">
+    <span class="tweaks-title">Personalizar</span>
+    <button class="tweaks-close" (click)="close.emit()">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+      </svg>
+    </button>
+  </div>
+
+  <!-- Cor de destaque -->
+  <div class="tweaks-section">
+    <span class="tweaks-section-label">Cor de destaque</span>
+    <div class="accent-swatches">
+      @for (c of accentColors; track c.value) {
+        <button
+          class="accent-swatch"
+          [style.background]="c.value"
+          [class.active]="tweaks.accent() === c.value"
+          [title]="c.name"
+          (click)="setAccent(c.value)"
+        ></button>
+      }
+    </div>
+  </div>
+
+  <!-- Densidade -->
+  <div class="tweaks-section">
+    <span class="tweaks-section-label">Densidade</span>
+    <div class="density-options">
+      @for (d of densities; track d.value) {
+        <button
+          class="density-btn"
+          [class.active]="tweaks.density() === d.value"
+          (click)="setDensity(d.value)"
+        >{{ d.label }}</button>
+      }
+    </div>
+  </div>
+</div>

--- a/personal-finance/src/app/shared/components/tweaks-panel/tweaks-panel.component.ts
+++ b/personal-finance/src/app/shared/components/tweaks-panel/tweaks-panel.component.ts
@@ -1,0 +1,43 @@
+import { Component, inject, output, signal, OnInit } from '@angular/core';
+import { TweaksService } from '../../../core/services/tweaks.service';
+
+const ACCENT_COLORS = [
+  { name: 'Terracotta', value: '#C4674A' },
+  { name: 'Slate',      value: '#6B8CAD' },
+  { name: 'Olive',      value: '#7B8C5F' },
+  { name: 'Purple',     value: '#9E8BB5' },
+  { name: 'Rose',       value: '#B57A9E' },
+  { name: 'Gold',       value: '#C4924A' },
+];
+
+export type Density = 'compact' | 'normal' | 'comfortable';
+
+@Component({
+  selector: 'app-tweaks-panel',
+  standalone: true,
+  templateUrl: './tweaks-panel.component.html',
+  styleUrls: ['./tweaks-panel.component.css']
+})
+export class TweaksPanelComponent implements OnInit {
+  readonly tweaks  = inject(TweaksService);
+  readonly close   = output<void>();
+
+  readonly accentColors = ACCENT_COLORS;
+  readonly densities: { label: string; value: Density }[] = [
+    { label: 'Compacto',     value: 'compact'     },
+    { label: 'Normal',       value: 'normal'      },
+    { label: 'Confortável',  value: 'comfortable' },
+  ];
+
+  ngOnInit(): void {
+    this.tweaks.apply();
+  }
+
+  setAccent(color: string): void {
+    this.tweaks.setAccent(color);
+  }
+
+  setDensity(density: Density): void {
+    this.tweaks.setDensity(density);
+  }
+}

--- a/personal-finance/src/index.html
+++ b/personal-finance/src/index.html
@@ -8,7 +8,7 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=DM+Serif+Display&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
 </head>
 <body>

--- a/personal-finance/src/styles/_variables.css
+++ b/personal-finance/src/styles/_variables.css
@@ -65,6 +65,32 @@
 
   /* Transições */
   --transition: 150ms ease;
+
+  /* ── Design system v2 — tokens novos (sem conflito) ── */
+  --terracotta:    #C4674A;
+  --purple:        #9E8BB5;
+  --amber:         #C4924A;
+  --slate:         #6B8CAD;
+  --rose:          #B57A9E;
+  --gold:          #D4B87A;
+  --font-b:        'Inter', sans-serif;
+  --font-d:        'DM Serif Display', serif;
+  --ease:          cubic-bezier(0.4, 0, 0.2, 1);
+  --t:             all 0.22s ease;
+  --text:          #3a2e22;
+  --text-muted:    #5c4e3c;
+  --text-subtle:   #8a7a68;
+  --radius-xs:     9px;
+  --surface-solid: #faf7f2;
+
+  /* ── Design system v2 — tokens conflitantes (prefixo --v2-) ── */
+  --v2-bg:         #f5f0e8;
+  --v2-sidebar-bg: #e4ddd1;
+  --v2-surface:    rgba(0,0,0,0.03);
+  --v2-border:     rgba(0,0,0,0.08);
+  --v2-radius:     18px;
+  --v2-radius-sm:  11px;
+  --v2-shadow:     0 4px 24px rgba(0,0,0,0.08);
 }
 
 /* ── Dark theme ────────────────────────────────────────────────────────────── */
@@ -114,4 +140,16 @@
   --sidebar-item-hover:   var(--bg3);
   --sidebar-item-active-bg: rgba(122, 170, 128, 0.12);
   --sidebar-item-active:  var(--sage);
+
+  /* ── Design system v2 — dark overrides ── */
+  --text:          #F0E8DC;
+  --text-muted:    #9A8E81;
+  --text-subtle:   #6A5E52;
+  --surface-solid: #1F1B17;
+
+  --v2-bg:         #1A1410;
+  --v2-sidebar-bg: #141210;
+  --v2-surface:    rgba(255,255,255,0.04);
+  --v2-border:     rgba(255,255,255,0.07);
+  --v2-shadow:     0 4px 24px rgba(0,0,0,0.32);
 }


### PR DESCRIPTION
Closes #126

## Resumo
- **Sidebar colapsável**: animação 198px → 64px, dark/light toggle no footer
- **Page-shell**: margin-left reativa ao collapse via `output`
- **Header**: botão tweaks panel (substituiu theme toggle)
- **TweaksService + TweaksPanelComponent**: cor de destaque global (`--terracotta`) e densidade compact/normal/comfortable
- **Dashboard**: KPI cards com design system v2, chips de período, 5 widgets CDK drag-drop, gráficos donut (echarts) com texto central em DM Serif Display
- **CSS variables**: Option C — tokens novos direto no `:root`, conflitantes com prefixo `--v2-*`
- **docs/design-system.md**: estratégia de migração gradual documentada para issues #127–#133

## Test plan
- [ ] Sidebar abre/fecha com animação
- [ ] Margin do conteúdo acompanha o collapse
- [ ] Dark/light toggle no footer da sidebar funciona
- [ ] KPI cards exibem valores com fonte DM Serif Display
- [ ] Chips de mês ativos com `--terracotta`
- [ ] Widgets arrastáveis reordenam sem erros
- [ ] Tweaks panel abre via header, muda cor de destaque globalmente e densidade de espaçamento
- [ ] Donuts renderizam com legenda central e animação

🤖 Generated with [Claude Code](https://claude.com/claude-code)