### PR TITLE
feat(#126): layout dashboard — sidebar, KPI cards, widgets drag-drop, tweaks panel

### DIFF
--- a/personal-finance/src/app/shared/components/header/header.component.spec.ts
+++ b/personal-finance/src/app/shared/components/header/header.component.spec.ts
@@ -46,10 +46,17 @@ describe('HeaderComponent', () => {
     expect(component.subtitle()).toBe('Visão geral');
   });
 
-  it('theme.toggle() é chamado ao clicar no botão', () => {
+  it('tweaksOpen começa como false', () => {
     fixture.detectChanges();
-    const btn = fixture.nativeElement.querySelector('.theme-toggle');
+    expect(component.tweaksOpen()).toBeFalse();
+  });
+
+  it('clique no botão de tweaks alterna tweaksOpen', () => {
+    fixture.detectChanges();
+    const btn = fixture.nativeElement.querySelector('.header-tweaks-btn');
     btn?.click();
-    expect(themeSpy.toggle).toHaveBeenCalled();
+    expect(component.tweaksOpen()).toBeTrue();
+    btn?.click();
+    expect(component.tweaksOpen()).toBeFalse();
   });
 });


### PR DESCRIPTION
Closes #126

## Resumo
- **Sidebar colapsável**: animação 198px → 64px, dark/light toggle no footer
- **Page-shell**: margin-left reativa ao collapse via `output`
- **Header**: botão tweaks panel (substituiu theme toggle)
- **TweaksService + TweaksPanelComponent**: cor de destaque global (`--terracotta`) e densidade compact/normal/comfortable
- **Dashboard**: KPI cards com design system v2, chips de período, 5 widgets CDK drag-drop, gráficos donut (echarts) com texto central em DM Serif Display
- **CSS variables**: Option C — tokens novos direto no `:root`, conflitantes com prefixo `--v2-*`
- **docs/design-system.md**: estratégia de migração gradual documentada para issues #127–#133

## Test plan
- [ ] Sidebar abre/fecha com animação
- [ ] Margin do conteúdo acompanha o collapse
- [ ] Dark/light toggle no footer da sidebar funciona
- [ ] KPI cards exibem valores com fonte DM Serif Display
- [ ] Chips de mês ativos com `--terracotta`
- [ ] Widgets arrastáveis reordenam sem erros
- [ ] Tweaks panel abre via header, muda cor de destaque globalmente e densidade de espaçamento
- [ ] Donuts renderizam com legenda central e animação
- [ ] Testes: 6/6 SUCCESS (HeaderComponent spec atualizado)

🤖 Generated with [Claude Code](https://claude.com/claude-code)