### PR TITLE
fix(#126): ícones sidebar, legend charts, chart2 dropdown, dark/light tweaks

### DIFF
--- a/personal-finance/src/app/features/dashboard/components/dashboard/dashboard.component.css
+++ b/personal-finance/src/app/features/dashboard/components/dashboard/dashboard.component.css
@@ -324,13 +324,26 @@
   font-weight: 600;
 }
 
-.echart { width: 100%; height: 260px; }
+.month-select {
+  padding: 4px 10px;
+  border-radius: var(--v2-radius-sm);
+  border: 1px solid var(--v2-border);
+  background: var(--v2-surface);
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  outline: none;
+  transition: var(--t);
+}
+
+.echart { width: 100%; height: 290px; }
 
 .chart-loading, .chart-empty {
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 260px;
+  height: 290px;
   color: var(--text-muted);
   font-size: 13px;
 }

--- a/personal-finance/src/app/features/dashboard/components/dashboard/dashboard.component.html
+++ b/personal-finance/src/app/features/dashboard/components/dashboard/dashboard.component.html
@@ -174,15 +174,15 @@
             @case ('chart2') {
               <div class="chart-header">
                 <h3 class="widget-title" style="margin-bottom:0">Despesas por categoria</h3>
-                <div class="segmented">
-                  @for (m of chart2AvailableMonths(); track m) {
-                    <button
-                      class="seg-btn"
-                      [class.active]="selectedMonth() === m"
-                      (click)="selectMonth(m)"
-                    >{{ monthName(m) }}</button>
+                <select
+                  class="month-select"
+                  [value]="selectedMonth()"
+                  (change)="selectMonth(+$any($event.target).value)"
+                >
+                  @for (name of MONTH_NAMES; track $index) {
+                    <option [value]="$index + 1">{{ name }}</option>
                   }
-                </div>
+                </select>
               </div>
               @if (loadingChart2()) {
                 <div class="chart-loading"><span class="spinner-v2"></span></div>

--- a/personal-finance/src/app/features/dashboard/components/dashboard/dashboard.component.ts
+++ b/personal-finance/src/app/features/dashboard/components/dashboard/dashboard.component.ts
@@ -183,19 +183,19 @@ export class DashboardComponent implements OnInit {
           `${params.name}<br/><b>R$ ${params.value.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}</b> (${params.percent}%)`,
       },
       legend: {
-        orient: 'vertical',
-        right: 4,
-        top: 'center',
-        textStyle: { fontSize: 11, color: textColor },
+        orient: 'horizontal',
+        bottom: 4,
+        left: 'center',
+        textStyle: { fontSize: 10, color: textColor },
         icon: 'circle',
-        itemWidth: 8,
-        itemHeight: 8,
+        itemWidth: 7,
+        itemHeight: 7,
         itemGap: 10,
       },
       graphic: [{
         type: 'group',
         left: 'center',
-        top: 'center',
+        top: '36%',
         children: [
           {
             type: 'text',
@@ -223,8 +223,8 @@ export class DashboardComponent implements OnInit {
       }],
       series: [{
         type: 'pie',
-        radius: ['54%', '74%'],
-        center: ['36%', '50%'],
+        radius: ['50%', '68%'],
+        center: ['50%', '44%'],
         avoidLabelOverlap: false,
         label: { show: false },
         emphasis: {

--- a/personal-finance/src/app/shared/components/sidebar/sidebar.component.html
+++ b/personal-finance/src/app/shared/components/sidebar/sidebar.component.html
@@ -36,23 +36,6 @@
 
   <!-- Footer -->
   <div class="sidebar-footer">
-    <!-- Dark/light toggle -->
-    <button class="sidebar-footer-btn" (click)="theme.toggle()" [title]="theme.isDark() ? 'Modo claro' : 'Modo escuro'">
-      @if (theme.isDark()) {
-        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <circle cx="12" cy="12" r="5"/>
-          <line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/>
-          <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
-          <line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/>
-          <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
-        </svg>
-      } @else {
-        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
-        </svg>
-      }
-    </button>
-
     <!-- Avatar -->
     <div class="sidebar-avatar" [title]="auth.currentUser()?.name ?? ''">
       {{ userInitials() }}

--- a/personal-finance/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/personal-finance/src/app/shared/components/sidebar/sidebar.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject, computed, signal, output } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { AuthService } from '../../../core/auth/auth.service';
-import { ThemeService } from '../../../core/services/theme.service';
 
 interface NavItem {
   label:     string;
@@ -28,8 +28,8 @@ const NAV_ITEMS: NavItem[] = [
   styleUrls: ['./sidebar.component.css']
 })
 export class SidebarComponent {
-  readonly auth  = inject(AuthService);
-  readonly theme = inject(ThemeService);
+  readonly auth      = inject(AuthService);
+  private readonly sanitizer = inject(DomSanitizer);
 
   readonly collapsed = signal(false);
   readonly collapsedChange = output<boolean>();
@@ -49,7 +49,7 @@ export class SidebarComponent {
     this.collapsedChange.emit(next);
   }
 
-  getIcon(name: string): string {
+  getIcon(name: string): SafeHtml {
     const icons: Record<string, string> = {
       grid:        `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>`,
       calendar:    `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>`,
@@ -59,6 +59,6 @@ export class SidebarComponent {
       upload:      `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>`,
       users:       `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>`,
     };
-    return icons[name] ?? '';
+    return this.sanitizer.bypassSecurityTrustHtml(icons[name] ?? '');
   }
 }

--- a/personal-finance/src/app/shared/components/tweaks-panel/tweaks-panel.component.css
+++ b/personal-finance/src/app/shared/components/tweaks-panel/tweaks-panel.component.css
@@ -71,6 +71,29 @@
   color: var(--text-subtle);
 }
 
+/* Theme toggle row */
+.theme-toggle-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius-sm);
+  background: var(--v2-surface);
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  width: 100%;
+  transition: var(--t);
+}
+
+.theme-toggle-row:hover {
+  background: color-mix(in srgb, var(--terracotta) 10%, transparent);
+  color: var(--text);
+  border-color: var(--terracotta);
+}
+
 /* Accent swatches */
 .accent-swatches {
   display: flex;

--- a/personal-finance/src/app/shared/components/tweaks-panel/tweaks-panel.component.html
+++ b/personal-finance/src/app/shared/components/tweaks-panel/tweaks-panel.component.html
@@ -26,6 +26,28 @@
     </div>
   </div>
 
+  <!-- Tema -->
+  <div class="tweaks-section">
+    <span class="tweaks-section-label">Aparência</span>
+    <button class="theme-toggle-row" (click)="theme.toggle()">
+      @if (theme.isDark()) {
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <circle cx="12" cy="12" r="5"/>
+          <line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/>
+          <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+          <line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/>
+          <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+        </svg>
+        <span>Modo claro</span>
+      } @else {
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+        </svg>
+        <span>Modo escuro</span>
+      }
+    </button>
+  </div>
+
   <!-- Densidade -->
   <div class="tweaks-section">
     <span class="tweaks-section-label">Densidade</span>

--- a/personal-finance/src/app/shared/components/tweaks-panel/tweaks-panel.component.ts
+++ b/personal-finance/src/app/shared/components/tweaks-panel/tweaks-panel.component.ts
@@ -1,5 +1,6 @@
-import { Component, inject, output, signal, OnInit } from '@angular/core';
+import { Component, inject, output, OnInit } from '@angular/core';
 import { TweaksService } from '../../../core/services/tweaks.service';
+import { ThemeService } from '../../../core/services/theme.service';
 
 const ACCENT_COLORS = [
   { name: 'Terracotta', value: '#C4674A' },
@@ -20,6 +21,7 @@ export type Density = 'compact' | 'normal' | 'comfortable';
 })
 export class TweaksPanelComponent implements OnInit {
   readonly tweaks  = inject(TweaksService);
+  readonly theme   = inject(ThemeService);
   readonly close   = output<void>();
 
   readonly accentColors = ACCENT_COLORS;


### PR DESCRIPTION
Closes #126

## Correções
- **Ícones sidebar**: `DomSanitizer.bypassSecurityTrustHtml()` — Angular sanitizava e removia os SVGs
- **Dark/light toggle**: removido do footer da sidebar, adicionado no tweaks panel como botão com label
- **Charts legend**: horizontal no `bottom` — não sobrepõe mais o donut; `center ['50%','44%']` + altura 290px
- **Chart2**: substituído segmented control pelo `<select>` com todos os 12 meses do ano selecionado

🤖 Generated with [Claude Code](https://claude.com/claude-code)