### PR TITLE
fix(#126): logo text em duas linhas

### DIFF
--- a/personal-finance/src/app/shared/components/sidebar/sidebar.component.css
+++ b/personal-finance/src/app/shared/components/sidebar/sidebar.component.css
@@ -46,12 +46,10 @@
   font-size: 0.9rem;
   font-weight: 600;
   color: var(--text);
-  white-space: nowrap;
-  /* min-width: 0 + overflow: hidden garantem que o texto não vaze para fora do padding-box */
   min-width: 0;
   overflow: hidden;
-  text-overflow: ellipsis;
   flex: 1;
+  line-height: 1.25;
   opacity: 1;
   transition: opacity 0.22s;
 }

--- a/personal-finance/src/app/shared/components/sidebar/sidebar.component.html
+++ b/personal-finance/src/app/shared/components/sidebar/sidebar.component.html
@@ -4,7 +4,7 @@
     <span class="sidebar-logo-mark">
       <img src="coin.gif" alt="logo" class="sidebar-logo-img" />
     </span>
-    <span class="sidebar-logo-text">Personal Finance</span>
+    <span class="sidebar-logo-text">Personal<br>Finance</span>
   </div>
 
   <!-- Toggle collapse -->


### PR DESCRIPTION
- `<br>` entre Personal e Finance — quebra explícita de linha
- Remove `white-space: nowrap` e `text-overflow: ellipsis`
- `line-height: 1.25` para as duas linhas ficarem compactas

🤖 Generated with [Claude Code](https://claude.com/claude-code)