### PR TITLE
test(#126): fix spec sidebar — getIcon retorna SafeHtml

### DIFF
--- a/personal-finance/src/app/shared/components/sidebar/sidebar.component.spec.ts
+++ b/personal-finance/src/app/shared/components/sidebar/sidebar.component.spec.ts
@@ -77,17 +77,19 @@ describe('SidebarComponent', () => {
     });
 
     it('retorna SVG para ícone conhecido (grid)', () => {
-      const svg = component.getIcon('grid');
+      // getIcon retorna SafeHtml; extrai o conteúdo interno para comparação
+      const svg = (component.getIcon('grid') as any).changingThisBreaksApplicationSecurity as string;
       expect(svg).toContain('<svg');
     });
 
     it('retorna SVG para ícone settings', () => {
-      const svg = component.getIcon('settings');
+      const svg = (component.getIcon('settings') as any).changingThisBreaksApplicationSecurity as string;
       expect(svg).toContain('<svg');
     });
 
-    it('retorna string vazia para ícone desconhecido', () => {
-      expect(component.getIcon('unknown-icon')).toBe('');
+    it('retorna SafeHtml vazio para ícone desconhecido', () => {
+      const svg = (component.getIcon('unknown-icon') as any).changingThisBreaksApplicationSecurity as string;
+      expect(svg).toBe('');
     });
   });
 });


### PR DESCRIPTION
Closes #126

Fix nos testes do `SidebarComponent`: `getIcon()` agora retorna `SafeHtml` via `DomSanitizer.bypassSecurityTrustHtml`. Specs atualizados para extrair o conteúdo via `.changingThisBreaksApplicationSecurity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)