### PR TITLE
test(#127): corrige mock de matchMedia no ThemeService spec

### DIFF
--- a/personal-finance/src/app/core/services/theme.service.spec.ts
+++ b/personal-finance/src/app/core/services/theme.service.spec.ts
@@ -37,8 +37,11 @@ describe('ThemeService', () => {
         addEventListener: () => {}, removeEventListener: () => {},
         dispatchEvent: () => false,
       } as MediaQueryList;
-      // spyOn antes do configureTestingModule — signal é avaliado na instanciação
-      spyOn(window, 'matchMedia').and.returnValue(mql);
+      // Object.defineProperty necessário — matchMedia é read-only no Chrome Headless 147+
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true, configurable: true,
+        value: jasmine.createSpy('matchMedia').and.returnValue(mql),
+      });
       TestBed.configureTestingModule({ providers: [ThemeService] });
       const svc = TestBed.inject(ThemeService);
       TestBed.flushEffects();


### PR DESCRIPTION
Closes #127

## Resumo
- Substitui `spyOn` por `Object.defineProperty` no teste de `ThemeService`
- `window.matchMedia` é read-only no Chrome Headless 147+ — o spy anterior silenciava sem efeito, causando falha

🤖 Generated with [Claude Code](https://claude.com/claude-code)