### PR TITLE
feat(layout): responsividade mobile nos componentes de layout base

### DIFF
--- a/personal-finance/src/app/shared/components/header/header.component.css
+++ b/personal-finance/src/app/shared/components/header/header.component.css
@@ -24,3 +24,15 @@
 .theme-toggle {
   color: var(--ink3);
 }
+
+@media (max-width: 767px) {
+  .header {
+    padding: 12px 16px 12px 60px;
+    min-height: 52px;
+    gap: 8px;
+  }
+
+  .page-title {
+    font-size: 1rem;
+  }
+}

--- a/personal-finance/src/app/shared/components/page-shell/page-shell.component.css
+++ b/personal-finance/src/app/shared/components/page-shell/page-shell.component.css
@@ -16,3 +16,31 @@
 .shell-main.collapsed {
   margin-left: 64px;
 }
+
+.mobile-menu-btn {
+  display: none;
+}
+
+@media (max-width: 767px) {
+  .shell-main {
+    margin-left: 0 !important;
+  }
+
+  .mobile-menu-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: fixed;
+    top: 14px;
+    left: 14px;
+    z-index: 38;
+    width: 36px;
+    height: 36px;
+    border: 1px solid var(--v2-border);
+    border-radius: 10px;
+    background: var(--v2-sidebar-bg);
+    color: var(--text-muted);
+    cursor: pointer;
+    box-shadow: var(--v2-shadow);
+  }
+}

--- a/personal-finance/src/app/shared/components/page-shell/page-shell.component.html
+++ b/personal-finance/src/app/shared/components/page-shell/page-shell.component.html
@@ -1,6 +1,15 @@
 <div class="shell">
-  <app-sidebar (collapsedChange)="sidebarCollapsed.set($event)" />
+  <app-sidebar
+    (collapsedChange)="sidebarCollapsed.set($event)"
+    [mobileOpen]="mobileSidebarOpen()"
+    (closeMobile)="mobileSidebarOpen.set(false)"
+  />
   <main class="shell-main" [class.collapsed]="sidebarCollapsed()">
+    <button class="mobile-menu-btn" (click)="mobileSidebarOpen.set(true)" aria-label="Abrir menu">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="18" x2="21" y2="18"/>
+      </svg>
+    </button>
     <router-outlet />
   </main>
 </div>

--- a/personal-finance/src/app/shared/components/page-shell/page-shell.component.ts
+++ b/personal-finance/src/app/shared/components/page-shell/page-shell.component.ts
@@ -10,5 +10,6 @@ import { SidebarComponent } from '../sidebar/sidebar.component';
   styleUrls: ['./page-shell.component.css']
 })
 export class PageShellComponent {
-  readonly sidebarCollapsed = signal(false);
+  readonly sidebarCollapsed   = signal(false);
+  readonly mobileSidebarOpen  = signal(false);
 }

--- a/personal-finance/src/app/shared/components/pagination/pagination.component.css
+++ b/personal-finance/src/app/shared/components/pagination/pagination.component.css
@@ -62,3 +62,16 @@
   color: var(--ink3);
   line-height: 28px;
 }
+
+@media (max-width: 767px) {
+  .pagination-bar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 10px 12px;
+  }
+
+  .pagination-info {
+    font-size: 0.75rem;
+  }
+}

--- a/personal-finance/src/app/shared/components/sidebar/sidebar.component.css
+++ b/personal-finance/src/app/shared/components/sidebar/sidebar.component.css
@@ -238,3 +238,25 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+/* ── Mobile ── */
+.sidebar-mobile-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  z-index: 39;
+}
+
+@media (max-width: 767px) {
+  .sidebar {
+    transform: translateX(-100%);
+    transition: width 0.34s var(--ease), transform 0.3s var(--ease);
+    width: 198px !important;
+  }
+
+  .sidebar.mobile-open {
+    transform: translateX(0);
+  }
+
+  .sidebar-toggle { display: none; }
+}

--- a/personal-finance/src/app/shared/components/sidebar/sidebar.component.html
+++ b/personal-finance/src/app/shared/components/sidebar/sidebar.component.html
@@ -1,4 +1,8 @@
-<aside class="sidebar" [class.collapsed]="collapsed()">
+@if (mobileOpen()) {
+  <div class="sidebar-mobile-backdrop" (click)="closeMobile.emit()"></div>
+}
+
+<aside class="sidebar" [class.collapsed]="collapsed()" [class.mobile-open]="mobileOpen()">
   <!-- Logo -->
   <div class="sidebar-logo">
     <span class="sidebar-logo-mark">

--- a/personal-finance/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/personal-finance/src/app/shared/components/sidebar/sidebar.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, computed, signal, output } from '@angular/core';
+import { Component, inject, computed, signal, input, output } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { AuthService } from '../../../core/auth/auth.service';
@@ -31,8 +31,10 @@ export class SidebarComponent {
   readonly auth      = inject(AuthService);
   private readonly sanitizer = inject(DomSanitizer);
 
-  readonly collapsed = signal(false);
+  readonly mobileOpen     = input<boolean>(false);
+  readonly collapsed      = signal(false);
   readonly collapsedChange = output<boolean>();
+  readonly closeMobile    = output<void>();
 
   readonly visibleItems = computed(() =>
     NAV_ITEMS.filter(item => !item.adminOnly || this.auth.isAdmin())

--- a/personal-finance/src/app/shared/components/stat-card/stat-card.component.css
+++ b/personal-finance/src/app/shared/components/stat-card/stat-card.component.css
@@ -56,3 +56,13 @@
 
 .stat-card--info    .stat-card-value { color: var(--color-info); }
 .stat-card--info    .stat-card-icon  { background: var(--color-info-bg); color: var(--color-info); }
+
+@media (max-width: 767px) {
+  .stat-card {
+    padding: 14px 16px;
+  }
+
+  .stat-card-value {
+    font-size: 1.25rem;
+  }
+}

--- a/personal-finance/src/app/shared/components/tweaks-panel/tweaks-panel.component.css
+++ b/personal-finance/src/app/shared/components/tweaks-panel/tweaks-panel.component.css
@@ -146,3 +146,12 @@
   color: var(--text);
   font-weight: 600;
 }
+
+@media (max-width: 767px) {
+  .tweaks-panel {
+    top: 52px;
+    right: 8px;
+    left: 8px;
+    width: auto;
+  }
+}


### PR DESCRIPTION
Closes #192

## O que foi feito
- **sidebar**: drawer mobile com `transform: translateX`, backdrop com `closeMobile` output, toggle interno oculto em mobile
- **page-shell**: botão hamburger fixo no canto superior esquerdo (mobile only), `margin-left: 0` em mobile, coordena `mobileSidebarOpen`
- **header**: padding reduzido e `padding-left: 60px` para não sobrepor o hamburguer em mobile
- **stat-card**: padding e font-size do valor reduzidos em mobile
- **tweaks-panel**: width auto + left/right 8px em mobile (ocupa a largura disponível)
- **pagination**: stack vertical em mobile

Breakpoint único: `767px`