### PR TITLE
feat(responsividade): períodos e mario-modal mobile

### DIFF
--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.css
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.css
@@ -318,3 +318,27 @@
 .input-sm { padding: 6px 10px; font-size: 0.8125rem; }
 .field-label { font-size: 0.875rem; font-weight: 500; color: var(--ink2); }
 .text-muted { color: var(--ink3); }
+
+@media (max-width: 767px) {
+  .page-content { padding: 16px; gap: 16px; }
+
+  .summary-bar {
+    flex-direction: column;
+    align-items: stretch;
+    padding: 16px;
+    gap: 12px;
+  }
+
+  .summary-divider { display: none; }
+
+  .summary-item {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .filters-grid { flex-direction: column; }
+  .filter-field { min-width: unset; }
+
+  .loading-state, .empty-state { padding: 32px; }
+}

--- a/personal-finance/src/app/features/periods/components/periods/periods.component.css
+++ b/personal-finance/src/app/features/periods/components/periods/periods.component.css
@@ -251,3 +251,15 @@
 }
 
 @keyframes spin { to { transform: rotate(360deg); } }
+
+@media (max-width: 767px) {
+  .page-content { padding: 16px; gap: 16px; }
+
+  .filter-controls { flex-direction: column; align-items: stretch; }
+  .filter-field { min-width: unset; }
+  .input-sm { min-width: unset; }
+
+  .periods-grid { grid-template-columns: 1fr; }
+
+  .loading-state, .empty-state { padding: 32px; }
+}

--- a/personal-finance/src/app/shared/components/modal/mario-modal/mario-modal.component.css
+++ b/personal-finance/src/app/shared/components/modal/mario-modal/mario-modal.component.css
@@ -87,3 +87,14 @@
   background: #fff;
   color: #000;
 }
+
+@media (max-width: 560px) {
+  .mario-box {
+    min-width: 0;
+    width: calc(100vw - 32px);
+    height: auto;
+    min-height: 280px;
+    font-size: 0.55rem;
+    padding: 20px 20px 56px;
+  }
+}


### PR DESCRIPTION
## Resumo
- `periods.component.css`: grid 1 coluna, filtros em coluna, padding reduzido em mobile
- `period-detail.component.css`: summary-bar em coluna, dividers ocultos, filtros em coluna, summary-item em row com space-between
- `mario-modal.component.css`: largura fluida `calc(100vw - 32px)`, altura auto com min-height em telas ≤560px

Closes #194