### PR TITLE
feat(period-detail): ícone de categoria com tooltip kbd em mobile

### DIFF
--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.css
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.css
@@ -210,6 +210,66 @@
 .font-semibold { font-weight: 600; color: var(--ink); }
 .success-text  { color: var(--sage2); }
 
+/* ── Categoria: dot + ícone + kbd tooltip ── */
+.category-dot-wrap {
+  display: none;
+  position: relative;
+  align-items: center;
+}
+
+.category-name-desktop {
+  display: inline-flex;
+  align-items: center;
+}
+
+.category-dot--icon {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--cat-color, #c8bfaf);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  cursor: default;
+}
+
+.category-dot-img {
+  width: 14px;
+  height: 14px;
+  object-fit: contain;
+  display: block;
+}
+
+.category-kbd {
+  visibility: hidden;
+  opacity: 0;
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  white-space: nowrap;
+  background: var(--surface-raised);
+  color: var(--ink);
+  font-family: inherit;
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 3px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  box-shadow: 0 3px 0 var(--border);
+  pointer-events: none;
+  transition: opacity 120ms ease, visibility 120ms ease;
+  z-index: 10;
+}
+
+.category-dot-wrap:hover .category-kbd,
+.category-dot-wrap:focus-within .category-kbd,
+.category-dot-wrap.touched .category-kbd {
+  visibility: visible;
+  opacity: 1;
+}
+
 .loading-state, .empty-state {
   display: flex;
   flex-direction: column;
@@ -341,4 +401,7 @@
   .filter-field { min-width: unset; }
 
   .loading-state, .empty-state { padding: 32px; }
+
+  .category-dot-wrap    { display: inline-flex; }
+  .category-name-desktop { display: none; }
 }

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.html
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.html
@@ -161,8 +161,25 @@
                 <tr>
                   <td class="cell-primary">{{ expense.description }}</td>
                   <td>
-                    <span class="category-dot" [style.background]="categoryColor(expense.categoryId)"></span>
-                    {{ categoryName(expense.categoryId) }}
+                    <span class="category-dot-wrap"
+                      [style.--cat-color]="categoryColor(expense.categoryId)"
+                      [class.touched]="touchedCatId() === expense.categoryId"
+                      (touchstart)="touchedCatId.set(expense.categoryId)"
+                      (touchend)="touchedCatId.set(null)"
+                    >
+                      @if (categoryIcon(expense.categoryId)) {
+                        <span class="category-dot category-dot--icon">
+                          <img class="category-dot-img" [src]="categoryIcon(expense.categoryId)" [alt]="categoryName(expense.categoryId)" />
+                        </span>
+                      } @else {
+                        <span class="category-dot"></span>
+                      }
+                      <kbd class="category-kbd">{{ categoryName(expense.categoryId) }}</kbd>
+                    </span>
+                    <span class="category-name-desktop">
+                      <span class="category-dot" [style.background]="categoryColor(expense.categoryId)"></span>
+                      {{ categoryName(expense.categoryId) }}
+                    </span>
                   </td>
                   <td class="text-muted text-sm">{{ sourceLabel(expense.sourceType) }}</td>
                   <td class="text-muted text-sm">{{ fortnightLabel(expense.fortnightType) }}</td>

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.ts
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.ts
@@ -50,6 +50,8 @@ export class PeriodDetailComponent implements OnInit {
   readonly summary    = signal<PeriodSummary | null>(null);
   readonly categories = signal<CategoryResponse[]>([]);
 
+  readonly touchedCatId = signal<string | null>(null);
+
   // Mario modal
   readonly marioOpen    = signal(false);
   readonly marioTitle   = signal('');
@@ -398,6 +400,11 @@ export class PeriodDetailComponent implements OnInit {
 
   categoryColor(categoryId: string): string {
     return this.categories().find(c => c.id === categoryId)?.color ?? '#c8bfaf';
+  }
+
+  categoryIcon(categoryId: string): string | null {
+    const icon = this.categories().find(c => c.id === categoryId)?.icon ?? null;
+    return icon ? `data:image/png;base64,${icon}` : null;
   }
 
   statusLabel(status: PaymentStatus): string {


### PR DESCRIPTION
## Resumo
- Coluna Categoria em mobile exibe círculo colorido com ícone da categoria centralizado
- Ao hover/touch, o nome da categoria aparece em tooltip estilo tecla de teclado (`kbd`)
- Categorias sem ícone exibem apenas o dot colorido como fallback
- Signal `touchedCatId` gerencia o estado de toque em mobile via `(touchstart)`/`(touchend)`

Closes #194