### PR TITLE
feat(expenses,incomes): responsividade mobile nas telas de despesas e receitas

### DIFF
--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.css
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.css
@@ -288,6 +288,27 @@
 
 .row-selected { background: rgba(196,103,74,0.06) !important; }
 
+.period-select { width: auto; min-width: 180px; }
+
+/* ── Responsividade mobile ── */
+@media (max-width: 767px) {
+  .page-content { padding: 16px; gap: 16px; }
+
+  .filter-row { flex-wrap: wrap; }
+  .period-select { width: 100%; min-width: unset; }
+
+  .filters-grid { grid-template-columns: 1fr; }
+
+  .col-hide-mobile { display: none; }
+
+  .batch-action-bar { flex-wrap: wrap; }
+
+  .loading-state, .empty-state { padding: 32px; }
+
+  .modal-form-grid { grid-template-columns: 1fr; }
+  .field-full { grid-column: span 1; }
+}
+
 /* ── Animations ── */
 @keyframes fadeUp {
   from { opacity: 0; transform: translateY(14px); }

--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.html
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.html
@@ -9,7 +9,7 @@
   <!-- Filtro por período -->
   <div class="filter-row">
     <label class="field-label">Filtrar por período</label>
-    <select #periodFilterSelect class="input" style="width:auto; min-width:180px" (change)="onPeriodFilter($event)">
+    <select #periodFilterSelect class="input period-select" (change)="onPeriodFilter($event)">
       <option value="">Selecione um período</option>
       @for (p of periods(); track p.id) {
         <option [value]="p.id">{{ monthName(p.month) }}/{{ p.year }}</option>
@@ -118,10 +118,10 @@
             <th class="sortable" (click)="toggleSort('category')">
               Categoria {{ sortIcon('category') }}
             </th>
-            <th class="sortable" (click)="toggleSort('sourceType')">
+            <th class="sortable col-hide-mobile" (click)="toggleSort('sourceType')">
               Fonte {{ sortIcon('sourceType') }}
             </th>
-            <th class="sortable" (click)="toggleSort('fortnightType')">
+            <th class="sortable col-hide-mobile" (click)="toggleSort('fortnightType')">
               Quinzena {{ sortIcon('fortnightType') }}
             </th>
             <th class="sortable" (click)="toggleSort('dueDate')">
@@ -161,8 +161,8 @@
                 <span class="category-dot" [style.background]="categoryColor(expense.categoryId)"></span>
                 {{ categoryName(expense.categoryId) }}
               </td>
-              <td class="text-muted text-sm">{{ sourceLabel(expense.sourceType) }}</td>
-              <td class="text-muted text-sm">{{ fortnightLabel(expense.fortnightType) }}</td>
+              <td class="text-muted text-sm col-hide-mobile">{{ sourceLabel(expense.sourceType) }}</td>
+              <td class="text-muted text-sm col-hide-mobile">{{ fortnightLabel(expense.fortnightType) }}</td>
               <td class="text-muted text-sm">{{ formatDate(expense.dueDate) }}</td>
               <td class="font-semibold">{{ expense.amount | currencyBrl }}</td>
               <td>

--- a/personal-finance/src/app/features/incomes/components/incomes/incomes.component.css
+++ b/personal-finance/src/app/features/incomes/components/incomes/incomes.component.css
@@ -244,6 +244,25 @@
   border-top: 1px solid var(--v2-border);
 }
 
+.period-select { width: auto; min-width: 180px; }
+
+/* ── Responsividade mobile ── */
+@media (max-width: 767px) {
+  .page-content { padding: 16px; gap: 16px; }
+
+  .filter-row { flex-wrap: wrap; }
+  .period-select { width: 100%; min-width: unset; }
+
+  .filters-grid { grid-template-columns: 1fr; }
+
+  .col-hide-mobile { display: none; }
+
+  .loading-state, .empty-state { padding: 32px; }
+
+  .modal-form-grid { grid-template-columns: 1fr; }
+  .field-full { grid-column: span 1; }
+}
+
 /* ── Animations ── */
 @keyframes fadeUp {
   from { opacity: 0; transform: translateY(14px); }

--- a/personal-finance/src/app/features/incomes/components/incomes/incomes.component.html
+++ b/personal-finance/src/app/features/incomes/components/incomes/incomes.component.html
@@ -11,8 +11,7 @@
     <label class="field-label">Filtrar por período</label>
     <select
       #periodFilterSelect
-      class="input"
-      style="width:auto; min-width:180px"
+      class="input period-select"
       (change)="onPeriodFilter($event)"
     >
       <option value="">Selecione um período</option>
@@ -67,7 +66,7 @@
             <th class="sortable" (click)="toggleSort('description')">
               Descrição {{ sortIndicator('description') }}
             </th>
-            <th class="sortable" (click)="toggleSort('fortnightType')">
+            <th class="sortable col-hide-mobile" (click)="toggleSort('fortnightType')">
               Quinzena {{ sortIndicator('fortnightType') }}
             </th>
             <th class="sortable" (click)="toggleSort('receivedAt')">
@@ -88,7 +87,7 @@
                   <div class="cell-secondary">{{ income.notes }}</div>
                 }
               </td>
-              <td class="text-muted text-sm">{{ fortnightLabel(income.fortnightType) }}</td>
+              <td class="text-muted text-sm col-hide-mobile">{{ fortnightLabel(income.fortnightType) }}</td>
               <td class="text-muted text-sm">{{ formatDate(income.receivedAt) }}</td>
               <td class="amount-positive">{{ income.amount | currencyBrl }}</td>
               <td>


### PR DESCRIPTION
Closes #195

## Alterações

**Expenses:**
- `period-select` movido de inline style para CSS
- `col-hide-mobile` em th/td de Fonte e Quinzena
- `@media (max-width: 767px)`: padding reduzido, filter-row wrap, filters-grid 1 col, batch-action-bar wrap, modal form 1 col

**Incomes:**
- `period-select` movido de inline style para CSS
- `col-hide-mobile` em th/td de Quinzena
- `@media (max-width: 767px)`: mesmo padrão