### PR TITLE
feat(expenses,period-detail): categoria com dot-wrap e ocultar colunas em mobile

### DIFF
--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.css
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.css
@@ -137,7 +137,59 @@
 
 .cell-primary   { color: var(--text); font-weight: 500; }
 .cell-secondary { font-size: 0.75rem; color: var(--text-subtle); margin-top: 2px; }
-.category-dot   { display: inline-block; width: 7px; height: 7px; border-radius: 50%; margin-right: 6px; }
+.category-dot { display: inline-block; width: 7px; height: 7px; border-radius: 50%; margin-right: 6px; }
+
+/* ── Categoria: dot + ícone + kbd tooltip ── */
+.category-dot-wrap {
+  display: none;
+  position: relative;
+  align-items: center;
+}
+
+.category-name-desktop { display: inline-flex; align-items: center; }
+
+.category-dot--icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--cat-color, #c8bfaf);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  cursor: default;
+}
+
+.category-dot-img { width: 20px; height: 20px; object-fit: contain; display: block; }
+
+.category-kbd {
+  visibility: hidden;
+  opacity: 0;
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  white-space: nowrap;
+  background: var(--v2-surface);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 3px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--v2-border);
+  box-shadow: 0 3px 0 var(--v2-border);
+  pointer-events: none;
+  transition: opacity 120ms ease, visibility 120ms ease;
+  z-index: 10;
+}
+
+.category-dot-wrap:hover .category-kbd,
+.category-dot-wrap:focus-within .category-kbd,
+.category-dot-wrap.touched .category-kbd {
+  visibility: visible;
+  opacity: 1;
+}
 .text-sm        { font-size: 0.8125rem; }
 .text-muted     { color: var(--text-muted); }
 .font-semibold  { font-weight: 600; color: var(--text); font-family: var(--font-d); }
@@ -300,6 +352,10 @@
   .filters-grid { grid-template-columns: 1fr; }
 
   .col-hide-mobile { display: none; }
+
+  .category-dot-wrap    { display: inline-flex; }
+  .category-name-desktop { display: none; }
+  td:has(.category-dot-wrap) { text-align: center; }
 
   .batch-action-bar { flex-wrap: wrap; }
 

--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.html
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.html
@@ -158,8 +158,25 @@
                 }
               </td>
               <td>
-                <span class="category-dot" [style.background]="categoryColor(expense.categoryId)"></span>
-                {{ categoryName(expense.categoryId) }}
+                <span class="category-dot-wrap"
+                  [style.--cat-color]="categoryColor(expense.categoryId)"
+                  [class.touched]="touchedCatId() === expense.categoryId"
+                  (touchstart)="touchedCatId.set(expense.categoryId)"
+                  (touchend)="touchedCatId.set(null)"
+                >
+                  @if (categoryIcon(expense.categoryId)) {
+                    <span class="category-dot category-dot--icon">
+                      <img class="category-dot-img" [src]="categoryIcon(expense.categoryId)" [alt]="categoryName(expense.categoryId)" />
+                    </span>
+                  } @else {
+                    <span class="category-dot"></span>
+                  }
+                  <kbd class="category-kbd">{{ categoryName(expense.categoryId) }}</kbd>
+                </span>
+                <span class="category-name-desktop">
+                  <span class="category-dot" [style.background]="categoryColor(expense.categoryId)"></span>
+                  {{ categoryName(expense.categoryId) }}
+                </span>
               </td>
               <td class="text-muted text-sm col-hide-mobile">{{ sourceLabel(expense.sourceType) }}</td>
               <td class="text-muted text-sm col-hide-mobile">{{ fortnightLabel(expense.fortnightType) }}</td>

--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.ts
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.ts
@@ -53,6 +53,7 @@ export class ExpensesComponent implements OnInit {
 
   readonly periods    = signal<PeriodResponse[]>([]);
   readonly categories = signal<CategoryResponse[]>([]);
+  readonly touchedCatId = signal<string | null>(null);
 
   // Dados vindos da API (página atual)
   readonly expenses    = signal<ExpenseResponse[]>([]);
@@ -523,6 +524,11 @@ export class ExpensesComponent implements OnInit {
 
   categoryColor(categoryId: string): string {
     return this.categories().find(c => c.id === categoryId)?.color ?? '#c8bfaf';
+  }
+
+  categoryIcon(categoryId: string): string | null {
+    const icon = this.categories().find(c => c.id === categoryId)?.icon ?? null;
+    return icon ? `data:image/png;base64,${icon}` : null;
   }
 
   statusLabel(status: PaymentStatus): string     { return PAYMENT_STATUS_LABELS[status]; }

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.css
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.css
@@ -400,6 +400,8 @@
   .filters-grid { flex-direction: column; }
   .filter-field { min-width: unset; }
 
+  .col-hide-mobile { display: none; }
+
   .loading-state, .empty-state { padding: 32px; }
 
   .category-dot-wrap    { display: inline-flex; }

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.html
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.html
@@ -149,8 +149,8 @@
               <tr>
                 <th class="sortable" (click)="toggleExpSort('description')">Descrição {{ expSortIcon('description') }}</th>
                 <th class="sortable" (click)="toggleExpSort('category')">Categoria {{ expSortIcon('category') }}</th>
-                <th class="sortable" (click)="toggleExpSort('sourceType')">Fonte {{ expSortIcon('sourceType') }}</th>
-                <th class="sortable" (click)="toggleExpSort('fortnightType')">Quinzena {{ expSortIcon('fortnightType') }}</th>
+                <th class="sortable col-hide-mobile" (click)="toggleExpSort('sourceType')">Fonte {{ expSortIcon('sourceType') }}</th>
+                <th class="sortable col-hide-mobile" (click)="toggleExpSort('fortnightType')">Quinzena {{ expSortIcon('fortnightType') }}</th>
                 <th class="sortable" (click)="toggleExpSort('dueDate')">Vencimento {{ expSortIcon('dueDate') }}</th>
                 <th class="sortable" (click)="toggleExpSort('amount')">Valor {{ expSortIcon('amount') }}</th>
                 <th class="sortable" (click)="toggleExpSort('paymentStatus')">Status {{ expSortIcon('paymentStatus') }}</th>
@@ -181,8 +181,8 @@
                       {{ categoryName(expense.categoryId) }}
                     </span>
                   </td>
-                  <td class="text-muted text-sm">{{ sourceLabel(expense.sourceType) }}</td>
-                  <td class="text-muted text-sm">{{ fortnightLabel(expense.fortnightType) }}</td>
+                  <td class="text-muted text-sm col-hide-mobile">{{ sourceLabel(expense.sourceType) }}</td>
+                  <td class="text-muted text-sm col-hide-mobile">{{ fortnightLabel(expense.fortnightType) }}</td>
                   <td class="text-muted text-sm">{{ formatDate(expense.dueDate) }}</td>
                   <td class="font-semibold">{{ expense.amount | currencyBrl }}</td>
                   <td>


### PR DESCRIPTION
Closes #195

## Alterações

**Expenses:**
- Categoria com padrão dot-wrap (ícone + kbd tooltip em mobile)
- `categoryIcon()` e `touchedCatId` adicionados ao TS

**Period-detail (aba despesas):**
- Colunas Fonte e Quinzena ocultas em mobile via `col-hide-mobile`