### PR TITLE
feat(config,admin,import): responsividade mobile + tweaks accent + fix theme test

### DIFF
--- a/personal-finance/src/app/core/services/theme.service.spec.ts
+++ b/personal-finance/src/app/core/services/theme.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { ThemeService } from './theme.service';
+import { ThemeService, MATCH_MEDIA_FN } from './theme.service';
 
 const THEME_KEY = 'pf_theme';
 
@@ -37,12 +37,13 @@ describe('ThemeService', () => {
         addEventListener: () => {}, removeEventListener: () => {},
         dispatchEvent: () => false,
       } as MediaQueryList;
-      // Object.defineProperty necessário — matchMedia é read-only no Chrome Headless 147+
-      Object.defineProperty(window, 'matchMedia', {
-        writable: true, configurable: true,
-        value: jasmine.createSpy('matchMedia').and.returnValue(mql),
+      const matchMediaSpy = jasmine.createSpy('matchMedia').and.returnValue(mql);
+      TestBed.configureTestingModule({
+        providers: [
+          ThemeService,
+          { provide: MATCH_MEDIA_FN, useValue: matchMediaSpy },
+        ],
       });
-      TestBed.configureTestingModule({ providers: [ThemeService] });
       const svc = TestBed.inject(ThemeService);
       TestBed.flushEffects();
       expect(svc.isDark()).toBeTrue();

--- a/personal-finance/src/app/core/services/theme.service.ts
+++ b/personal-finance/src/app/core/services/theme.service.ts
@@ -1,14 +1,21 @@
-import { Injectable, signal, effect } from '@angular/core';
+import { Injectable, signal, effect, inject, InjectionToken } from '@angular/core';
 
 const THEME_KEY = 'pf_theme';
 
+export const MATCH_MEDIA_FN = new InjectionToken<(query: string) => MediaQueryList>(
+  'MATCH_MEDIA_FN',
+  { factory: () => window.matchMedia.bind(window) }
+);
+
 @Injectable({ providedIn: 'root' })
 export class ThemeService {
+  private readonly matchMedia = inject(MATCH_MEDIA_FN);
+
   readonly isDark = signal<boolean>(
     localStorage.getItem(THEME_KEY) === 'dark' ||
     (!localStorage.getItem(THEME_KEY) &&
-      typeof window.matchMedia === 'function' &&
-      window.matchMedia('(prefers-color-scheme: dark)').matches)
+      typeof this.matchMedia === 'function' &&
+      this.matchMedia('(prefers-color-scheme: dark)').matches)
   );
 
   constructor() {


### PR DESCRIPTION
Closes #196

## Resumo
- Responsividade mobile: Config, Admin de Usuários e Import
- `btn-primary` global, aba ativa e elementos de destaque respondem ao accent do tweaks via `--terracotta`
- `ThemeService`: `matchMedia` extraído para `InjectionToken` — corrige teste no Chrome Headless 147+