### PR TITLE
feat(modal): redesign sonic-modal — 4 bordas SVG, Playfair Display e animação de anel

### DIFF
--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.html
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.html
@@ -236,6 +236,7 @@
   <div class="modal-center" @modalAnim>
     <app-sonic-modal
       [title]="modalMode() === 'create' ? 'Nova Despesa' : 'Editar Despesa'"
+      [subtitle]="modalMode() === 'create' ? 'Registre uma nova saída' : 'Edite os dados da despesa'"
       (closed)="closeModal()"
     >
       <form [formGroup]="form" (ngSubmit)="onSubmit()">
@@ -278,15 +279,39 @@
 
           <div class="field">
             <label class="field-label">Valor (R$) *</label>
-            <input
-              type="number"
-              formControlName="amount"
-              class="input"
-              [class.error]="showError('amount')"
-              placeholder="0,00"
-              step="0.01"
-              min="0.01"
-            />
+            <div class="value-wrap">
+              @for (ring of rings(); track ring.id) {
+                <img class="ring-bounce" [style.left.px]="ring.x" src="ring.gif" alt="" />
+              }
+              @for (sp of sparkles(); track sp.id) {
+                <div class="sparkle" [style.left.px]="sp.x" [style.top]="sp.y">
+                  <svg width="14" height="14" viewBox="0 0 16 16">
+                    <path d="M8 0 L9 7 L16 8 L9 9 L8 16 L7 9 L0 8 L7 7 Z" fill="#F5C842" opacity="0.9" />
+                  </svg>
+                </div>
+              }
+              <input
+                type="number"
+                formControlName="amount"
+                class="input"
+                [class.error]="showError('amount')"
+                placeholder="0,00"
+                step="0.01"
+                min="0.01"
+              />
+              <div class="value-arrows">
+                <button type="button" class="value-arrow" (click)="incrementAmount()" title="Aumentar">
+                  <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+                    <polyline points="2,7 5,3 8,7" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
+                </button>
+                <button type="button" class="value-arrow" (click)="decrementAmount()" title="Diminuir">
+                  <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+                    <polyline points="2,3 5,7 8,3" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
+                </button>
+              </div>
+            </div>
             @if (showError('amount')) { <span class="field-error">Valor inválido</span> }
           </div>
 

--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.ts
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.ts
@@ -91,6 +91,37 @@ export class ExpensesComponent implements OnInit {
     return displayed.length > 0 && displayed.every(e => this.selectedExpenseIds().includes(e.id));
   });
 
+  // Ring animation — campo de valor
+  private _ringId = 0;
+  readonly rings    = signal<{ id: number; x: number }[]>([]);
+  readonly sparkles = signal<{ id: number; x: number; y: string }[]>([]);
+
+  incrementAmount(): void {
+    const cur = this.form.get('amount')?.value ?? 0;
+    this.form.get('amount')?.setValue(Math.round((cur + 10) * 100) / 100);
+    this._spawnRing();
+  }
+
+  decrementAmount(): void {
+    const cur = this.form.get('amount')?.value ?? 0;
+    const next = Math.max(0, Math.round((cur - 10) * 100) / 100);
+    this.form.get('amount')?.setValue(next);
+    this._spawnRing();
+  }
+
+  private _spawnRing(): void {
+    const id = ++this._ringId;
+    const x  = 20 + Math.random() * 140;
+    this.rings.update(r => [...r, { id, x }]);
+    this.sparkles.update(s => [
+      ...s,
+      { id: id * 100 + 1, x: x - 10 + Math.random() * 20, y: '30%' },
+      { id: id * 100 + 2, x: x - 20 + Math.random() * 40, y: '60%' },
+    ]);
+    setTimeout(() => this.rings.update(r => r.filter(ring => ring.id !== id)), 900);
+    setTimeout(() => this.sparkles.update(s => s.filter(sp => sp.id !== id * 100 + 1 && sp.id !== id * 100 + 2)), 500);
+  }
+
   // Drag and drop
   private draggedIndex: number | null = null;
   readonly pendingOrders = signal<ExpenseOrderItem[]>([]);

--- a/personal-finance/src/app/features/incomes/components/incomes/incomes.component.html
+++ b/personal-finance/src/app/features/incomes/components/incomes/incomes.component.html
@@ -134,6 +134,7 @@
   <div class="modal-center" @modalAnim>
     <app-sonic-modal
       [title]="modalMode() === 'create' ? 'Nova Receita' : 'Editar Receita'"
+      [subtitle]="modalMode() === 'create' ? 'Registre uma nova entrada' : 'Edite os dados da receita'"
       (closed)="closeModal()"
     >
       <form [formGroup]="form" (ngSubmit)="onSubmit()">
@@ -171,15 +172,39 @@
 
           <div class="field">
             <label class="field-label">Valor (R$) *</label>
-            <input
-              type="number"
-              formControlName="amount"
-              class="input"
-              [class.error]="showError('amount')"
-              placeholder="0,00"
-              step="0.01"
-              min="0.01"
-            />
+            <div class="value-wrap">
+              @for (ring of rings(); track ring.id) {
+                <img class="ring-bounce" [style.left.px]="ring.x" src="ring.gif" alt="" />
+              }
+              @for (sp of sparkles(); track sp.id) {
+                <div class="sparkle" [style.left.px]="sp.x" [style.top]="sp.y">
+                  <svg width="14" height="14" viewBox="0 0 16 16">
+                    <path d="M8 0 L9 7 L16 8 L9 9 L8 16 L7 9 L0 8 L7 7 Z" fill="#F5C842" opacity="0.9" />
+                  </svg>
+                </div>
+              }
+              <input
+                type="number"
+                formControlName="amount"
+                class="input"
+                [class.error]="showError('amount')"
+                placeholder="0,00"
+                step="0.01"
+                min="0.01"
+              />
+              <div class="value-arrows">
+                <button type="button" class="value-arrow" (click)="incrementAmount()" title="Aumentar">
+                  <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+                    <polyline points="2,7 5,3 8,7" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
+                </button>
+                <button type="button" class="value-arrow" (click)="decrementAmount()" title="Diminuir">
+                  <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+                    <polyline points="2,3 5,7 8,3" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
+                </button>
+              </div>
+            </div>
             @if (showError('amount')) { <span class="field-error">Valor inválido</span> }
           </div>
 

--- a/personal-finance/src/app/features/incomes/components/incomes/incomes.component.ts
+++ b/personal-finance/src/app/features/incomes/components/incomes/incomes.component.ts
@@ -76,6 +76,37 @@ export class IncomesComponent implements OnInit {
   readonly modalOpen   = signal(false);
   readonly modalMode   = signal<'create' | 'edit'>('create');
 
+  // Ring animation — campo de valor
+  private _ringId = 0;
+  readonly rings    = signal<{ id: number; x: number }[]>([]);
+  readonly sparkles = signal<{ id: number; x: number; y: string }[]>([]);
+
+  incrementAmount(): void {
+    const cur = this.form.get('amount')?.value ?? 0;
+    this.form.get('amount')?.setValue(Math.round((cur + 10) * 100) / 100);
+    this._spawnRing();
+  }
+
+  decrementAmount(): void {
+    const cur = this.form.get('amount')?.value ?? 0;
+    const next = Math.max(0, Math.round((cur - 10) * 100) / 100);
+    this.form.get('amount')?.setValue(next);
+    this._spawnRing();
+  }
+
+  private _spawnRing(): void {
+    const id = ++this._ringId;
+    const x  = 20 + Math.random() * 140;
+    this.rings.update(r => [...r, { id, x }]);
+    this.sparkles.update(s => [
+      ...s,
+      { id: id * 100 + 1, x: x - 10 + Math.random() * 20, y: '30%' },
+      { id: id * 100 + 2, x: x - 20 + Math.random() * 40, y: '60%' },
+    ]);
+    setTimeout(() => this.rings.update(r => r.filter(ring => ring.id !== id)), 900);
+    setTimeout(() => this.sparkles.update(s => s.filter(sp => sp.id !== id * 100 + 1 && sp.id !== id * 100 + 2)), 500);
+  }
+
   private editingId: string | null = null;
   selectedPeriodId: string | null = null;
 

--- a/personal-finance/src/app/shared/components/modal/sonic-modal/sonic-modal.component.css
+++ b/personal-finance/src/app/shared/components/modal/sonic-modal/sonic-modal.component.css
@@ -1,117 +1,142 @@
-:host { display: block; }
+/* SVG tile Green Hill Zone — reutilizado em bordas e cantos */
+:host {
+  display: block;
+}
 
 .sonic-modal-wrap {
   background: var(--surface-raised);
-  border-radius: 0;
   box-shadow: var(--shadow-modal),
               4px 4px 0 #1a0e00,
               -1px -1px 0 #1a0e00;
   min-width: 480px;
-  max-width: 600px;
+  max-width: 560px;
   width: 100%;
-  overflow: hidden;
   position: relative;
+  overflow: visible;
 }
 
-.sonic-border {
-  height: 28px;
-  overflow: hidden;
-  background: #1a0e00;
-}
-
-.sonic-border--top    { border-bottom: 2px solid #1a0e00; }
-.sonic-border--bottom { border-top: 2px solid #1a0e00; }
-
-.sonic-blocks {
-  display: flex;
-  height: 100%;
-  gap: 2px;
-  padding: 2px;
-}
-
-.sonic-block {
-  flex: 1;
-  height: 100%;
-  background: linear-gradient(
-    135deg,
-    #c8722a 0%,
-    #d4892f 30%,
-    #b85e20 70%,
-    #a04e18 100%
-  );
-  border: 1px solid #1a0e00;
-  border-radius: 1px;
-  position: relative;
-  box-shadow: inset 1px 1px 0 rgba(255,200,120,0.35),
-              inset -1px -1px 0 rgba(0,0,0,0.4);
-}
-
-.sonic-block--dark {
-  background: linear-gradient(
-    135deg,
-    #7a3a0e 0%,
-    #8c4510 30%,
-    #6a2e08 70%,
-    #5a2406 100%
-  );
-  box-shadow: inset 1px 1px 0 rgba(180,100,50,0.2),
-              inset -1px -1px 0 rgba(0,0,0,0.6);
-}
-
-.sonic-block::after {
-  content: '';
+/* ── Tile SVG compartilhado ─────────────────────────────── */
+.sonic-border,
+.sonic-corner {
   position: absolute;
-  bottom: 3px;
-  left: 8%;
-  right: 8%;
-  height: 1px;
-  background: rgba(255, 220, 160, 0.2);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24'%3E%3Crect width='23' height='23' fill='%23C47832'/%3E%3Crect width='23' height='3' fill='%23F5B84A'/%3E%3Crect x='0' y='3' width='3' height='18' fill='%23E09840'/%3E%3Crect y='20' width='23' height='3' fill='%23562E08'/%3E%3Crect x='20' y='3' width='3' height='17' fill='%237A4418'/%3E%3Crect x='4' y='4' width='8' height='5' fill='%23ECA84A' opacity='0.55'/%3E%3Crect x='23' y='0' width='1' height='24' fill='%23281004'/%3E%3Crect x='0' y='23' width='24' height='1' fill='%23281004'/%3E%3C/svg%3E");
+  background-size: 24px 24px;
+  z-index: 10;
 }
 
-.sonic-modal-body {
-  padding: 0;
+/* ── Bordas horizontais ──────────────────────────────────── */
+.sonic-border--top,
+.sonic-border--bottom {
+  left: -24px;
+  right: -24px;
+  height: 24px;
+  background-repeat: repeat-x;
+}
+.sonic-border--top    { top: -24px; }
+.sonic-border--bottom { bottom: -24px; }
+
+/* ── Bordas verticais ────────────────────────────────────── */
+.sonic-border--left,
+.sonic-border--right {
+  top: 0;
+  bottom: 0;
+  width: 24px;
+  background-repeat: repeat-y;
+}
+.sonic-border--left  { left: -24px; }
+.sonic-border--right { right: -24px; }
+
+/* ── Cantos ──────────────────────────────────────────────── */
+.sonic-corner {
+  width: 24px;
+  height: 24px;
+  background-repeat: no-repeat;
+  z-index: 11;
+}
+.sonic-corner--tl { top: -24px;    left: -24px; }
+.sonic-corner--tr { top: -24px;    right: -24px; }
+.sonic-corner--bl { bottom: -24px; left: -24px; }
+.sonic-corner--br { bottom: -24px; right: -24px; }
+
+/* ── Inner wrapper ───────────────────────────────────────── */
+.sonic-modal-inner {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  max-height: 92vh;
+  border: 1px solid rgba(255, 255, 255, 0.09);
 }
 
+/* ── Header ──────────────────────────────────────────────── */
 .sonic-modal-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 16px 24px 12px;
+  padding: 20px 24px 16px;
   border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.03) 0%, transparent 100%);
+}
+
+.sonic-modal-header-text {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
 }
 
 .sonic-modal-title {
-  font-size: 1.0625rem;
+  font-family: 'Playfair Display', 'DM Serif Display', Georgia, serif;
+  font-size: 1.375rem;
   font-weight: 600;
   color: var(--ink);
   margin: 0;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+}
+
+.sonic-modal-subtitle {
+  font-size: 0.75rem;
+  color: var(--ink3);
+  margin: 0;
+  letter-spacing: 0.03em;
 }
 
 .sonic-modal-close {
-  width: 32px;
-  height: 32px;
+  width: 34px;
+  height: 34px;
   display: flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid var(--border);
-  background: var(--surface-raised);
-  border-radius: var(--radius);
+  border: 1px solid rgba(255, 255, 255, 0.11);
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 50%;
   cursor: pointer;
   color: var(--ink3);
-  transition: all var(--transition);
+  transition: background var(--transition), color var(--transition);
   flex-shrink: 0;
 }
 
 .sonic-modal-close:hover {
-  background: var(--color-danger-bg);
-  border-color: var(--rust);
-  color: var(--rust);
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--ink);
 }
 
+/* ── Content slot ────────────────────────────────────────── */
 .sonic-modal-content {
   padding: 20px 24px 24px;
+  overflow-y: auto;
+  flex: 1;
 }
 
+/* ── Responsivo ──────────────────────────────────────────── */
 @media (max-width: 560px) {
-  .sonic-modal-wrap { min-width: 0; width: calc(100vw - 32px); }
+  .sonic-modal-wrap {
+    min-width: 0;
+    width: calc(100vw - 80px); /* 32px margens + 24px bordas cada lado */
+  }
+
+  .sonic-modal-title {
+    font-size: 1.125rem;
+    white-space: normal;
+  }
 }

--- a/personal-finance/src/app/shared/components/modal/sonic-modal/sonic-modal.component.html
+++ b/personal-finance/src/app/shared/components/modal/sonic-modal/sonic-modal.component.html
@@ -1,28 +1,34 @@
 <div class="sonic-modal-wrap">
 
-  <!-- Borda superior com blocos Green Hill Zone -->
-  <div class="sonic-border sonic-border--top">
-    <div class="sonic-blocks">
-      @for (b of blocks; track $index) {
-        <div class="sonic-block" [class.sonic-block--dark]="b === 'd'"></div>
-      }
-    </div>
-  </div>
+  <!-- Bordas laterais SVG Green Hill Zone -->
+  <div class="sonic-border sonic-border--top"></div>
+  <div class="sonic-border sonic-border--bottom"></div>
+  <div class="sonic-border sonic-border--left"></div>
+  <div class="sonic-border sonic-border--right"></div>
+  <div class="sonic-corner sonic-corner--tl"></div>
+  <div class="sonic-corner sonic-corner--tr"></div>
+  <div class="sonic-corner sonic-corner--bl"></div>
+  <div class="sonic-corner sonic-corner--br"></div>
 
-  <!-- Conteúdo -->
-  <div class="sonic-modal-body">
+  <!-- Inner clip wrapper -->
+  <div class="sonic-modal-inner">
+
     <!-- Header -->
     <div class="sonic-modal-header">
-      <h2 class="sonic-modal-title">{{ title() }}</h2>
+      <div class="sonic-modal-header-text">
+        <h2 class="sonic-modal-title">{{ title() }}</h2>
+        @if (subtitle()) {
+          <p class="sonic-modal-subtitle">{{ subtitle() }}</p>
+        }
+      </div>
       <button
         class="sonic-modal-close"
         (click)="closed.emit()"
         aria-label="Fechar"
       >
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
-             stroke="currentColor" stroke-width="2.5">
-          <line x1="18" y1="6" x2="6" y2="18"/>
-          <line x1="6" y1="6" x2="18" y2="18"/>
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+          <line x1="2" y1="2" x2="12" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+          <line x1="12" y1="2" x2="2" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
         </svg>
       </button>
     </div>
@@ -31,15 +37,7 @@
     <div class="sonic-modal-content">
       <ng-content />
     </div>
-  </div>
 
-  <!-- Borda inferior com blocos Green Hill Zone -->
-  <div class="sonic-border sonic-border--bottom">
-    <div class="sonic-blocks">
-      @for (b of blocks; track $index) {
-        <div class="sonic-block" [class.sonic-block--dark]="b === 'd'"></div>
-      }
-    </div>
   </div>
 
 </div>

--- a/personal-finance/src/app/shared/components/modal/sonic-modal/sonic-modal.component.spec.ts
+++ b/personal-finance/src/app/shared/components/modal/sonic-modal/sonic-modal.component.spec.ts
@@ -32,6 +32,16 @@ describe('SonicModalComponent', () => {
     expect(component.title()).toBe('Meu Modal');
   });
 
+  it('subtitle tem valor padrão vazio', () => {
+    expect(component.subtitle()).toBe('');
+  });
+
+  it('subtitle recebe valor via input', () => {
+    fixture.componentRef.setInput('subtitle', 'Subtítulo do modal');
+    fixture.detectChanges();
+    expect(component.subtitle()).toBe('Subtítulo do modal');
+  });
+
   it('emite "closed" ao pressionar Escape', () => {
     let emitted = false;
     component.closed.subscribe(() => { emitted = true; });
@@ -52,7 +62,4 @@ describe('SonicModalComponent', () => {
     expect(emitted).toBeTrue();
   });
 
-  it('blocks é um array não-vazio', () => {
-    expect(component.blocks.length).toBeGreaterThan(0);
-  });
 });

--- a/personal-finance/src/app/shared/components/modal/sonic-modal/sonic-modal.component.ts
+++ b/personal-finance/src/app/shared/components/modal/sonic-modal/sonic-modal.component.ts
@@ -1,7 +1,4 @@
-import {
-  Component, input, output, OnInit, OnDestroy,
-  signal, HostListener
-} from '@angular/core';
+import { Component, input, output, HostListener } from '@angular/core';
 
 @Component({
   selector: 'app-sonic-modal',
@@ -10,15 +7,9 @@ import {
   styleUrls: ['./sonic-modal.component.css']
 })
 export class SonicModalComponent {
-  readonly title  = input<string>('');
-  readonly closed = output<void>();
-
-  // Padrão de blocos — 'l' = light, 'd' = dark
-  readonly blocks: ('l' | 'd')[] = [
-    'l','d','l','l','d','l','l','d','l','l','d','l',
-    'l','d','l','l','d','l','l','d','l','l','d','l',
-    'l','d','l','l','d','l',
-  ];
+  readonly title    = input<string>('');
+  readonly subtitle = input<string>('');
+  readonly closed   = output<void>();
 
   @HostListener('document:keydown.escape')
   onEscape(): void {

--- a/personal-finance/src/index.html
+++ b/personal-finance/src/index.html
@@ -8,7 +8,7 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=DM+Serif+Display&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=DM+Serif+Display&family=Playfair+Display:wght@400;500;600&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
 </head>
 <body>

--- a/personal-finance/src/styles/_modal.css
+++ b/personal-finance/src/styles/_modal.css
@@ -54,3 +54,96 @@
     transform: scale(0.93) translateY(10px);
   }
 }
+
+/* ── Value field com setas de incremento/decremento ─────── */
+
+.value-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.value-wrap .input {
+  padding-right: 40px;
+}
+
+.value-arrows {
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid rgba(255, 255, 255, 0.11);
+}
+
+.value-arrow {
+  flex: 1;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--ink3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 9px;
+  transition: color 0.18s, background 0.18s;
+}
+
+.value-arrow:first-child {
+  border-radius: 0 var(--radius) 0 0;
+}
+
+.value-arrow:last-child {
+  border-radius: 0 0 var(--radius) 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.11);
+}
+
+.value-arrow:hover {
+  color: #F5C842;
+  background: rgba(245, 200, 66, 0.08);
+}
+
+.value-arrow:active {
+  background: rgba(245, 200, 66, 0.16);
+}
+
+/* ── Animações de anel e sparkle ─────────────────────────── */
+
+@keyframes ringBounce {
+  0%   { transform: translate(-50%, -50%) scale(0.3); opacity: 1; }
+  35%  { transform: translate(-50%, -120%) scale(1.15); opacity: 1; }
+  55%  { transform: translate(-50%, -60%) scale(0.95); opacity: 0.9; }
+  70%  { transform: translate(-50%, -100%) scale(1.05); opacity: 0.8; }
+  82%  { transform: translate(-50%, -75%) scale(0.98); opacity: 0.6; }
+  92%  { transform: translate(-50%, -90%) scale(1.02); opacity: 0.4; }
+  100% { transform: translate(-50%, -110%) scale(1); opacity: 0; }
+}
+
+@keyframes sparkle {
+  0%   { opacity: 0; transform: translate(-50%, -50%) scale(0) rotate(0deg); }
+  40%  { opacity: 1; transform: translate(-50%, -50%) scale(1.4) rotate(45deg); }
+  100% { opacity: 0; transform: translate(-50%, -50%) scale(0.5) rotate(90deg); }
+}
+
+.ring-bounce {
+  position: absolute;
+  top: 50%;
+  pointer-events: none;
+  z-index: 999;
+  width: 28px;
+  height: 28px;
+  animation: ringBounce 0.85s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+  transform-origin: center;
+}
+
+.sparkle {
+  position: absolute;
+  pointer-events: none;
+  z-index: 998;
+  animation: sparkle 0.5s ease-out forwards;
+}
+
+.sparkle svg {
+  display: block;
+}


### PR DESCRIPTION
## Resumo
- Redesign completo do `SonicModalComponent`: bordas SVG Green Hill Zone em 4 lados + cantos
- Header com fonte Playfair Display, input `subtitle` opcional e botão fechar circular
- Campo Valor nos formulários de Despesa e Receita com setas ▲▼ (+10/-10) e animação bounce do `ring.gif` + sparkle
- Testes ajustados: subtitle adicionado, teste `blocks` removido

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)