### PR TITLE
fix(styles): select legível em dark/light mode

### DIFF
--- a/personal-finance/src/styles/styles.css
+++ b/personal-finance/src/styles/styles.css
@@ -78,6 +78,16 @@ a:hover { color: var(--sage); }
 .badge-info    { background: var(--color-info-bg);    color: var(--color-info);    }
 .badge-neutral { background: var(--bg3); color: var(--ink3); }
 
+/* ── color-scheme — form controls acompanham o tema ── */
+:root { color-scheme: light; }
+.dark { color-scheme: dark; }
+
+/* ── Select options — cores explícitas cross-browser ── */
+select option {
+  background-color: var(--surface-solid);
+  color: var(--text);
+}
+
 /* ── Inputs ──────────────────────────────────────────────────────────────── */
 .input {
   width: 100%;


### PR DESCRIPTION
Fix global para dropdowns ilegíveis — detectado durante a migração da tela de Períodos.

## Problema
Em dark mode, `select` com `background: rgba(255,255,255,0.04)` (transparente) fazia o browser renderizar o fundo nativo claro, com texto também claro → ilegível.

## Solução
- `color-scheme: light/dark` no `:root` e `.dark` — instrui o browser a usar estilo nativo adequado para todos os form controls
- `select option { background-color: var(--surface-solid); color: var(--text); }` — garante cores explícitas cross-browser no dropdown popup

Aplica a **todas as telas** automaticamente.