### PR TITLE
fix(styles): select legível em dark/light mode (global)

### DIFF
--- a/personal-finance/src/styles/styles.css
+++ b/personal-finance/src/styles/styles.css
@@ -78,6 +78,16 @@ a:hover { color: var(--sage); }
 .badge-info    { background: var(--color-info-bg);    color: var(--color-info);    }
 .badge-neutral { background: var(--bg3); color: var(--ink3); }
 
+/* ── color-scheme — form controls acompanham o tema ── */
+:root { color-scheme: light; }
+.dark { color-scheme: dark; }
+
+/* ── Select options — cores explícitas cross-browser ── */
+select option {
+  background-color: var(--surface-solid);
+  color: var(--text);
+}
+
 /* ── Inputs ──────────────────────────────────────────────────────────────── */
 .input {
   width: 100%;


### PR DESCRIPTION
Fix global para dropdowns ilegíveis em dark mode — detectado pós-merge da issue #129.

## Problema
`select` com background transparente (`rgba(255,255,255,0.04)`) fazia o browser renderizar fundo nativo claro com texto claro em dark mode → ilegível.

## Solução
- `color-scheme: light/dark` no `:root` e `.dark` — form controls nativos acompanham o tema em todas as telas
- `select option { background-color: var(--surface-solid); color: var(--text) }` — cores explícitas cross-browser no popup do dropdown