### PR TITLE
feat(#131, #132, #187): layout admin/config v2 + health check

### DIFF
--- a/personal-finance/src/app/features/config/components/admin-users/admin-users.component.css
+++ b/personal-finance/src/app/features/config/components/admin-users/admin-users.component.css
@@ -1,94 +1,184 @@
-.page-content { padding: 28px; display: flex; flex-direction: column; gap: 20px; }
+.page-content {
+  padding: var(--density-padding, 28px);
+  display: flex;
+  flex-direction: column;
+  gap: var(--density-gap, 24px);
+  flex: 1;
+}
 
-.filters-bar { padding: 16px; }
-.filters-row { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+/* ── Filters bar ── */
+.filters-bar {
+  background: var(--v2-surface);
+  backdrop-filter: blur(24px);
+  border-radius: var(--v2-radius);
+  border: 1px solid var(--v2-border);
+  box-shadow: var(--v2-shadow);
+  padding: 16px 20px;
+  animation: fadeUp 0.4s var(--ease) both;
+}
+
+.filters-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
 .filter-input  { width: 200px; }
 .filter-select { width: 140px; }
 
-.table-wrap { overflow-x: auto; }
-.table { width: 100%; border-collapse: collapse; font-size: 0.875rem; }
-.table th {
-  text-align: left; padding: 12px 16px;
-  font-size: 0.75rem; font-weight: 600;
-  text-transform: uppercase; letter-spacing: 0.04em;
-  color: var(--ink3); border-bottom: 1px solid var(--border);
+/* ── Table wrap ── */
+.table-wrap {
+  background: var(--v2-surface);
+  backdrop-filter: blur(24px);
+  border-radius: var(--v2-radius);
+  border: 1px solid var(--v2-border);
+  box-shadow: var(--v2-shadow);
+  overflow-x: auto;
+  animation: fadeUp 0.4s var(--ease) 0.06s both;
 }
-.table td {
-  padding: 12px 16px; border-bottom: 1px solid var(--bg3);
-  color: var(--ink2); vertical-align: middle;
-}
-.table tr:last-child td  { border-bottom: none; }
-.table tbody tr:hover    { background: var(--surface-overlay); }
-.table tbody .row-inactive td { opacity: 0.5; }
 
-.cell-primary { color: var(--ink); font-weight: 500; }
+.table { width: 100%; border-collapse: collapse; font-size: 0.875rem; }
+
+.table th {
+  text-align: left;
+  padding: 12px 16px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-subtle);
+  border-bottom: 1px solid var(--v2-border);
+}
+
+.table td {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--v2-border);
+  color: var(--text-muted);
+  vertical-align: middle;
+}
+
+.table tr:last-child td { border-bottom: none; }
+.table tbody tr:hover   { background: color-mix(in srgb, var(--terracotta) 4%, transparent); }
+.table tbody .row-inactive td { opacity: 0.45; }
+
+.cell-primary { color: var(--text); font-weight: 500; }
 .text-sm      { font-size: 0.8125rem; }
-.text-muted   { color: var(--ink3); }
+.text-muted   { color: var(--text-subtle); }
 
 .roles-wrap { display: flex; gap: 4px; flex-wrap: wrap; }
 
+/* ── Row actions ── */
 .row-actions { display: flex; gap: 4px; }
-.action-btn {
-  width: 28px; height: 28px; border: 1px solid var(--border);
-  background: none; border-radius: var(--radius-sm);
-  cursor: pointer; font-size: 13px;
-  display: flex; align-items: center; justify-content: center;
-  transition: all var(--transition);
-  color: var(--terracotta);
-}
-.action-primary:hover { background: var(--color-info-bg);    border-color: var(--color-info);    }
-.action-success:hover { background: var(--color-success-bg); border-color: var(--sage2);         }
-.action-warning:hover { background: var(--color-warning-bg); border-color: var(--color-warning); }
-.action-info:hover    { background: var(--color-info-bg);    border-color: var(--color-info);    }
 
-.modal-overlay {
-  position: fixed; inset: 0;
-  background: rgba(0,0,0,.4); z-index: 100;
+.action-btn {
+  width: 30px;
+  height: 30px;
+  border: 1px solid var(--v2-border);
+  background: var(--v2-surface);
+  border-radius: var(--v2-radius-sm);
+  cursor: pointer;
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: var(--t);
+  color: var(--text-subtle);
 }
+
+.action-primary:hover { background: color-mix(in srgb, var(--purple) 12%, transparent);     border-color: var(--purple);     color: var(--purple); }
+.action-success:hover { background: color-mix(in srgb, var(--olive) 12%, transparent);      border-color: var(--olive);      color: var(--olive); }
+.action-warning:hover { background: color-mix(in srgb, var(--amber) 12%, transparent);      border-color: var(--amber);      color: var(--amber); }
+.action-info:hover    { background: color-mix(in srgb, var(--terracotta) 12%, transparent); border-color: var(--terracotta); color: var(--terracotta); }
+
+/* ── Loading ── */
+.loading-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 60px 0;
+  gap: 12px;
+  color: var(--text-subtle);
+}
+
+/* ── Modal overlay ── */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  z-index: 100;
+}
+
 .modal-center {
-  position: fixed; inset: 0; z-index: 101;
-  display: flex; align-items: center; justify-content: center;
+  position: fixed;
+  inset: 0;
+  z-index: 101;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   pointer-events: none;
 }
-.modal-card {
-  width: 100%; max-width: 420px;
-  padding: 28px;
-  box-shadow: var(--shadow-modal);
-  pointer-events: all;
-}
 
-.modal-title { font-size: 1rem; margin-bottom: 20px; }
+.modal-center > * { pointer-events: all; }
+
+/* ── Modal form ── */
+.modal-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 0 24px 4px;
+}
 
 .field { display: flex; flex-direction: column; gap: 6px; }
-.field-label { font-size: 0.875rem; font-weight: 500; color: var(--ink2); }
 
-.roles-edit { display: flex; gap: 16px; flex-wrap: wrap; margin-top: 4px; }
-.role-check { display: flex; align-items: center; gap: 6px; font-size: 0.875rem; cursor: pointer; }
+.field-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-subtle);
+}
 
 .form-error {
-  margin-top: 12px; padding: 10px 14px;
-  background: var(--color-danger-bg); color: var(--color-danger);
-  border-radius: var(--radius); font-size: 0.875rem;
+  padding: 10px 14px;
+  background: var(--color-danger-bg);
+  color: var(--color-danger);
+  border-radius: var(--v2-radius-sm);
+  font-size: 0.8125rem;
 }
 
-.modal-footer { display: flex; justify-content: flex-end; gap: 10px; margin-top: 20px; }
-
-.loading-state { display: flex; align-items: center; justify-content: center; padding: 64px; }
-.spinner-lg {
-  width: 32px; height: 32px; border: 3px solid var(--border);
-  border-top-color: var(--terracotta); border-radius: 50%;
-  animation: spin .8s linear infinite; display: block;
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+  padding: 16px 24px;
+  border-top: 1px solid var(--v2-border);
 }
-@keyframes spin { to { transform: rotate(360deg); } }
 
-/* ── Responsividade mobile ── */
+/* ── Roles edit ── */
+.roles-edit {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.role-check {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.role-check input[type="checkbox"] { accent-color: var(--terracotta); cursor: pointer; }
+
+/* ── Responsive ── */
 @media (max-width: 767px) {
-  .page-content { padding: 16px; gap: 16px; }
-
   .filters-row { flex-direction: column; align-items: stretch; }
   .filter-input, .filter-select { width: 100%; }
-
   .col-hide-mobile { display: none; }
-
-  .modal-card { max-width: 100%; margin: 16px; }
+  .modal-form { padding: 0 16px 4px; }
+  .modal-footer { padding: 16px; }
 }

--- a/personal-finance/src/app/features/config/components/admin-users/admin-users.component.html
+++ b/personal-finance/src/app/features/config/components/admin-users/admin-users.component.html
@@ -1,8 +1,8 @@
 <app-header title="Usuários" subtitle="Gerenciamento de usuários do sistema" />
 
 <div class="page-content">
-  <!-- Filtros externos -->
-  <div class="filters-bar card">
+  <!-- Filtros -->
+  <div class="filters-bar">
     <div class="filters-row">
       <input class="input filter-input" type="text" placeholder="Nome"   [(ngModel)]="nameFilter"   />
       <input class="input filter-input" type="text" placeholder="E-mail" [(ngModel)]="emailFilter"  />
@@ -11,16 +11,16 @@
         <option value="true">Ativo</option>
         <option value="false">Inativo</option>
       </select>
-      <button class="btn btn-primary"   (click)="applyFilters()">Filtrar</button>
-      <button class="btn btn-secondary" (click)="clearFilters()">Limpar</button>
-      <button class="btn btn-primary" style="margin-left: auto" (click)="openCreate()">+ Novo Usuário</button>
+      <button class="btn btn-primary btn-sm"   (click)="applyFilters()">Filtrar</button>
+      <button class="btn btn-ghost btn-sm" (click)="clearFilters()">Limpar</button>
+      <button class="btn btn-primary btn-sm" style="margin-left: auto" (click)="openCreate()">+ Novo Usuário</button>
     </div>
   </div>
 
   @if (loading()) {
     <div class="loading-state"><span class="spinner-lg"></span></div>
   } @else {
-    <div class="table-wrap card">
+    <div class="table-wrap">
       <table class="table">
         <thead>
           <tr>
@@ -80,32 +80,33 @@
     @if (showCreateModal()) {
       <div class="modal-overlay" @backdropAnim (click)="showCreateModal.set(false)"></div>
       <div class="modal-center" @modalAnim>
-        <div class="modal-card card" (click)="$event.stopPropagation()">
-          <h3 class="modal-title">Novo Usuário</h3>
+        <app-sonic-modal title="Novo Usuário" subtitle="Preencha os dados do novo usuário" (closed)="showCreateModal.set(false)">
           <form [formGroup]="createForm" (ngSubmit)="onCreateUser()">
-            <div class="field" style="margin-bottom: 14px">
-              <label class="field-label">Nome *</label>
-              <input type="text" formControlName="name" class="input" placeholder="Nome completo" />
+            <div class="modal-form">
+              <div class="field">
+                <label class="field-label">Nome *</label>
+                <input type="text" formControlName="name" class="input" placeholder="Nome completo" />
+              </div>
+              <div class="field">
+                <label class="field-label">E-mail *</label>
+                <input type="email" formControlName="email" class="input" placeholder="email@exemplo.com" />
+              </div>
+              <div class="field">
+                <label class="field-label">Senha *</label>
+                <input type="password" formControlName="password" class="input" placeholder="Mínimo 8 caracteres" />
+              </div>
+              @if (createError()) {
+                <div class="form-error">{{ createError() }}</div>
+              }
             </div>
-            <div class="field" style="margin-bottom: 14px">
-              <label class="field-label">E-mail *</label>
-              <input type="email" formControlName="email" class="input" placeholder="email@exemplo.com" />
-            </div>
-            <div class="field" style="margin-bottom: 14px">
-              <label class="field-label">Senha *</label>
-              <input type="password" formControlName="password" class="input" placeholder="Mínimo 8 caracteres" />
-            </div>
-            @if (createError()) {
-              <div class="form-error">{{ createError() }}</div>
-            }
             <div class="modal-footer">
-              <button type="button" class="btn btn-secondary" (click)="showCreateModal.set(false)">Cancelar</button>
-              <button type="submit" class="btn btn-primary" [disabled]="loadingAction()">
+              <button type="button" class="btn btn-ghost btn-sm" (click)="showCreateModal.set(false)">Cancelar</button>
+              <button type="submit" class="btn btn-primary btn-sm" [disabled]="loadingAction()">
                 {{ loadingAction() ? 'Salvando...' : 'Criar' }}
               </button>
             </div>
           </form>
-        </div>
+        </app-sonic-modal>
       </div>
     }
 
@@ -113,40 +114,41 @@
     @if (showEditModal()) {
       <div class="modal-overlay" @backdropAnim (click)="showEditModal.set(false)"></div>
       <div class="modal-center" @modalAnim>
-        <div class="modal-card card" (click)="$event.stopPropagation()">
-          <h3 class="modal-title">Editar — {{ selectedUser()?.email }}</h3>
+        <app-sonic-modal title="Editar Usuário" [subtitle]="selectedUser()?.email ?? ''" (closed)="showEditModal.set(false)">
           <form [formGroup]="editForm" (ngSubmit)="onUpdateUser()">
-            <div class="field" style="margin-bottom: 14px">
-              <label class="field-label">Nome *</label>
-              <input type="text" formControlName="name" class="input" />
-            </div>
-            <div class="field" style="margin-bottom: 16px">
-              <label class="field-label">Roles</label>
-              <div class="roles-edit">
-                @for (role of availableRoles; track role.id) {
-                  <label class="role-check">
-                    <input
-                      type="checkbox"
-                      [checked]="selectedUser()?.roles?.includes(role.name)"
-                      (change)="onRoleToggle(role.id, role.name, $event)"
-                      [disabled]="loadingAction()"
-                    />
-                    {{ role.name }}
-                  </label>
-                }
+            <div class="modal-form">
+              <div class="field">
+                <label class="field-label">Nome *</label>
+                <input type="text" formControlName="name" class="input" />
               </div>
+              <div class="field">
+                <label class="field-label">Roles</label>
+                <div class="roles-edit">
+                  @for (role of availableRoles; track role.id) {
+                    <label class="role-check">
+                      <input
+                        type="checkbox"
+                        [checked]="selectedUser()?.roles?.includes(role.name)"
+                        (change)="onRoleToggle(role.id, role.name, $event)"
+                        [disabled]="loadingAction()"
+                      />
+                      {{ role.name }}
+                    </label>
+                  }
+                </div>
+              </div>
+              @if (editError()) {
+                <div class="form-error">{{ editError() }}</div>
+              }
             </div>
-            @if (editError()) {
-              <div class="form-error">{{ editError() }}</div>
-            }
             <div class="modal-footer">
-              <button type="button" class="btn btn-secondary" (click)="showEditModal.set(false)">Cancelar</button>
-              <button type="submit" class="btn btn-primary" [disabled]="loadingAction()">
+              <button type="button" class="btn btn-ghost btn-sm" (click)="showEditModal.set(false)">Cancelar</button>
+              <button type="submit" class="btn btn-primary btn-sm" [disabled]="loadingAction()">
                 {{ loadingAction() ? 'Salvando...' : 'Salvar' }}
               </button>
             </div>
           </form>
-        </div>
+        </app-sonic-modal>
       </div>
     }
 
@@ -154,24 +156,25 @@
     @if (showResetModal()) {
       <div class="modal-overlay" @backdropAnim (click)="showResetModal.set(false)"></div>
       <div class="modal-center" @modalAnim>
-        <div class="modal-card card" (click)="$event.stopPropagation()">
-          <h3 class="modal-title">Resetar senha — {{ selectedUser()?.name }}</h3>
+        <app-sonic-modal title="Resetar Senha" [subtitle]="selectedUser()?.name ?? ''" (closed)="showResetModal.set(false)">
           <form [formGroup]="resetForm" (ngSubmit)="onResetPassword()">
-            <div class="field" style="margin-bottom: 16px">
-              <label class="field-label">Nova senha *</label>
-              <input type="password" formControlName="newPassword" class="input" placeholder="Mínimo 8 caracteres" />
+            <div class="modal-form">
+              <div class="field">
+                <label class="field-label">Nova senha *</label>
+                <input type="password" formControlName="newPassword" class="input" placeholder="Mínimo 8 caracteres" />
+              </div>
+              @if (resetError()) {
+                <div class="form-error">{{ resetError() }}</div>
+              }
             </div>
-            @if (resetError()) {
-              <div class="form-error">{{ resetError() }}</div>
-            }
             <div class="modal-footer">
-              <button type="button" class="btn btn-secondary" (click)="showResetModal.set(false)">Cancelar</button>
-              <button type="submit" class="btn btn-primary" [disabled]="loadingAction()">
+              <button type="button" class="btn btn-ghost btn-sm" (click)="showResetModal.set(false)">Cancelar</button>
+              <button type="submit" class="btn btn-primary btn-sm" [disabled]="loadingAction()">
                 {{ loadingAction() ? 'Salvando...' : 'Salvar' }}
               </button>
             </div>
           </form>
-        </div>
+        </app-sonic-modal>
       </div>
     }
   }

--- a/personal-finance/src/app/features/config/components/admin-users/admin-users.component.ts
+++ b/personal-finance/src/app/features/config/components/admin-users/admin-users.component.ts
@@ -5,6 +5,7 @@ import { animate, style, transition, trigger } from '@angular/animations';
 import { ApiService } from '../../../../core/services/api.service';
 import { HeaderComponent } from '../../../../shared/components/header/header.component';
 import { PaginationComponent } from '../../../../shared/components/pagination/pagination.component';
+import { SonicModalComponent } from '../../../../shared/components/modal/sonic-modal/sonic-modal.component';
 import { AdminUserResponse } from '../../../../core/models/models';
 
 const AVAILABLE_ROLES = [
@@ -15,7 +16,7 @@ const AVAILABLE_ROLES = [
 @Component({
   selector: 'app-admin-users',
   standalone: true,
-  imports: [HeaderComponent, ReactiveFormsModule, FormsModule, PaginationComponent],
+  imports: [HeaderComponent, ReactiveFormsModule, FormsModule, PaginationComponent, SonicModalComponent],
   templateUrl: './admin-users.component.html',
   styleUrls: ['./admin-users.component.css'],
   animations: [

--- a/personal-finance/src/app/features/config/components/config/config.component.css
+++ b/personal-finance/src/app/features/config/components/config/config.component.css
@@ -1,58 +1,152 @@
-.page-content { padding: 28px; display: flex; flex-direction: column; gap: 20px; }
-
-.tabs { display: flex; gap: 4px; border-bottom: 1px solid var(--border); }
-.tab {
-  padding: 10px 16px; border: none; background: none;
-  color: var(--ink3); font-size: 0.875rem; font-weight: 500;
-  cursor: pointer; border-bottom: 2px solid transparent;
-  margin-bottom: -1px; transition: all var(--transition);
+.page-content {
+  padding: var(--density-padding, 28px);
+  display: flex;
+  flex-direction: column;
+  gap: var(--density-gap, 24px);
+  flex: 1;
 }
-.tab:hover  { color: var(--ink); }
+
+/* ── Tabs ── */
+.tabs {
+  display: flex;
+  gap: 2px;
+  border-bottom: 1px solid var(--v2-border);
+}
+
+.tab {
+  padding: 10px 18px;
+  border: none;
+  background: none;
+  color: var(--text-subtle);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  letter-spacing: 0.01em;
+  transition: var(--t);
+}
+
+.tab:hover  { color: var(--text); }
 .tab.active { color: var(--terracotta); border-bottom-color: var(--terracotta); }
 
+/* ── Section header ── */
 .section-header {
-  display: flex; align-items: center;
+  display: flex;
+  align-items: center;
   justify-content: space-between;
 }
 
-.form-card { padding: 20px; }
-.form-row {
-  display: flex; align-items: flex-end;
-  gap: 16px; flex-wrap: wrap;
+.section-title {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-subtle);
 }
-.field { display: flex; flex-direction: column; gap: 6px; min-width: 160px; }
+
+/* ── Form card ── */
+.form-card {
+  background: var(--v2-surface);
+  backdrop-filter: blur(24px);
+  border-radius: var(--v2-radius);
+  border: 1px solid var(--v2-border);
+  box-shadow: var(--v2-shadow);
+  padding: 20px 24px;
+  animation: fadeUp 0.35s var(--ease) both;
+}
+
+.form-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 160px;
+}
+
 .field-wide { flex: 1; min-width: 240px; }
-.field-label { font-size: 0.875rem; font-weight: 500; color: var(--ink2); }
-.form-actions { display: flex; gap: 8px; align-items: flex-end; padding-bottom: 1px; }
+
+.field-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-subtle);
+}
+
+.form-actions {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+  padding-bottom: 1px;
+}
 
 .form-error {
-  margin-top: 12px; padding: 10px 14px;
-  background: var(--color-danger-bg); color: var(--color-danger);
-  border-radius: var(--radius); font-size: 0.875rem;
+  margin-top: 12px;
+  padding: 10px 14px;
+  background: var(--color-danger-bg);
+  color: var(--color-danger);
+  border-radius: var(--v2-radius-sm);
+  font-size: 0.8125rem;
 }
 
-.color-input-wrap { display: flex; gap: 8px; align-items: center; }
-.color-picker { width: 40px; height: 40px; padding: 2px; border: 1px solid var(--border); border-radius: var(--radius); cursor: pointer; }
+.color-input-wrap {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
 
+.color-picker {
+  width: 40px;
+  height: 36px;
+  padding: 2px;
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius-sm);
+  cursor: pointer;
+  background: var(--v2-surface);
+}
+
+/* ── Categories grid ── */
 .categories-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
   gap: 12px;
 }
 
 .category-card {
-  display: flex; align-items: center; gap: 12px;
-  padding: 12px 16px;
+  background: var(--v2-surface);
+  backdrop-filter: blur(24px);
+  border-radius: var(--v2-radius);
+  border: 1px solid var(--v2-border);
+  box-shadow: var(--v2-shadow);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  animation: fadeUp 0.4s var(--ease) both;
+  transition: var(--t);
+}
+
+.category-card:hover {
+  border-color: color-mix(in srgb, var(--terracotta) 30%, var(--v2-border));
 }
 
 .category-color {
-  width: 32px; height: 32px;
-  border-radius: 4px; flex-shrink: 0;
+  width: 34px;
+  height: 34px;
+  border-radius: var(--v2-radius-sm);
+  flex-shrink: 0;
 }
 
 .category-icon-container {
-  width: 32px;
-  height: 32px;
+  width: 34px;
+  height: 34px;
   display: inline-flex;
   padding-left: 5px;
   padding-top: 5px;
@@ -65,82 +159,126 @@
 }
 
 .category-info {
-  flex: 1; display: flex; flex-direction: column; gap: 2px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
 }
 
-.category-name { font-size: 0.875rem; font-weight: 500; color: var(--ink); }
+.category-name {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 
-.lookup-list { overflow: hidden; }
+/* ── Card actions ── */
+.card-actions {
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.action-btn {
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--v2-border);
+  background: var(--v2-surface);
+  border-radius: var(--v2-radius-sm);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: var(--t);
+  color: var(--text-subtle);
+}
+
+.action-edit:hover   { border-color: var(--amber);      background: color-mix(in srgb, var(--amber) 12%, transparent);      color: var(--amber); }
+.action-danger:hover { border-color: var(--terracotta); background: color-mix(in srgb, var(--terracotta) 12%, transparent); color: var(--terracotta); }
+
+/* ── Lookup list ── */
+.lookup-list {
+  background: var(--v2-surface);
+  backdrop-filter: blur(24px);
+  border-radius: var(--v2-radius);
+  border: 1px solid var(--v2-border);
+  box-shadow: var(--v2-shadow);
+  overflow: hidden;
+  animation: fadeUp 0.4s var(--ease) both;
+}
 
 .lookup-item {
-  display: flex; align-items: center;
+  display: flex;
+  align-items: center;
   justify-content: space-between;
-  padding: 12px 20px;
-  border-bottom: 1px solid var(--bg3);
+  padding: 13px 20px;
+  border-bottom: 1px solid var(--v2-border);
+  transition: var(--t);
 }
 
 .lookup-item:last-child { border-bottom: none; }
+.lookup-item:hover { background: color-mix(in srgb, var(--terracotta) 4%, transparent); }
 
-.lookup-info { display: flex; flex-direction: column; gap: 2px; }
-.lookup-name { font-size: 0.875rem; font-weight: 500; color: var(--ink); }
-.lookup-desc { font-size: 0.8125rem; color: var(--ink3); }
-
-.card-actions { display: flex; gap: 6px; align-items: center; }
-
-.action-btn {
-  width: 28px; height: 28px; border: 1px solid var(--border);
-  background: none; border-radius: var(--radius-sm);
-  cursor: pointer; font-size: 12px;
-  display: flex; align-items: center; justify-content: center;
-  transition: all var(--transition);
-  color: var(--terracotta);
+.lookup-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
-.action-edit:hover  { background: var(--bg2); border-color: var(--ink3); color: var(--ink); }
-.action-danger:hover { background: var(--color-danger-bg); border-color: var(--rust); color: var(--rust); }
 
+.lookup-name { font-size: 0.875rem; font-weight: 500; color: var(--text); }
+.lookup-desc { font-size: 0.75rem; color: var(--text-subtle); }
+
+/* ── Modal overlay ── */
 .modal-overlay {
-  position: fixed; inset: 0;
-  background: rgba(0,0,0,0.45);
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
   z-index: 100;
 }
 
 .modal-center {
-  position: fixed; inset: 0;
-  display: flex; align-items: center; justify-content: center;
-  z-index: 101; pointer-events: none;
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 101;
+  pointer-events: none;
 }
 
 .modal-center > * { pointer-events: all; }
 
+/* ── Modal form ── */
 .modal-form { display: flex; flex-direction: column; gap: 0; }
 
 .form-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 16px;
+  gap: 14px;
   padding: 20px 24px;
 }
 
 .field-full { grid-column: 1 / -1; }
 
 .modal-footer {
-  display: flex; justify-content: flex-end; gap: 8px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
   padding: 16px 24px;
-  border-top: 1px solid var(--border);
+  border-top: 1px solid var(--v2-border);
 }
 
-/* ── Responsividade mobile ── */
+/* ── Responsive ── */
 @media (max-width: 767px) {
   .page-content { padding: 16px; gap: 16px; }
-
   .tabs { flex-wrap: wrap; }
   .tab { padding: 8px 12px; font-size: 0.8125rem; }
-
-  .form-row { flex-direction: column; }
-  .field, .field-wide { min-width: unset; width: 100%; }
-
+  .form-row { flex-direction: column; align-items: stretch; }
+  .field, .field-wide { min-width: 0; width: 100%; }
   .categories-grid { grid-template-columns: 1fr; }
-
   .form-grid { grid-template-columns: 1fr; }
   .field-full { grid-column: span 1; }
 }

--- a/personal-finance/src/app/features/config/components/config/config.component.html
+++ b/personal-finance/src/app/features/config/components/config/config.component.html
@@ -20,7 +20,7 @@
     </div>
 
     @if (showCatForm()) {
-      <div class="card form-card">
+      <div class="form-card">
         <form [formGroup]="catForm" (ngSubmit)="onCreateCategory()">
           <div class="form-row">
             <div class="field">
@@ -53,7 +53,7 @@
 
     <div class="categories-grid">
       @for (cat of categories(); track cat.id) {
-        <div class="category-card card">
+        <div class="category-card">
           <div class="category-color" [style.background]="cat.color">
             @if(cat.icon)
             {
@@ -98,7 +98,7 @@
     </div>
 
     @if (showPayForm() && auth.isAdmin()) {
-      <div class="card form-card">
+      <div class="form-card">
         <form [formGroup]="payForm" (ngSubmit)="onCreatePaymentStatus()">
           <div class="form-row">
             <div class="field">
@@ -117,7 +117,7 @@
       </div>
     }
 
-    <div class="lookup-list card">
+    <div class="lookup-list">
       @for (item of paymentStatuses(); track item.id) {
         <div class="lookup-item">
           <div class="lookup-info">
@@ -157,7 +157,7 @@
     </div>
 
     @if (showSrcForm() && auth.isAdmin()) {
-      <div class="card form-card">
+      <div class="form-card">
         <form [formGroup]="srcForm" (ngSubmit)="onCreateSourceType()">
           <div class="form-row">
             <div class="field field-wide">
@@ -172,7 +172,7 @@
       </div>
     }
 
-    <div class="lookup-list card">
+    <div class="lookup-list">
       @for (item of sourceTypes(); track item.id) {
         <div class="lookup-item">
           <span class="lookup-name">{{ item.name }}</span>
@@ -207,7 +207,7 @@
     </div>
 
     @if (showFnForm() && auth.isAdmin()) {
-      <div class="card form-card">
+      <div class="form-card">
         <form [formGroup]="fnForm" (ngSubmit)="onCreateFortnightType()">
           <div class="form-row">
             <div class="field field-wide">
@@ -222,7 +222,7 @@
       </div>
     }
 
-    <div class="lookup-list card">
+    <div class="lookup-list">
       @for (item of fortnightTypes(); track item.id) {
         <div class="lookup-item">
           <span class="lookup-name">{{ item.name }}</span>

--- a/src/PersonalFinance.Api/Controllers/HealthController.cs
+++ b/src/PersonalFinance.Api/Controllers/HealthController.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace PersonalFinance.Api.Controllers;
+
+[ApiController]
+[AllowAnonymous]
+[Route("health")]
+public class HealthController : ControllerBase
+{
+    [HttpGet]
+    public IActionResult Get() =>
+        Ok(new { status = "healthy", timestamp = DateTime.UtcNow });
+}


### PR DESCRIPTION
## Resumo

- **#131** — Design system v2 na tela de Configurações: tabs, cards de categoria, listas de lookup e form-cards com `--v2-surface`, `backdrop-filter`, `--v2-border`, `--v2-shadow` e animações `fadeUp`
- **#132** — Design system v2 na tela de Usuários (Admin): filters-bar, table-wrap e tabela com variáveis v2; modais de criar/editar/reset senha migrados de raw card para `app-sonic-modal`
- **#187** — Endpoint `GET /health` no backend (`HealthController`, `[AllowAnonymous]`, rota `/health`) para health check no Render

Closes #131
Closes #132
Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)