### PR TITLE
feat(#221): animação de dano do Sonic ao marcar despesa como paga

### DIFF
--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.html
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.html
@@ -1,3 +1,7 @@
+@for (b of bursts(); track b.id) {
+  <app-sonic-ring-burst [origin]="b.origin" (done)="removeBurst(b.id)" />
+}
+
 <app-header title="Despesas" subtitle="Gerencie seus lançamentos de despesas">
   <button class="btn btn-primary btn-sm" (click)="openCreateModal()">
     + Nova despesa
@@ -190,7 +194,7 @@
               <td>
                 <div class="row-actions">
                   @if (expense.paymentStatus === PaymentStatus.Pending || expense.paymentStatus === PaymentStatus.Partial) {
-                    <button class="action-btn action-success" (click)="markAsPaid(expense)" title="Marcar como pago">
+                    <button class="action-btn action-success" (click)="markAsPaid($event, expense)" title="Marcar como pago">
                       ✓
                     </button>
                   }

--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.spec.ts
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.spec.ts
@@ -143,16 +143,35 @@ describe('ExpensesComponent', () => {
   });
 
   describe('markAsPaid()', () => {
+    const mockEvent = (left = 0, top = 0, width = 28, height = 28) =>
+      ({ currentTarget: { getBoundingClientRect: () => ({ left, top, width, height }) } } as unknown as MouseEvent);
+
     it('atualiza paymentStatus para Paid na lista', fakeAsync(() => {
       component.expenses.set([EXPENSE]);
       apiSpy.markExpenseAsPaid.and.returnValue(of(undefined));
 
-      component.markAsPaid(EXPENSE);
+      component.markAsPaid(mockEvent(), EXPENSE);
       tick();
 
       const updated = component.expenses().find(e => e.id === 'e-1');
       expect(updated?.paymentStatus).toBe(PaymentStatus.Paid);
     }));
+
+    it('adiciona burst ao signal bursts', () => {
+      apiSpy.markExpenseAsPaid.and.returnValue(of(undefined));
+      component.markAsPaid(mockEvent(100, 200, 28, 28), EXPENSE);
+      expect(component.bursts().length).toBe(1);
+      expect(component.bursts()[0].origin.x).toBe(114);
+      expect(component.bursts()[0].origin.y).toBe(214);
+    });
+  });
+
+  describe('removeBurst()', () => {
+    it('remove burst do signal pelo id', () => {
+      component.bursts.set([{ id: 1, origin: { x: 100, y: 200 } }]);
+      component.removeBurst(1);
+      expect(component.bursts().length).toBe(0);
+    });
   });
 
   describe('deleteExpense()', () => {

--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.ts
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.ts
@@ -6,6 +6,7 @@ import { HeaderComponent } from '../../../../shared/components/header/header.com
 import { SonicModalComponent } from '../../../../shared/components/modal/sonic-modal/sonic-modal.component';
 import { PaginationComponent } from '../../../../shared/components/pagination/pagination.component';
 import { CurrencyBrlPipe } from '../../../../shared/pipes/currency-brl.pipe';
+import { SonicRingBurstComponent } from '../../../../shared/components/sonic-ring-burst/sonic-ring-burst.component';
 import {
   ExpenseResponse, PeriodResponse, CategoryResponse,
   MONTH_NAMES, PAYMENT_STATUS_LABELS, FORTNIGHT_TYPE_LABELS, SOURCE_TYPE_LABELS,
@@ -17,7 +18,7 @@ type SortCol = 'description' | 'category' | 'sourceType' | 'fortnightType' | 'du
 @Component({
   selector: 'app-expenses',
   standalone: true,
-  imports: [HeaderComponent, CurrencyBrlPipe, ReactiveFormsModule, SonicModalComponent, PaginationComponent],
+  imports: [HeaderComponent, CurrencyBrlPipe, ReactiveFormsModule, SonicModalComponent, PaginationComponent, SonicRingBurstComponent],
   templateUrl: './expenses.component.html',
   styleUrls: ['./expenses.component.css'],
   animations: [
@@ -95,6 +96,10 @@ export class ExpensesComponent implements OnInit {
   private _ringId = 0;
   readonly rings    = signal<{ id: number; x: number }[]>([]);
   readonly sparkles = signal<{ id: number; x: number; y: string }[]>([]);
+
+  // Sonic ring burst — animação de pagamento
+  private _burstId = 0;
+  readonly bursts = signal<{ id: number; origin: { x: number; y: number } }[]>([]);
 
   incrementAmount(): void {
     const cur = this.form.get('amount')?.value ?? 0;
@@ -418,7 +423,15 @@ export class ExpensesComponent implements OnInit {
     }
   }
 
-  markAsPaid(expense: ExpenseResponse): void {
+  markAsPaid(event: MouseEvent, expense: ExpenseResponse): void {
+    const btn  = event.currentTarget as HTMLElement;
+    const rect = btn.getBoundingClientRect();
+    const id   = ++this._burstId;
+    this.bursts.update(b => [...b, {
+      id,
+      origin: { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 },
+    }]);
+
     const today = new Date().toISOString().split('T')[0];
     this.api.markExpenseAsPaid(expense.id, { paymentDate: today }).subscribe({
       next: () => {
@@ -430,6 +443,10 @@ export class ExpensesComponent implements OnInit {
         );
       }
     });
+  }
+
+  removeBurst(id: number): void {
+    this.bursts.update(b => b.filter(x => x.id !== id));
   }
 
   deleteExpense(id: string): void {

--- a/personal-finance/src/app/shared/components/sonic-ring-burst/sonic-ring-burst.component.css
+++ b/personal-finance/src/app/shared/components/sonic-ring-burst/sonic-ring-burst.component.css
@@ -1,0 +1,12 @@
+.ring-burst-overlay {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9999;
+}
+
+.ring-burst-item {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  filter: drop-shadow(0 0 4px rgba(245, 194, 24, 0.8));
+}

--- a/personal-finance/src/app/shared/components/sonic-ring-burst/sonic-ring-burst.component.html
+++ b/personal-finance/src/app/shared/components/sonic-ring-burst/sonic-ring-burst.component.html
@@ -1,0 +1,16 @@
+<div class="ring-burst-overlay">
+  @for (ring of rings(); track ring.id) {
+    @if (ring.opacity >= 0) {
+      <img
+        class="ring-burst-item"
+        src="/ring.gif"
+        alt=""
+        [style.left.px]="ring.x"
+        [style.top.px]="ring.y"
+        [style.width.px]="ring.size"
+        [style.height.px]="ring.size"
+        [style.opacity]="ring.opacity"
+      />
+    }
+  }
+</div>

--- a/personal-finance/src/app/shared/components/sonic-ring-burst/sonic-ring-burst.component.spec.ts
+++ b/personal-finance/src/app/shared/components/sonic-ring-burst/sonic-ring-burst.component.spec.ts
@@ -1,0 +1,54 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { SonicRingBurstComponent } from './sonic-ring-burst.component';
+
+describe('SonicRingBurstComponent', () => {
+  let fixture: ComponentFixture<SonicRingBurstComponent>;
+  let component: SonicRingBurstComponent;
+  let rafCallbacks: FrameRequestCallback[];
+  let rafCounter: number;
+
+  beforeEach(() => {
+    rafCallbacks = [];
+    rafCounter = 0;
+    spyOn(window, 'requestAnimationFrame').and.callFake((cb: FrameRequestCallback) => {
+      rafCallbacks.push(cb);
+      return ++rafCounter;
+    });
+    spyOn(window, 'cancelAnimationFrame');
+  });
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SonicRingBurstComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SonicRingBurstComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('origin', { x: 100, y: 200 });
+    fixture.detectChanges();
+  });
+
+  const runFrames = (n: number) => {
+    for (let i = 0; i < n; i++) {
+      if (rafCallbacks.length > 0) {
+        rafCallbacks.shift()!(i * 16);
+      }
+    }
+  };
+
+  it('spawna 24 anéis ao inicializar', () => {
+    expect(component.rings().length).toBe(24);
+  });
+
+  it('emite done quando todos os anéis desaparecem', () => {
+    let doneFired = false;
+    component.done.subscribe(() => doneFired = true);
+    runFrames(500);
+    expect(doneFired).toBeTrue();
+  });
+
+  it('cancela o RAF no destroy', () => {
+    component.ngOnDestroy();
+    expect(window.cancelAnimationFrame).toHaveBeenCalled();
+  });
+});

--- a/personal-finance/src/app/shared/components/sonic-ring-burst/sonic-ring-burst.component.ts
+++ b/personal-finance/src/app/shared/components/sonic-ring-burst/sonic-ring-burst.component.ts
@@ -1,0 +1,112 @@
+import { Component, input, output, signal, OnInit, OnDestroy, ChangeDetectionStrategy } from '@angular/core';
+
+interface Ring {
+  id: number;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  ground: number;
+  bounces: number;
+  opacity: number;
+  blinking: boolean;
+  blinkFrame: number;
+  size: number;
+}
+
+@Component({
+  selector: 'app-sonic-ring-burst',
+  standalone: true,
+  imports: [],
+  templateUrl: './sonic-ring-burst.component.html',
+  styleUrls: ['./sonic-ring-burst.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SonicRingBurstComponent implements OnInit, OnDestroy {
+  readonly origin = input.required<{ x: number; y: number }>();
+  readonly done = output<void>();
+
+  readonly rings = signal<Ring[]>([]);
+
+  private rafId: number | null = null;
+  private readonly G = 0.32;
+  private readonly BOUNCE_AMP = 0.50;
+  private readonly FRICTION = 0.88;
+
+  ngOnInit(): void {
+    const COUNT = 24;
+    const o = this.origin();
+    this.rings.set(Array.from({ length: COUNT }, (_, i) => {
+      const pct   = i / (COUNT - 1);
+      const deg   = 200 + pct * 140;
+      const rad   = (deg * Math.PI) / 180;
+      const inner = i % 2 === 0;
+      const speed = inner ? 3 + pct * 2 : 5 + pct * 3;
+      return {
+        id: i,
+        x: o.x,
+        y: o.y,
+        vx: Math.cos(rad) * speed,
+        vy: Math.sin(rad) * speed,
+        ground: o.y + 90 + Math.random() * 60,
+        bounces: 0,
+        opacity: 1,
+        blinking: false,
+        blinkFrame: 0,
+        size: inner ? 20 : 24,
+      };
+    }));
+    this.rafId = requestAnimationFrame(() => this.step());
+  }
+
+  private blinkOpacity(f: number): number {
+    if (f < 120) { const fi = f % 40;        return fi < 20 ? 1 : 0; }
+    if (f < 180) { const fi = (f - 120) % 20; return fi < 10 ? 1 : 0; }
+    if (f < 220) { const fi = (f - 180) % 10; return fi < 5  ? 1 : 0; }
+    return -1;
+  }
+
+  private step(): void {
+    let alive = 0;
+    const updated = this.rings().map(r => {
+      if (r.opacity < 0) return r;
+      let { x, y, vx, vy, ground, bounces, opacity, blinking, blinkFrame } = r;
+
+      if (!blinking) {
+        vy += this.G;
+        x  += vx;
+        y  += vy;
+        if (y >= ground && vy > 0) {
+          y       = ground;
+          vy      = -Math.abs(vy) * this.BOUNCE_AMP;
+          vx     *= this.FRICTION;
+          bounces += 1;
+          if (bounces >= 3 || Math.abs(vy) < 1.4) {
+            blinking = true;
+            vy = 0; vx = 0; y = ground;
+          }
+        }
+        opacity = 1;
+      } else {
+        blinkFrame += 1;
+        const bop = this.blinkOpacity(blinkFrame);
+        opacity = bop < 0 ? -1 : bop;
+      }
+
+      if (opacity >= 0) alive++;
+      return { ...r, x, y, vx, vy, bounces, opacity, blinking, blinkFrame };
+    });
+
+    this.rings.set(updated);
+
+    if (alive > 0) {
+      this.rafId = requestAnimationFrame(() => this.step());
+    } else {
+      this.done.emit();
+    }
+  }
+
+  ngOnDestroy(): void {
+    if (this.rafId !== null) cancelAnimationFrame(this.rafId);
+  }
+}


### PR DESCRIPTION
Closes #221

## Resumo
- Novo `SonicRingBurstComponent` standalone com 24 anéis em arco (200°→340°), física via `requestAnimationFrame` (gravidade 0.32, bounce 0.50, fricção 0.88) e fase de blink em 3 velocidades (~3.7s total)
- `ExpensesComponent` captura `getBoundingClientRect()` do botão "Pagar" e dispara o burst; remove on `done`
- 254/254 testes passando