### PR TITLE
feat(#222): desabilitar drag-and-drop em dispositivos mobile

### DIFF
--- a/personal-finance/src/app/features/dashboard/components/dashboard/dashboard.component.html
+++ b/personal-finance/src/app/features/dashboard/components/dashboard/dashboard.component.html
@@ -87,10 +87,11 @@
       cdkDropList
       cdkDropListOrientation="mixed"
       class="widgets-grid"
+      [cdkDropListDisabled]="isMobile()"
       (cdkDropListDropped)="dropWidget($event)"
     >
       @for (widget of widgets(); track widget.id) {
-        <div class="widget-card" cdkDrag>
+        <div class="widget-card" cdkDrag [cdkDragDisabled]="isMobile()">
           <!-- Drag handle -->
           <div class="widget-drag-handle" cdkDragHandle>
             <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">

--- a/personal-finance/src/app/features/dashboard/components/dashboard/dashboard.component.spec.ts
+++ b/personal-finance/src/app/features/dashboard/components/dashboard/dashboard.component.spec.ts
@@ -133,6 +133,55 @@ describe('DashboardComponent', () => {
     }));
   });
 
+  describe('isMobile', () => {
+    let fakeQuery: { matches: boolean; listeners: Map<string, Function> };
+
+    function mockMatchMedia(matches: boolean): void {
+      fakeQuery = { matches, listeners: new Map() };
+      spyOn(window, 'matchMedia').and.returnValue({
+        matches,
+        addEventListener: (type: string, fn: Function) => fakeQuery.listeners.set(type, fn),
+        removeEventListener: (type: string, _fn: Function) => fakeQuery.listeners.delete(type),
+      } as any);
+    }
+
+    it('inicia como false quando não é mobile', () => {
+      mockMatchMedia(false);
+      fixture = TestBed.createComponent(DashboardComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+      expect(component.isMobile()).toBeFalse();
+    });
+
+    it('inicia como true quando é mobile', () => {
+      mockMatchMedia(true);
+      fixture = TestBed.createComponent(DashboardComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+      expect(component.isMobile()).toBeTrue();
+    });
+
+    it('atualiza signal ao disparar evento de mudança', fakeAsync(() => {
+      mockMatchMedia(false);
+      fixture = TestBed.createComponent(DashboardComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+      tick();
+      fakeQuery.listeners.get('change')!({ matches: true } as MediaQueryListEvent);
+      expect(component.isMobile()).toBeTrue();
+    }));
+
+    it('remove listener no ngOnDestroy', fakeAsync(() => {
+      mockMatchMedia(false);
+      fixture = TestBed.createComponent(DashboardComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+      tick();
+      component.ngOnDestroy();
+      expect(fakeQuery.listeners.has('change')).toBeFalse();
+    }));
+  });
+
   describe('computed — paymentProgress', () => {
     it('retorna 0 quando não há summary', () => {
       expect(component.paymentProgress()).toBe(0);

--- a/personal-finance/src/app/features/dashboard/components/dashboard/dashboard.component.ts
+++ b/personal-finance/src/app/features/dashboard/components/dashboard/dashboard.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal, computed, OnInit, effect, untracked } from '@angular/core';
+import { Component, inject, signal, computed, OnInit, OnDestroy, effect, untracked } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { DecimalPipe } from '@angular/common';
 import { CdkDragDrop, CdkDropList, CdkDrag, moveItemInArray } from '@angular/cdk/drag-drop';
@@ -34,10 +34,14 @@ const DEFAULT_WIDGETS: DashWidget[] = [
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.css'],
 })
-export class DashboardComponent implements OnInit {
+export class DashboardComponent implements OnInit, OnDestroy {
   private readonly api   = inject(ApiService);
   private readonly auth  = inject(AuthService);
   private readonly theme = inject(ThemeService);
+
+  private readonly mobileQuery = window.matchMedia('(max-width: 767px)');
+  readonly isMobile = signal(this.mobileQuery.matches);
+  private readonly onMobileChange = (e: MediaQueryListEvent) => this.isMobile.set(e.matches);
 
   readonly MONTH_NAMES = MONTH_NAMES;
 
@@ -96,7 +100,12 @@ export class DashboardComponent implements OnInit {
     });
   }
 
+  ngOnDestroy(): void {
+    this.mobileQuery.removeEventListener('change', this.onMobileChange);
+  }
+
   ngOnInit(): void {
+    this.mobileQuery.addEventListener('change', this.onMobileChange);
     this.api.getPeriods().subscribe({
       next: periods => {
         this.periods.set(periods);


### PR DESCRIPTION
Closes #222

## Resumo
- Signal `isMobile` via `window.matchMedia('(max-width: 767px)')` com listener de mudança e cleanup no `ngOnDestroy`
- `[cdkDropListDisabled]` e `[cdkDragDisabled]` bindados ao signal no template
- 4 novos testes cobrindo inicialização, atualização do signal e cleanup do listener