### PR TITLE
fix(#222): ajuste de responsividade para dispositivos com width <= 412px

### DIFF
--- a/personal-finance/src/app/features/dashboard/components/dashboard/dashboard.component.css
+++ b/personal-finance/src/app/features/dashboard/components/dashboard/dashboard.component.css
@@ -376,6 +376,17 @@
   .widget-card { padding: 16px; }
 }
 
+@media (max-width: 412px) {
+  .page-content { padding: 12px; gap: 12px; }
+  .kpi-card { padding: 12px 14px; }
+  .kpi-value { font-size: 18px; }
+  .widget-card { padding: 12px 14px; }
+  .widget-drag-handle { top: 10px; right: 10px; }
+  .chart-header { flex-direction: column; align-items: flex-start; gap: 8px; padding-right: 28px; }
+  .loading-state, .empty-state { padding: 40px 16px; }
+  .month-chip { padding: 6px 10px; font-size: 11px; }
+}
+
 @keyframes spin    { to { transform: rotate(360deg); } }
 @keyframes fadeUp  {
   from { opacity: 0; transform: translateY(14px); }


### PR DESCRIPTION
Closes #222

## Resumo
- Adicionado `@media (max-width: 412px)` com padding/gap reduzidos no `page-content`
- `kpi-card` e `widget-card` com padding menor
- `kpi-value` reduzido para 18px
- `chart-header` empilhado verticalmente em telas muito pequenas
- `month-chip` com padding e fonte menores
- `loading-state` / `empty-state` com padding reduzido