### PR TITLE
fix(#223): exibe ações do header no mobile via ng-deep

### DIFF
--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.css
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.css
@@ -483,8 +483,9 @@
 }
 
 @media (max-width: 568px) {
-  app-header, .period-back-link { display: none; }
+  .period-back-link { display: none; }
   .period-header-mobile { display: flex; }
+  app-header ::ng-deep .header-title { display: none; }
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
Closes #223

## Resumo
- Remove ocultação total do `app-header` no mobile
- Usa `::ng-deep .header-title` para esconder apenas o título/subtítulo
- Gif, + Despesa, + Receita e tweaks permanecem visíveis
- Mês/ano exibidos via `.period-header-mobile`