### PR TITLE
fix(#223): alinha ações à direita e aumenta espaçamento no mobile

### DIFF
--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.css
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.css
@@ -486,6 +486,7 @@
   .period-back-link { display: none; }
   .period-header-mobile { display: flex; }
   app-header ::ng-deep .header-title { display: none; }
+  app-header ::ng-deep .header-actions { margin-left: auto; gap: 16px; }
 }
 
 @media (max-width: 480px) {


### PR DESCRIPTION
Closes #223

## Resumo
- `margin-left: auto` nas `.header-actions` para empurrar à direita
- `gap: 16px` (era 8px) entre os ícones no mobile ≤568px