### PR TITLE
feat(#223): responsividade mobile no period-detail

### DIFF
--- a/personal-finance/angular.json
+++ b/personal-finance/angular.json
@@ -44,8 +44,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "4kB",
-                  "maximumError": "8kB"
+                  "maximumWarning": "6kB",
+                  "maximumError": "10kB"
                 }
               ],
               "outputHashing": "all",

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.css
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.css
@@ -486,6 +486,7 @@
   .period-back-link { display: none; }
   .period-header-mobile { display: flex; }
   app-header ::ng-deep .header-title { display: none; }
+  app-header ::ng-deep .header-actions { margin-left: auto; gap: 16px; }
 }
 
 @media (max-width: 480px) {

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.css
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.css
@@ -483,8 +483,9 @@
 }
 
 @media (max-width: 568px) {
-  app-header, .period-back-link { display: none; }
+  .period-back-link { display: none; }
   .period-header-mobile { display: flex; }
+  app-header ::ng-deep .header-title { display: none; }
 }
 
 @media (max-width: 480px) {

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.css
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.css
@@ -434,6 +434,32 @@
 
 @keyframes spin { to { transform: rotate(360deg); } }
 
+/* ── Header mobile alternativo ── */
+.period-header-mobile {
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 18px 16px 8px;
+  line-height: 1.1;
+}
+
+.period-header-mobile .month-abbr {
+  font-family: var(--font-d);
+  font-size: 2rem;
+  font-weight: 600;
+  color: var(--text);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.period-header-mobile .year {
+  font-family: var(--font-b);
+  font-size: 0.875rem;
+  color: var(--text-subtle);
+  font-weight: 500;
+}
+
 /* ── Responsividade ── */
 @media (max-width: 1100px) {
   .summary-bar { grid-template-columns: repeat(3, 1fr); }
@@ -454,6 +480,11 @@
   .category-dot-wrap    { display: inline-flex; }
   .category-name-desktop { display: none; }
   td:has(.category-dot-wrap) { text-align: center; }
+}
+
+@media (max-width: 568px) {
+  app-header, .period-back-link { display: none; }
+  .period-header-mobile { display: flex; }
 }
 
 @media (max-width: 480px) {

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.html
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.html
@@ -7,10 +7,15 @@
     <img class="pswitch-icon" src="icons/readonly-indicator.png" width="22" height="22" alt="Somente leitura" />
     <span class="readonly-tooltip">Tela apenas para consulta/visualização</span>
   </span>
-  <a routerLink="/periods" class="btn btn-secondary btn-sm">← Períodos</a>
+  <a routerLink="/periods" class="btn btn-secondary btn-sm period-back-link">← Períodos</a>
   <a routerLink="/expenses" class="btn btn-primary btn-sm">+ Despesa</a>
   <a routerLink="/incomes" class="btn btn-ghost btn-sm">+ Receita</a>
 </app-header>
+
+<div class="period-header-mobile">
+  <span class="month-abbr">{{ monthAbbr() }}</span>
+  <span class="year">{{ year() }}</span>
+</div>
 
 <div class="page-content">
   @if (loading()) {

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.spec.ts
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.spec.ts
@@ -122,6 +122,44 @@ describe('PeriodDetailComponent', () => {
     }));
   });
 
+  describe('monthAbbr computed', () => {
+    it('retorna string vazia sem summary', () => {
+      expect(component.monthAbbr()).toBe('');
+    });
+
+    it('retorna "Abr" para mês 4', fakeAsync(() => {
+      fixture.detectChanges();
+      tick();
+      expect(component.monthAbbr()).toBe('Abr');
+    }));
+
+    it('retorna "Dez" para mês 12', fakeAsync(() => {
+      apiSpy.getPeriodSummary.and.returnValue(of({ ...SUMMARY, month: 12 }));
+      fixture.detectChanges();
+      tick();
+      expect(component.monthAbbr()).toBe('Dez');
+    }));
+
+    it('retorna "Jan" para mês 1', fakeAsync(() => {
+      apiSpy.getPeriodSummary.and.returnValue(of({ ...SUMMARY, month: 1 }));
+      fixture.detectChanges();
+      tick();
+      expect(component.monthAbbr()).toBe('Jan');
+    }));
+  });
+
+  describe('year computed', () => {
+    it('retorna null sem summary', () => {
+      expect(component.year()).toBeNull();
+    });
+
+    it('retorna o ano do summary', fakeAsync(() => {
+      fixture.detectChanges();
+      tick();
+      expect(component.year()).toBe(2024);
+    }));
+  });
+
   describe('openMario()', () => {
     beforeEach(fakeAsync(() => {
       fixture.detectChanges();

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.ts
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.ts
@@ -143,6 +143,14 @@ export class PeriodDetailComponent implements OnInit {
     return `${MONTH_NAMES[s.month - 1]} ${s.year}`;
   });
 
+  readonly monthAbbr = computed(() => {
+    const s = this.summary();
+    if (!s) return '';
+    return MONTH_NAMES[s.month - 1].slice(0, 3);
+  });
+
+  readonly year = computed(() => this.summary()?.year ?? null);
+
   // Exposição de enums para o template
   readonly PaymentStatus  = PaymentStatus;
   readonly FortnightType  = FortnightType;


### PR DESCRIPTION
Closes #223

## Resumo
- Header mobile alternativo com mês abreviado e ano (≤568px)
- Oculta título/subtítulo do header via `::ng-deep` — gif, botões de ação e tweaks permanecem visíveis
- Ações alinhadas à direita com `gap` aumentado no mobile
- Budget `anyComponentStyle` ajustado para 10kB
- Testes de `monthAbbr()` e `year()` adicionados