### PR TITLE
fix(#224): responsividade modal Diálogo Mario

### DIFF
--- a/personal-finance/src/app/shared/components/modal/mario-modal/mario-modal.component.css
+++ b/personal-finance/src/app/shared/components/modal/mario-modal/mario-modal.component.css
@@ -92,8 +92,7 @@
   .mario-box {
     min-width: 0;
     width: calc(100vw - 32px);
-    height: auto;
-    min-height: 280px;
+    height: 360px;
     font-size: 0.55rem;
     padding: 20px 20px 56px;
   }


### PR DESCRIPTION
Closes #224

## Summary
- Substitui `height: auto; min-height: 280px` por `height: 360px` fixo no breakpoint `@media (max-width: 560px)` do `.mario-box`

## Test plan
- [ ] Verificar em viewport 360×640 que o modal mantém altura fixa sem expandir
- [ ] Verificar em viewport 320×568
- [ ] Verificar que desktop (>560px) não foi afetado

🤖 Generated with [Claude Code](https://claude.com/claude-code)