### PR TITLE
feat(#240): FilterModalComponent reutilizável + refatoração de filtros (Despesas e Receitas)

### DIFF
--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.css
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.css
@@ -36,53 +36,12 @@
 }
 
 /* ── Filtros externos ── */
-.external-filters {
-  background: var(--v2-surface);
-  backdrop-filter: blur(24px);
-  border-radius: var(--v2-radius);
-  border: 1px solid var(--v2-border);
-  box-shadow: var(--v2-shadow);
-  padding: 18px 20px;
+.filter-bar {
   display: flex;
   flex-direction: column;
-  gap: 14px;
-  animation: fadeUp 0.5s var(--ease) both;
+  gap: 10px;
 }
 
-.filters-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 12px;
-}
-
-.filter-field {
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
-}
-
-.filter-field .field-label {
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--text-subtle);
-}
-
-.input-sm {
-  height: 32px;
-  padding: 0 10px;
-  font-size: 0.8125rem;
-  border-radius: var(--v2-radius-sm);
-  border: 1px solid var(--v2-border);
-  background: var(--v2-surface);
-  color: var(--text-muted);
-  outline: none;
-  transition: var(--t);
-  backdrop-filter: blur(24px);
-}
-
-.input-sm:focus { border-color: var(--terracotta); color: var(--text); }
 
 .btn-clear-filters {
   align-self: flex-start;
@@ -348,8 +307,6 @@
 
   .filter-row { flex-wrap: wrap; }
   .period-select { width: 100%; min-width: unset; }
-
-  .filters-grid { grid-template-columns: 1fr; }
 
   .col-hide-mobile { display: none; }
 

--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.html
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.html
@@ -23,61 +23,17 @@
 
   <!-- Filtros externos (server-side) — visíveis apenas quando há período selecionado -->
   @if (selectedPeriodId) {
-    <div class="external-filters card">
-      <div class="filters-grid">
-        <div class="filter-field">
-          <label class="field-label">Descrição</label>
-          <input
-            class="input input-sm"
-            placeholder="Buscar..."
-            [value]="filterDescription()"
-            (input)="onFilterDescriptionChange($event)"
-          />
-        </div>
-
-        <div class="filter-field">
-          <label class="field-label">Categoria</label>
-          <select class="input input-sm" (change)="onFilterCategoryChange($event)">
-            <option value="">Todas</option>
-            @for (c of categories(); track c.id) {
-              <option [value]="c.id">{{ c.name }}</option>
-            }
-          </select>
-        </div>
-
-        <div class="filter-field">
-          <label class="field-label">Fonte</label>
-          <select class="input input-sm" (change)="onFilterSourceTypeChange($event)">
-            <option value="">Todas</option>
-            <option [value]="SourceType.Parental">Parental</option>
-            <option [value]="SourceType.Personal">Própria</option>
-          </select>
-        </div>
-
-        <div class="filter-field">
-          <label class="field-label">Status</label>
-          <select class="input input-sm" (change)="onFilterStatusChange($event)">
-            <option value="">Todos</option>
-            <option [value]="PaymentStatus.Pending">Pendente</option>
-            <option [value]="PaymentStatus.Paid">Pago</option>
-            <option [value]="PaymentStatus.Partial">Parcial</option>
-            <option [value]="PaymentStatus.Cancelled">Cancelado</option>
-          </select>
-        </div>
-
-        <div class="filter-field">
-          <label class="field-label">Quinzena</label>
-          <select class="input input-sm" (change)="onFilterFortnightChange($event)">
-            <option value="">Ambas</option>
-            <option [value]="FortnightType.First">1ª Quinzena</option>
-            <option [value]="FortnightType.Second">2ª Quinzena</option>
-          </select>
-        </div>
-      </div>
-
-      @if (hasActiveFilters()) {
-        <button class="btn-clear-filters" (click)="clearFilters()">Limpar filtros</button>
-      }
+    <div class="filter-bar">
+      <app-filter-button
+        [activeCount]="activeFilterCount()"
+        (toggled)="filterOpen.update(v => !v)"
+      />
+      <app-filter-modal
+        [fields]="filterFields()"
+        [open]="filterOpen()"
+        (apply)="onApplyFilters($event)"
+        (clear)="onClearFilters()"
+      />
     </div>
   }
 

--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.spec.ts
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.spec.ts
@@ -310,6 +310,67 @@ describe('ExpensesComponent', () => {
     });
   });
 
+  describe('filtros — onApplyFilters()', () => {
+    beforeEach(() => { (component as any).selectedPeriodId = 'p-1'; });
+
+    it('aplica description e dispara loadPage', fakeAsync(() => {
+      component.onApplyFilters({ description: 'aluguel', categoryId: '', paymentStatus: '', fortnightType: '', sourceType: '' });
+      tick();
+      expect(component.filterDescription()).toBe('aluguel');
+      expect(apiSpy.getExpensesByPeriod).toHaveBeenCalled();
+    }));
+
+    it('aplica paymentStatus numérico', fakeAsync(() => {
+      component.onApplyFilters({ description: '', categoryId: '', paymentStatus: PaymentStatus.Paid, fortnightType: '', sourceType: '' });
+      tick();
+      expect(component.filterStatus()).toBe(PaymentStatus.Paid);
+    }));
+
+    it('converte string vazia em null para campos enum', fakeAsync(() => {
+      component.onApplyFilters({ description: '', categoryId: '', paymentStatus: '', fortnightType: '', sourceType: '' });
+      tick();
+      expect(component.filterStatus()).toBeNull();
+      expect(component.filterFortnightType()).toBeNull();
+      expect(component.filterSourceType()).toBeNull();
+    }));
+
+    it('reseta currentPage para 1', fakeAsync(() => {
+      component.currentPage.set(3);
+      component.onApplyFilters({ description: '', categoryId: '', paymentStatus: '', fortnightType: '', sourceType: '' });
+      tick();
+      expect(component.currentPage()).toBe(1);
+    }));
+  });
+
+  describe('filtros — onClearFilters()', () => {
+    beforeEach(() => { (component as any).selectedPeriodId = 'p-1'; });
+
+    it('limpa todos os filtros e dispara loadPage', fakeAsync(() => {
+      component.filterDescription.set('aluguel');
+      component.filterCategoryId.set('cat-1');
+      component.filterStatus.set(PaymentStatus.Paid);
+      component.onClearFilters();
+      tick();
+      expect(component.filterDescription()).toBe('');
+      expect(component.filterCategoryId()).toBe('');
+      expect(component.filterStatus()).toBeNull();
+      expect(apiSpy.getExpensesByPeriod).toHaveBeenCalled();
+    }));
+  });
+
+  describe('activeFilterCount', () => {
+    it('retorna 0 quando nenhum filtro ativo', () => {
+      expect(component.activeFilterCount()).toBe(0);
+    });
+
+    it('conta cada filtro ativo individualmente', () => {
+      component.filterDescription.set('a');
+      component.filterCategoryId.set('cat-1');
+      component.filterStatus.set(PaymentStatus.Paid);
+      expect(component.activeFilterCount()).toBe(3);
+    });
+  });
+
   describe('helpers', () => {
     beforeEach(fakeAsync(() => { tick(); }));
 

--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.ts
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.ts
@@ -7,6 +7,9 @@ import { SonicModalComponent } from '../../../../shared/components/modal/sonic-m
 import { PaginationComponent } from '../../../../shared/components/pagination/pagination.component';
 import { CurrencyBrlPipe } from '../../../../shared/pipes/currency-brl.pipe';
 import { SonicRingBurstComponent } from '../../../../shared/components/sonic-ring-burst/sonic-ring-burst.component';
+import { FilterModalComponent } from '../../../../shared/components/filter-modal/filter-modal.component';
+import { FilterButtonComponent } from '../../../../shared/components/filter-modal/filter-button.component';
+import { FilterFieldConfig } from '../../../../shared/components/filter-modal/filter-field-config';
 import {
   ExpenseResponse, PeriodResponse, CategoryResponse,
   MONTH_NAMES, PAYMENT_STATUS_LABELS, FORTNIGHT_TYPE_LABELS, SOURCE_TYPE_LABELS,
@@ -18,7 +21,7 @@ type SortCol = 'description' | 'category' | 'sourceType' | 'fortnightType' | 'du
 @Component({
   selector: 'app-expenses',
   standalone: true,
-  imports: [HeaderComponent, CurrencyBrlPipe, ReactiveFormsModule, SonicModalComponent, PaginationComponent, SonicRingBurstComponent],
+  imports: [HeaderComponent, CurrencyBrlPipe, ReactiveFormsModule, SonicModalComponent, PaginationComponent, SonicRingBurstComponent, FilterModalComponent, FilterButtonComponent],
   templateUrl: './expenses.component.html',
   styleUrls: ['./expenses.component.css'],
   animations: [
@@ -82,9 +85,6 @@ export class ExpensesComponent implements OnInit {
   private editingId: string | null = null;
   selectedPeriodId: string | null = null;
 
-  // Debounce para busca por descrição
-  private descriptionDebounce: ReturnType<typeof setTimeout> | null = null;
-
   // Seleção em lote
   readonly selectedExpenseIds = signal<string[]>([]);
   readonly allSelected = computed(() => {
@@ -137,11 +137,31 @@ export class ExpensesComponent implements OnInit {
   readonly periodId = input<string>();
   @ViewChild('periodFilterSelect') periodFilterSelect!: ElementRef<HTMLSelectElement>;
 
-  /** Verifica se há algum filtro ativo */
-  readonly hasActiveFilters = computed(() =>
-    !!this.filterDescription() || !!this.filterCategoryId() ||
-    this.filterStatus() != null || this.filterFortnightType() != null ||
-    this.filterSourceType() != null);
+  readonly filterOpen = signal(false);
+
+  readonly activeFilterCount = computed(() =>
+    (this.filterDescription() ? 1 : 0) +
+    (this.filterCategoryId() ? 1 : 0) +
+    (this.filterStatus() != null ? 1 : 0) +
+    (this.filterFortnightType() != null ? 1 : 0) +
+    (this.filterSourceType() != null ? 1 : 0)
+  );
+
+  readonly filterFields = computed<FilterFieldConfig[]>(() => [
+    { key: 'description',   label: 'Descrição', type: 'text',   value: this.filterDescription() },
+    { key: 'categoryId',    label: 'Categoria',  type: 'select',
+      options: [{ value: '', label: 'Todas' }, ...this.categories().map(c => ({ value: c.id, label: c.name }))],
+      value: this.filterCategoryId() },
+    { key: 'sourceType',    label: 'Fonte',      type: 'select',
+      options: [{ value: '', label: 'Todas' }, { value: SourceType.Parental, label: 'Parental' }, { value: SourceType.Personal, label: 'Própria' }],
+      value: this.filterSourceType() ?? '' },
+    { key: 'paymentStatus', label: 'Status',     type: 'select',
+      options: [{ value: '', label: 'Todos' }, { value: PaymentStatus.Pending, label: 'Pendente' }, { value: PaymentStatus.Paid, label: 'Pago' }, { value: PaymentStatus.Partial, label: 'Parcial' }, { value: PaymentStatus.Cancelled, label: 'Cancelado' }],
+      value: this.filterStatus() ?? '' },
+    { key: 'fortnightType', label: 'Quinzena',   type: 'select',
+      options: [{ value: '', label: 'Ambas' }, { value: FortnightType.First, label: '1ª Quinzena' }, { value: FortnightType.Second, label: '2ª Quinzena' }],
+      value: this.filterFortnightType() ?? '' },
+  ]);
 
   /** Aplica ordenação client-side sobre os itens da página atual */
   readonly displayedExpenses = computed<ExpenseResponse[]>(() => {
@@ -273,44 +293,20 @@ export class ExpensesComponent implements OnInit {
 
   // ── Filtros externos ──────────────────────────────────────────────────────
 
-  onFilterDescriptionChange(event: Event): void {
-    const val = (event.target as HTMLInputElement).value;
-    this.filterDescription.set(val);
-    if (this.descriptionDebounce) clearTimeout(this.descriptionDebounce);
-    this.descriptionDebounce = setTimeout(() => {
-      this.currentPage.set(1);
-      this.loadPage();
-    }, 350);
-  }
-
-  onFilterCategoryChange(event: Event): void {
-    this.filterCategoryId.set((event.target as HTMLSelectElement).value);
+  onApplyFilters(values: Record<string, unknown>): void {
+    this.filterDescription.set((values['description'] as string) || '');
+    this.filterCategoryId.set((values['categoryId'] as string) || '');
+    const status = values['paymentStatus'];
+    this.filterStatus.set(status !== '' && status != null ? Number(status) as PaymentStatus : null);
+    const fortnight = values['fortnightType'];
+    this.filterFortnightType.set(fortnight !== '' && fortnight != null ? Number(fortnight) as FortnightType : null);
+    const source = values['sourceType'];
+    this.filterSourceType.set(source !== '' && source != null ? Number(source) as SourceType : null);
     this.currentPage.set(1);
     this.loadPage();
   }
 
-  onFilterStatusChange(event: Event): void {
-    const val = (event.target as HTMLSelectElement).value;
-    this.filterStatus.set(val ? Number(val) as PaymentStatus : null);
-    this.currentPage.set(1);
-    this.loadPage();
-  }
-
-  onFilterFortnightChange(event: Event): void {
-    const val = (event.target as HTMLSelectElement).value;
-    this.filterFortnightType.set(val ? Number(val) as FortnightType : null);
-    this.currentPage.set(1);
-    this.loadPage();
-  }
-
-  onFilterSourceTypeChange(event: Event): void {
-    const val = (event.target as HTMLSelectElement).value;
-    this.filterSourceType.set(val ? Number(val) as SourceType : null);
-    this.currentPage.set(1);
-    this.loadPage();
-  }
-
-  clearFilters(): void {
+  onClearFilters(): void {
     this.filterDescription.set('');
     this.filterCategoryId.set('');
     this.filterStatus.set(null);

--- a/personal-finance/src/app/features/incomes/components/incomes/incomes.component.css
+++ b/personal-finance/src/app/features/incomes/components/incomes/incomes.component.css
@@ -36,67 +36,11 @@
 }
 
 /* ── Filtros externos ── */
-.external-filters {
-  background: var(--v2-surface);
-  backdrop-filter: blur(24px);
-  border-radius: var(--v2-radius);
-  border: 1px solid var(--v2-border);
-  box-shadow: var(--v2-shadow);
-  padding: 18px 20px;
+.filter-bar {
   display: flex;
   flex-direction: column;
-  gap: 14px;
-  animation: fadeUp 0.5s var(--ease) both;
+  gap: 10px;
 }
-
-.filters-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 12px;
-}
-
-.filter-field {
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
-}
-
-.filter-field .field-label {
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--text-subtle);
-}
-
-.input-sm {
-  height: 32px;
-  padding: 0 10px;
-  font-size: 0.8125rem;
-  border-radius: var(--v2-radius-sm);
-  border: 1px solid var(--v2-border);
-  background: var(--v2-surface);
-  color: var(--text-muted);
-  outline: none;
-  transition: var(--t);
-  backdrop-filter: blur(24px);
-}
-
-.input-sm:focus { border-color: var(--terracotta); color: var(--text); }
-
-.btn-clear-filters {
-  align-self: flex-start;
-  background: none;
-  border: none;
-  color: var(--terracotta);
-  font-size: 0.8125rem;
-  cursor: pointer;
-  padding: 0;
-  text-decoration: underline;
-  transition: var(--t);
-}
-
-.btn-clear-filters:hover { opacity: 0.75; }
 
 /* ── Tabela ── */
 .table-wrap {
@@ -252,8 +196,6 @@
 
   .filter-row { flex-wrap: wrap; }
   .period-select { width: 100%; min-width: unset; }
-
-  .filters-grid { grid-template-columns: 1fr; }
 
   .col-hide-mobile { display: none; }
 

--- a/personal-finance/src/app/features/incomes/components/incomes/incomes.component.html
+++ b/personal-finance/src/app/features/incomes/components/incomes/incomes.component.html
@@ -23,31 +23,17 @@
 
   <!-- Filtros externos (server-side) — visíveis apenas quando há período selecionado -->
   @if (selectedPeriodId) {
-    <div class="external-filters card">
-      <div class="filters-grid">
-        <div class="filter-field">
-          <label class="field-label">Descrição</label>
-          <input
-            class="input input-sm"
-            placeholder="Buscar..."
-            [value]="filterDescription()"
-            (input)="onFilterDescriptionChange($event)"
-          />
-        </div>
-
-        <div class="filter-field">
-          <label class="field-label">Quinzena</label>
-          <select class="input input-sm" (change)="onFilterFortnightChange($event)">
-            <option value="">Ambas</option>
-            <option [value]="FortnightType.First">1ª Quinzena</option>
-            <option [value]="FortnightType.Second">2ª Quinzena</option>
-          </select>
-        </div>
-      </div>
-
-      @if (hasActiveFilters()) {
-        <button class="btn-clear-filters" (click)="clearFilters()">Limpar filtros</button>
-      }
+    <div class="filter-bar">
+      <app-filter-button
+        [activeCount]="activeFilterCount()"
+        (toggled)="filterOpen.update(v => !v)"
+      />
+      <app-filter-modal
+        [fields]="filterFields()"
+        [open]="filterOpen()"
+        (apply)="onApplyFilters($event)"
+        (clear)="onClearFilters()"
+      />
     </div>
   }
 

--- a/personal-finance/src/app/features/incomes/components/incomes/incomes.component.spec.ts
+++ b/personal-finance/src/app/features/incomes/components/incomes/incomes.component.spec.ts
@@ -169,6 +169,62 @@ describe('IncomesComponent', () => {
     });
   });
 
+  describe('filtros — onApplyFilters()', () => {
+    beforeEach(() => { (component as any).selectedPeriodId = 'p-1'; });
+
+    it('aplica description e dispara loadPage', fakeAsync(() => {
+      component.onApplyFilters({ description: 'salário', fortnightType: '' });
+      tick();
+      expect(component.filterDescription()).toBe('salário');
+      expect(apiSpy.getIncomesByPeriod).toHaveBeenCalled();
+    }));
+
+    it('aplica fortnightType numérico', fakeAsync(() => {
+      component.onApplyFilters({ description: '', fortnightType: FortnightType.Second });
+      tick();
+      expect(component.filterFortnightType()).toBe(FortnightType.Second);
+    }));
+
+    it('converte string vazia em null para fortnightType', fakeAsync(() => {
+      component.onApplyFilters({ description: '', fortnightType: '' });
+      tick();
+      expect(component.filterFortnightType()).toBeNull();
+    }));
+
+    it('reseta currentPage para 1', fakeAsync(() => {
+      component.currentPage.set(5);
+      component.onApplyFilters({ description: '', fortnightType: '' });
+      tick();
+      expect(component.currentPage()).toBe(1);
+    }));
+  });
+
+  describe('filtros — onClearFilters()', () => {
+    beforeEach(() => { (component as any).selectedPeriodId = 'p-1'; });
+
+    it('limpa todos os filtros e dispara loadPage', fakeAsync(() => {
+      component.filterDescription.set('salário');
+      component.filterFortnightType.set(FortnightType.First);
+      component.onClearFilters();
+      tick();
+      expect(component.filterDescription()).toBe('');
+      expect(component.filterFortnightType()).toBeNull();
+      expect(apiSpy.getIncomesByPeriod).toHaveBeenCalled();
+    }));
+  });
+
+  describe('activeFilterCount', () => {
+    it('retorna 0 quando nenhum filtro ativo', () => {
+      expect(component.activeFilterCount()).toBe(0);
+    });
+
+    it('conta description e fortnightType quando ativos', () => {
+      component.filterDescription.set('s');
+      component.filterFortnightType.set(FortnightType.First);
+      expect(component.activeFilterCount()).toBe(2);
+    });
+  });
+
   describe('formatDate()', () => {
     it('retorna data formatada em pt-BR', () => {
       const result = component.formatDate('2024-04-05T00:00:00');

--- a/personal-finance/src/app/features/incomes/components/incomes/incomes.component.ts
+++ b/personal-finance/src/app/features/incomes/components/incomes/incomes.component.ts
@@ -9,6 +9,9 @@ import { HeaderComponent } from '../../../../shared/components/header/header.com
 import { SonicModalComponent } from '../../../../shared/components/modal/sonic-modal/sonic-modal.component';
 import { PaginationComponent } from '../../../../shared/components/pagination/pagination.component';
 import { CurrencyBrlPipe } from '../../../../shared/pipes/currency-brl.pipe';
+import { FilterModalComponent } from '../../../../shared/components/filter-modal/filter-modal.component';
+import { FilterButtonComponent } from '../../../../shared/components/filter-modal/filter-button.component';
+import { FilterFieldConfig } from '../../../../shared/components/filter-modal/filter-field-config';
 import {
   IncomeResponse, PeriodResponse,
   MONTH_NAMES, FORTNIGHT_TYPE_LABELS, FortnightType
@@ -21,7 +24,7 @@ type SortCol = 'description' | 'fortnightType' | 'receivedAt' | 'amount';
   standalone: true,
   imports: [
     HeaderComponent, CurrencyBrlPipe, ReactiveFormsModule,
-    SonicModalComponent, PaginationComponent
+    SonicModalComponent, PaginationComponent, FilterModalComponent, FilterButtonComponent
   ],
   templateUrl: './incomes.component.html',
   styleUrls: ['./incomes.component.css'],
@@ -110,14 +113,23 @@ export class IncomesComponent implements OnInit {
   private editingId: string | null = null;
   selectedPeriodId: string | null = null;
 
-  private descriptionDebounce: ReturnType<typeof setTimeout> | null = null;
-
   /** Pré-seleção via query param: /incomes?periodId=xxx */
   readonly periodId = input<string>();
   @ViewChild('periodFilterSelect') periodFilterSelect!: ElementRef<HTMLSelectElement>;
 
-  readonly hasActiveFilters = computed(() =>
-    !!this.filterDescription() || this.filterFortnightType() != null);
+  readonly filterOpen = signal(false);
+
+  readonly activeFilterCount = computed(() =>
+    (this.filterDescription() ? 1 : 0) +
+    (this.filterFortnightType() != null ? 1 : 0)
+  );
+
+  readonly filterFields = computed<FilterFieldConfig[]>(() => [
+    { key: 'description',   label: 'Descrição', type: 'text',   value: this.filterDescription() },
+    { key: 'fortnightType', label: 'Quinzena',   type: 'select',
+      options: [{ value: '', label: 'Ambas' }, { value: FortnightType.First, label: '1ª Quinzena' }, { value: FortnightType.Second, label: '2ª Quinzena' }],
+      value: this.filterFortnightType() ?? '' },
+  ]);
 
   readonly displayedIncomes = computed<IncomeResponse[]>(() => {
     const col = this.sortCol();
@@ -279,24 +291,15 @@ export class IncomesComponent implements OnInit {
 
   // ── Filtros externos ──────────────────────────────────────────────────────
 
-  onFilterDescriptionChange(event: Event): void {
-    const val = (event.target as HTMLInputElement).value;
-    this.filterDescription.set(val);
-    if (this.descriptionDebounce) clearTimeout(this.descriptionDebounce);
-    this.descriptionDebounce = setTimeout(() => {
-      this.currentPage.set(1);
-      this.loadPage();
-    }, 350);
-  }
-
-  onFilterFortnightChange(event: Event): void {
-    const val = (event.target as HTMLSelectElement).value;
-    this.filterFortnightType.set(val ? Number(val) as FortnightType : null);
+  onApplyFilters(values: Record<string, unknown>): void {
+    this.filterDescription.set((values['description'] as string) || '');
+    const fortnight = values['fortnightType'];
+    this.filterFortnightType.set(fortnight !== '' && fortnight != null ? Number(fortnight) as FortnightType : null);
     this.currentPage.set(1);
     this.loadPage();
   }
 
-  clearFilters(): void {
+  onClearFilters(): void {
     this.filterDescription.set('');
     this.filterFortnightType.set(null);
     this.currentPage.set(1);

--- a/personal-finance/src/app/shared/components/filter-modal/filter-button.component.css
+++ b/personal-finance/src/app/shared/components/filter-modal/filter-button.component.css
@@ -1,0 +1,35 @@
+.filter-toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  border-radius: var(--v2-radius-sm);
+  border: 1px solid var(--v2-border);
+  background: var(--v2-surface);
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: var(--t);
+  position: relative;
+}
+
+.filter-toggle-btn:hover {
+  border-color: var(--v2-accent);
+  color: var(--v2-accent);
+}
+
+.filter-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 8px;
+  background: var(--v2-accent);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+}

--- a/personal-finance/src/app/shared/components/filter-modal/filter-button.component.html
+++ b/personal-finance/src/app/shared/components/filter-modal/filter-button.component.html
@@ -1,0 +1,11 @@
+<button class="filter-toggle-btn" type="button" (click)="toggled.emit()">
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <line x1="4" y1="6" x2="20" y2="6"/>
+    <line x1="8" y1="12" x2="16" y2="12"/>
+    <line x1="11" y1="18" x2="13" y2="18"/>
+  </svg>
+  Filtros
+  @if (activeCount() > 0) {
+    <span class="filter-badge">{{ activeCount() }}</span>
+  }
+</button>

--- a/personal-finance/src/app/shared/components/filter-modal/filter-button.component.ts
+++ b/personal-finance/src/app/shared/components/filter-modal/filter-button.component.ts
@@ -1,0 +1,12 @@
+import { Component, input, output } from '@angular/core';
+
+@Component({
+  selector: 'app-filter-button',
+  standalone: true,
+  templateUrl: './filter-button.component.html',
+  styleUrls: ['./filter-button.component.css'],
+})
+export class FilterButtonComponent {
+  readonly activeCount = input(0);
+  readonly toggled = output<void>();
+}

--- a/personal-finance/src/app/shared/components/filter-modal/filter-field-config.ts
+++ b/personal-finance/src/app/shared/components/filter-modal/filter-field-config.ts
@@ -1,0 +1,12 @@
+export interface FilterFieldOption {
+  value: unknown;
+  label: string;
+}
+
+export interface FilterFieldConfig {
+  key: string;
+  label: string;
+  type: 'text' | 'select' | 'multiSelect';
+  options?: FilterFieldOption[];
+  value?: unknown;
+}

--- a/personal-finance/src/app/shared/components/filter-modal/filter-modal.component.css
+++ b/personal-finance/src/app/shared/components/filter-modal/filter-modal.component.css
@@ -1,0 +1,52 @@
+.filter-panel {
+  background: var(--v2-surface);
+  backdrop-filter: blur(24px);
+  border-radius: var(--v2-radius);
+  border: 1px solid var(--v2-border);
+  box-shadow: var(--v2-shadow);
+  padding: 18px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.filter-fields-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.filter-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.filter-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  justify-content: flex-end;
+  padding-top: 4px;
+}
+
+.multiselect-options {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.checkbox-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+@media (max-width: 640px) {
+  .filter-fields-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/personal-finance/src/app/shared/components/filter-modal/filter-modal.component.html
+++ b/personal-finance/src/app/shared/components/filter-modal/filter-modal.component.html
@@ -1,0 +1,48 @@
+@if (open()) {
+  <div class="filter-panel" @panelAnim>
+    <div class="filter-fields-grid">
+      @for (field of fields(); track field.key) {
+        <div class="filter-field">
+          <label class="field-label">{{ field.label }}</label>
+
+          @if (field.type === 'text') {
+            <input
+              class="input input-sm"
+              [value]="getStringValue(field.key)"
+              (input)="setValue(field.key, $any($event.target).value)"
+            />
+          } @else if (field.type === 'select') {
+            <select
+              class="input input-sm"
+              (change)="setValue(field.key, $any($event.target).value)"
+            >
+              @for (opt of field.options; track opt.value) {
+                <option [value]="opt.value" [selected]="getStringValue(field.key) == opt.value">
+                  {{ opt.label }}
+                </option>
+              }
+            </select>
+          } @else if (field.type === 'multiSelect') {
+            <div class="multiselect-options">
+              @for (opt of field.options; track opt.value) {
+                <label class="checkbox-label">
+                  <input
+                    type="checkbox"
+                    [checked]="isChecked(field.key, opt.value)"
+                    (change)="toggleMultiValue(field.key, opt.value)"
+                  />
+                  {{ opt.label }}
+                </label>
+              }
+            </div>
+          }
+        </div>
+      }
+    </div>
+
+    <div class="filter-actions">
+      <button type="button" class="btn-clear-filters" (click)="onClear()">Limpar</button>
+      <button type="button" class="btn btn-primary btn-sm" (click)="onApply()">Aplicar</button>
+    </div>
+  </div>
+}

--- a/personal-finance/src/app/shared/components/filter-modal/filter-modal.component.spec.ts
+++ b/personal-finance/src/app/shared/components/filter-modal/filter-modal.component.spec.ts
@@ -1,0 +1,136 @@
+import { TestBed } from '@angular/core/testing';
+import { ComponentFixture } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { FilterModalComponent } from './filter-modal.component';
+import { FilterFieldConfig } from './filter-field-config';
+
+const TEXT_FIELD: FilterFieldConfig = { key: 'description', label: 'Descrição', type: 'text', value: '' };
+const SELECT_FIELD: FilterFieldConfig = {
+  key: 'status', label: 'Status', type: 'select',
+  options: [{ value: '', label: 'Todos' }, { value: 1, label: 'Pendente' }, { value: 2, label: 'Pago' }],
+  value: '',
+};
+const MULTI_FIELD: FilterFieldConfig = {
+  key: 'tags', label: 'Tags', type: 'multiSelect',
+  options: [{ value: 'a', label: 'A' }, { value: 'b', label: 'B' }],
+  value: [],
+};
+
+describe('FilterModalComponent', () => {
+  let fixture: ComponentFixture<FilterModalComponent>;
+  let component: FilterModalComponent;
+
+  async function setup(fields: FilterFieldConfig[], open = true): Promise<void> {
+    await TestBed.configureTestingModule({
+      imports: [FilterModalComponent, BrowserAnimationsModule],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FilterModalComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('fields', fields);
+    fixture.componentRef.setInput('open', open);
+    fixture.detectChanges();
+  }
+
+  describe('render dinâmico de campos', () => {
+    it('renderiza campo text', async () => {
+      await setup([TEXT_FIELD]);
+      const input = fixture.nativeElement.querySelector('input[type!=checkbox]');
+      expect(input).toBeTruthy();
+    });
+
+    it('renderiza campo select com opções', async () => {
+      await setup([SELECT_FIELD]);
+      const select = fixture.nativeElement.querySelector('select');
+      expect(select).toBeTruthy();
+      expect(select.querySelectorAll('option').length).toBe(3);
+    });
+
+    it('renderiza campo multiSelect com checkboxes', async () => {
+      await setup([MULTI_FIELD]);
+      const checkboxes = fixture.nativeElement.querySelectorAll('input[type=checkbox]');
+      expect(checkboxes.length).toBe(2);
+    });
+
+    it('não renderiza painel quando open=false', async () => {
+      await setup([TEXT_FIELD], false);
+      const panel = fixture.nativeElement.querySelector('.filter-panel');
+      expect(panel).toBeNull();
+    });
+  });
+
+  describe('badge de count (activeCount)', () => {
+    it('draftValues inicializa vazio para campo text', async () => {
+      await setup([TEXT_FIELD]);
+      expect(component.getStringValue('description')).toBe('');
+    });
+
+    it('draftValues inicializa array vazio para campo multiSelect', async () => {
+      await setup([MULTI_FIELD]);
+      expect(component.getArrayValue('tags')).toEqual([]);
+    });
+
+    it('draftValues reflete value inicial do campo', async () => {
+      const field: FilterFieldConfig = { key: 'status', label: 'Status', type: 'select', options: [], value: 1 };
+      await setup([field]);
+      expect(component.getStringValue('status')).toBe(1 as unknown as string);
+    });
+  });
+
+  describe('emissão de apply', () => {
+    it('emite apply com os valores do rascunho', async () => {
+      await setup([TEXT_FIELD, SELECT_FIELD]);
+      const emitted: Record<string, unknown>[] = [];
+      component.apply.subscribe(v => emitted.push(v));
+
+      component.setValue('description', 'teste');
+      component.setValue('status', 1);
+      component.onApply();
+
+      expect(emitted.length).toBe(1);
+      expect(emitted[0]['description']).toBe('teste');
+      expect(emitted[0]['status']).toBe(1);
+    });
+  });
+
+  describe('emissão de clear', () => {
+    it('emite clear e reseta draftValues para vazio', async () => {
+      await setup([TEXT_FIELD, SELECT_FIELD]);
+      const cleared: void[] = [];
+      component.clear.subscribe(() => cleared.push());
+
+      component.setValue('description', 'abc');
+      component.onClear();
+
+      expect(cleared.length).toBe(1);
+      expect(component.getStringValue('description')).toBe('');
+      expect(component.getStringValue('status')).toBe('');
+    });
+
+    it('reseta array para multiSelect no clear', async () => {
+      await setup([MULTI_FIELD]);
+      component.toggleMultiValue('tags', 'a');
+      expect(component.getArrayValue('tags')).toContain('a');
+
+      component.onClear();
+      expect(component.getArrayValue('tags')).toEqual([]);
+    });
+  });
+
+  describe('toggleMultiValue', () => {
+    it('adiciona valor ao array', async () => {
+      await setup([MULTI_FIELD]);
+      component.toggleMultiValue('tags', 'a');
+      expect(component.isChecked('tags', 'a')).toBeTrue();
+    });
+
+    it('remove valor existente do array', async () => {
+      await setup([MULTI_FIELD]);
+      component.toggleMultiValue('tags', 'a');
+      component.toggleMultiValue('tags', 'a');
+      expect(component.isChecked('tags', 'a')).toBeFalse();
+    });
+  });
+});

--- a/personal-finance/src/app/shared/components/filter-modal/filter-modal.component.ts
+++ b/personal-finance/src/app/shared/components/filter-modal/filter-modal.component.ts
@@ -1,0 +1,83 @@
+import { Component, input, output, signal, effect, untracked } from '@angular/core';
+import { trigger, style, animate, transition } from '@angular/animations';
+import { FilterFieldConfig } from './filter-field-config';
+
+@Component({
+  selector: 'app-filter-modal',
+  standalone: true,
+  templateUrl: './filter-modal.component.html',
+  styleUrls: ['./filter-modal.component.css'],
+  animations: [
+    trigger('panelAnim', [
+      transition(':enter', [
+        style({ opacity: 0, transform: 'translateY(-8px)' }),
+        animate('200ms ease', style({ opacity: 1, transform: 'translateY(0)' }))
+      ]),
+      transition(':leave', [
+        animate('150ms ease-in', style({ opacity: 0, transform: 'translateY(-8px)' }))
+      ])
+    ])
+  ]
+})
+export class FilterModalComponent {
+  readonly fields = input<FilterFieldConfig[]>([]);
+  readonly open   = input(false);
+
+  readonly apply = output<Record<string, unknown>>();
+  readonly clear = output<void>();
+
+  readonly draftValues = signal<Record<string, unknown>>({});
+
+  constructor() {
+    // Ao abrir o painel, sincroniza o rascunho com o estado atual dos filtros
+    effect(() => {
+      if (this.open()) {
+        const fs = this.fields();
+        untracked(() => {
+          const initial: Record<string, unknown> = {};
+          for (const f of fs) {
+            initial[f.key] = f.value ?? (f.type === 'multiSelect' ? [] : '');
+          }
+          this.draftValues.set(initial);
+        });
+      }
+    });
+  }
+
+  setValue(key: string, value: unknown): void {
+    this.draftValues.update(v => ({ ...v, [key]: value }));
+  }
+
+  toggleMultiValue(key: string, value: unknown): void {
+    const current = this.getArrayValue(key);
+    const updated = current.includes(value)
+      ? current.filter(v => v !== value)
+      : [...current, value];
+    this.setValue(key, updated);
+  }
+
+  onApply(): void {
+    this.apply.emit(this.draftValues());
+  }
+
+  onClear(): void {
+    const cleared: Record<string, unknown> = {};
+    for (const f of this.fields()) {
+      cleared[f.key] = f.type === 'multiSelect' ? [] : '';
+    }
+    this.draftValues.set(cleared);
+    this.clear.emit();
+  }
+
+  getStringValue(key: string): string {
+    return (this.draftValues()[key] as string) ?? '';
+  }
+
+  getArrayValue(key: string): unknown[] {
+    return (this.draftValues()[key] as unknown[]) ?? [];
+  }
+
+  isChecked(key: string, value: unknown): boolean {
+    return this.getArrayValue(key).includes(value);
+  }
+}


### PR DESCRIPTION
Closes #240

## Summary
- Cria `FilterModalComponent` (painel inline colapsável, `@if` + `panelAnim`) com inputs `fields: FilterFieldConfig[]` e `open`, outputs `apply` e `clear`
- Cria `FilterButtonComponent` com badge de contagem de filtros ativos
- Refatora `expenses.component` e `incomes.component` — substitui filtros inline pelo novo componente, mantendo signals e `loadPage()` existentes

## Test plan
- [x] `filter-modal.component.spec.ts` — render dinâmico, emissão apply/clear, badge count, multiSelect toggle
- [x] `expenses.component.spec.ts` — `onApplyFilters`, `onClearFilters`, `activeFilterCount`
- [x] `incomes.component.spec.ts` — `onApplyFilters`, `onClearFilters`, `activeFilterCount`
- [x] 264 specs, 0 falhas

🤖 Generated with [Claude Code](https://claude.com/claude-code)