### PR TITLE
fix(#240): corrige seletores CSS inválidos e contagem no spec do FilterModal

### DIFF
--- a/personal-finance/src/app/shared/components/filter-modal/filter-modal.component.spec.ts
+++ b/personal-finance/src/app/shared/components/filter-modal/filter-modal.component.spec.ts
@@ -37,7 +37,7 @@ describe('FilterModalComponent', () => {
   describe('render dinâmico de campos', () => {
     it('renderiza campo text', async () => {
       await setup([TEXT_FIELD]);
-      const input = fixture.nativeElement.querySelector('input[type!=checkbox]');
+      const input = fixture.nativeElement.querySelector('input:not([type=checkbox])');
       expect(input).toBeTruthy();
     });
 
@@ -98,13 +98,13 @@ describe('FilterModalComponent', () => {
   describe('emissão de clear', () => {
     it('emite clear e reseta draftValues para vazio', async () => {
       await setup([TEXT_FIELD, SELECT_FIELD]);
-      const cleared: void[] = [];
-      component.clear.subscribe(() => cleared.push());
+      let clearCount = 0;
+      component.clear.subscribe(() => clearCount++);
 
       component.setValue('description', 'abc');
       component.onClear();
 
-      expect(cleared.length).toBe(1);
+      expect(clearCount).toBe(1);
       expect(component.getStringValue('description')).toBe('');
       expect(component.getStringValue('status')).toBe('');
     });


### PR DESCRIPTION
Corrige dois bugs no `filter-modal.component.spec.ts` identificados no CI (Linux):

- `input[type!=checkbox]` → `input:not([type=checkbox])` (seletor CSS inválido)
- `cleared.push()` sem argumento não adiciona elemento → usa contador `clearCount++`

🤖 Generated with [Claude Code](https://claude.com/claude-code)