### PR TITLE
feat(#240): FilterModalComponent reutilizável + refatoração de filtros (Despesas e Receitas)

### DIFF
--- a/personal-finance/src/app/shared/components/filter-modal/filter-modal.component.spec.ts
+++ b/personal-finance/src/app/shared/components/filter-modal/filter-modal.component.spec.ts
@@ -37,7 +37,7 @@ describe('FilterModalComponent', () => {
   describe('render dinâmico de campos', () => {
     it('renderiza campo text', async () => {
       await setup([TEXT_FIELD]);
-      const input = fixture.nativeElement.querySelector('input[type!=checkbox]');
+      const input = fixture.nativeElement.querySelector('input:not([type=checkbox])');
       expect(input).toBeTruthy();
     });
 
@@ -98,13 +98,13 @@ describe('FilterModalComponent', () => {
   describe('emissão de clear', () => {
     it('emite clear e reseta draftValues para vazio', async () => {
       await setup([TEXT_FIELD, SELECT_FIELD]);
-      const cleared: void[] = [];
-      component.clear.subscribe(() => cleared.push());
+      let clearCount = 0;
+      component.clear.subscribe(() => clearCount++);
 
       component.setValue('description', 'abc');
       component.onClear();
 
-      expect(cleared.length).toBe(1);
+      expect(clearCount).toBe(1);
       expect(component.getStringValue('description')).toBe('');
       expect(component.getStringValue('status')).toBe('');
     });


### PR DESCRIPTION
Closes #240

## Summary
- Cria `FilterModalComponent` (painel inline colapsável, `@if` + `panelAnim`) com inputs `fields: FilterFieldConfig[]` e `open`, outputs `apply` e `clear`
- Cria `FilterButtonComponent` com badge de contagem de filtros ativos
- Refatora `expenses.component` e `incomes.component` — substitui filtros inline pelo novo componente, mantendo signals e `loadPage()` existentes
- Corrige specs do `FilterModalComponent` (seletor CSS inválido + contagem de emissão)

## Test plan
- [x] `filter-modal.component.spec.ts` — render dinâmico, emissão apply/clear, badge count, multiSelect toggle
- [x] `expenses.component.spec.ts` — `onApplyFilters`, `onClearFilters`, `activeFilterCount`
- [x] `incomes.component.spec.ts` — `onApplyFilters`, `onClearFilters`, `activeFilterCount`
- [x] 290 specs, 0 falhas

🤖 Generated with [Claude Code](https://claude.com/claude-code)