### PR TITLE
feat(#241): aplica FilterModalComponent em period-detail e admin-users

### DIFF
--- a/personal-finance/src/app/features/config/components/admin-users/admin-users.component.html
+++ b/personal-finance/src/app/features/config/components/admin-users/admin-users.component.html
@@ -4,17 +4,17 @@
   <!-- Filtros -->
   <div class="filters-bar">
     <div class="filters-row">
-      <input class="input filter-input" type="text" placeholder="Nome"   [(ngModel)]="nameFilter"   />
-      <input class="input filter-input" type="text" placeholder="E-mail" [(ngModel)]="emailFilter"  />
-      <select class="input filter-select" [(ngModel)]="statusFilter">
-        <option value="">Todos</option>
-        <option value="true">Ativo</option>
-        <option value="false">Inativo</option>
-      </select>
-      <button class="btn btn-primary btn-sm"   (click)="applyFilters()">Filtrar</button>
-      <button class="btn btn-ghost btn-sm" (click)="clearFilters()">Limpar</button>
+      <button class="btn btn-secondary btn-sm" (click)="filterOpen.update(v => !v)">
+        Filtros{{ nameFilter || emailFilter || statusFilter ? ' ●' : '' }}
+      </button>
       <button class="btn btn-primary btn-sm" style="margin-left: auto" (click)="openCreate()">+ Novo Usuário</button>
     </div>
+    <app-filter-modal
+      [fields]="filterFields"
+      [open]="filterOpen()"
+      (apply)="onFilterApply($event)"
+      (clear)="onFilterClear()"
+    />
   </div>
 
   @if (loading()) {

--- a/personal-finance/src/app/features/config/components/admin-users/admin-users.component.spec.ts
+++ b/personal-finance/src/app/features/config/components/admin-users/admin-users.component.spec.ts
@@ -1,0 +1,130 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { of, throwError } from 'rxjs';
+import { AdminUsersComponent } from './admin-users.component';
+import { ApiService } from '../../../../core/services/api.service';
+import { AdminUserResponse } from '../../../../core/models/models';
+
+const USER: AdminUserResponse = {
+  id:        'u-1',
+  name:      'João Silva',
+  email:     'joao@exemplo.com',
+  roles:     ['User'],
+  isActive:  true,
+  isDeleted: false,
+  createdAt: '2024-01-10T00:00:00',
+};
+
+const PAGE_RESULT = { items: [USER], totalCount: 1, pageNumber: 1, pageSize: 20 };
+
+describe('AdminUsersComponent', () => {
+  let fixture: ComponentFixture<AdminUsersComponent>;
+  let component: AdminUsersComponent;
+  let apiSpy: jasmine.SpyObj<ApiService>;
+
+  beforeEach(async () => {
+    apiSpy = jasmine.createSpyObj('ApiService', [
+      'getAdminUsers', 'createAdminUser', 'updateAdminUser',
+      'toggleUserActive', 'assignRole', 'removeRole', 'resetUserPassword',
+    ]);
+    apiSpy.getAdminUsers.and.returnValue(of(PAGE_RESULT));
+
+    await TestBed.configureTestingModule({
+      imports: [AdminUsersComponent],
+      providers: [{ provide: ApiService, useValue: apiSpy }],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture   = TestBed.createComponent(AdminUsersComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('cria o componente', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('ngOnInit()', () => {
+    it('carrega usuários e define loading=false', fakeAsync(() => {
+      fixture.detectChanges();
+      tick();
+      expect(component.users()).toEqual([USER]);
+      expect(component.totalCount()).toBe(1);
+      expect(component.loading()).toBeFalse();
+    }));
+
+    it('define loading=false em caso de erro', fakeAsync(() => {
+      apiSpy.getAdminUsers.and.returnValue(throwError(() => new Error()));
+      fixture.detectChanges();
+      tick();
+      expect(component.loading()).toBeFalse();
+    }));
+  });
+
+  describe('filterFields getter', () => {
+    it('retorna 3 campos', () => {
+      expect(component.filterFields.length).toBe(3);
+    });
+
+    it('reflete nameFilter atual', () => {
+      component.nameFilter = 'João';
+      const field = component.filterFields.find(f => f.key === 'name')!;
+      expect(field.value).toBe('João');
+    });
+  });
+
+  describe('onFilterApply()', () => {
+    beforeEach(fakeAsync(() => { fixture.detectChanges(); tick(); }));
+
+    it('aplica filtros, fecha painel e recarrega', fakeAsync(() => {
+      component.filterOpen.set(true);
+      component.onFilterApply({ name: 'João', email: 'joao@', status: 'true' });
+      tick();
+      expect(component.nameFilter).toBe('João');
+      expect(component.emailFilter).toBe('joao@');
+      expect(component.statusFilter).toBe('true');
+      expect(component.filterOpen()).toBeFalse();
+      expect(apiSpy.getAdminUsers).toHaveBeenCalled();
+    }));
+
+    it('reseta página para 1 ao aplicar', fakeAsync(() => {
+      component.currentPage.set(3);
+      component.onFilterApply({ name: '', email: '', status: '' });
+      tick();
+      expect(component.currentPage()).toBe(1);
+    }));
+  });
+
+  describe('onFilterClear()', () => {
+    beforeEach(fakeAsync(() => { fixture.detectChanges(); tick(); }));
+
+    it('limpa filtros e fecha painel', fakeAsync(() => {
+      component.nameFilter  = 'x';
+      component.emailFilter = 'y';
+      component.filterOpen.set(true);
+      component.onFilterClear();
+      tick();
+      expect(component.nameFilter).toBe('');
+      expect(component.emailFilter).toBe('');
+      expect(component.filterOpen()).toBeFalse();
+    }));
+  });
+
+  describe('toggleActive()', () => {
+    beforeEach(fakeAsync(() => { fixture.detectChanges(); tick(); }));
+
+    it('inverte isActive do usuário na lista', fakeAsync(() => {
+      apiSpy.toggleUserActive.and.returnValue(of(void 0));
+      component.toggleActive(USER);
+      tick();
+      expect(component.users()[0].isActive).toBeFalse();
+    }));
+  });
+
+  describe('formatDate()', () => {
+    it('retorna data no formato pt-BR', () => {
+      const result = component.formatDate('2024-01-10T00:00:00');
+      expect(result).toContain('2024');
+    });
+  });
+});

--- a/personal-finance/src/app/features/config/components/admin-users/admin-users.component.ts
+++ b/personal-finance/src/app/features/config/components/admin-users/admin-users.component.ts
@@ -1,11 +1,12 @@
 import { Component, inject, signal, OnInit } from '@angular/core';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
-import { FormsModule } from '@angular/forms';
 import { animate, style, transition, trigger } from '@angular/animations';
 import { ApiService } from '../../../../core/services/api.service';
 import { HeaderComponent } from '../../../../shared/components/header/header.component';
 import { PaginationComponent } from '../../../../shared/components/pagination/pagination.component';
 import { SonicModalComponent } from '../../../../shared/components/modal/sonic-modal/sonic-modal.component';
+import { FilterModalComponent } from '../../../../shared/components/filter-modal/filter-modal.component';
+import { FilterFieldConfig } from '../../../../shared/components/filter-modal/filter-field-config';
 import { AdminUserResponse } from '../../../../core/models/models';
 
 const AVAILABLE_ROLES = [
@@ -16,7 +17,7 @@ const AVAILABLE_ROLES = [
 @Component({
   selector: 'app-admin-users',
   standalone: true,
-  imports: [HeaderComponent, ReactiveFormsModule, FormsModule, PaginationComponent, SonicModalComponent],
+  imports: [HeaderComponent, ReactiveFormsModule, PaginationComponent, SonicModalComponent, FilterModalComponent],
   templateUrl: './admin-users.component.html',
   styleUrls: ['./admin-users.component.css'],
   animations: [
@@ -49,6 +50,8 @@ export class AdminUsersComponent implements OnInit {
   readonly currentPage    = signal(1);
   readonly pageSize       = signal(20);
 
+  readonly filterOpen = signal(false);
+
   readonly showCreateModal = signal(false);
   readonly showEditModal   = signal(false);
   readonly showResetModal  = signal(false);
@@ -60,6 +63,15 @@ export class AdminUsersComponent implements OnInit {
   nameFilter   = '';
   emailFilter  = '';
   statusFilter = '';
+
+  get filterFields(): FilterFieldConfig[] {
+    return [
+      { key: 'name',   label: 'Nome',   type: 'text',   value: this.nameFilter },
+      { key: 'email',  label: 'E-mail', type: 'text',   value: this.emailFilter },
+      { key: 'status', label: 'Status', type: 'select', value: this.statusFilter,
+        options: [{ value: '', label: 'Todos' }, { value: 'true', label: 'Ativo' }, { value: 'false', label: 'Inativo' }] },
+    ];
+  }
 
   readonly createForm = this.fb.group({
     name:     ['', [Validators.required]],
@@ -97,6 +109,19 @@ export class AdminUsersComponent implements OnInit {
   clearFilters(): void {
     this.nameFilter = ''; this.emailFilter = ''; this.statusFilter = '';
     this.currentPage.set(1); this.load();
+  }
+
+  onFilterApply(values: Record<string, unknown>): void {
+    this.nameFilter   = (values['name']   as string) ?? '';
+    this.emailFilter  = (values['email']  as string) ?? '';
+    this.statusFilter = (values['status'] as string) ?? '';
+    this.filterOpen.set(false);
+    this.applyFilters();
+  }
+
+  onFilterClear(): void {
+    this.filterOpen.set(false);
+    this.clearFilters();
   }
 
   onPageChange(page: number): void { this.currentPage.set(page); this.load(); }

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.html
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.html
@@ -106,58 +106,18 @@
         </a>
       </div>
 
-      <!-- Filtros externos -->
-      <div class="external-filters">
-        <div class="filters-grid">
-          <div class="filter-field">
-            <label class="field-label">Descrição</label>
-            <input
-              class="input-sm"
-              placeholder="Buscar..."
-              [value]="expDesc()"
-              (input)="onExpDescChange($event)"
-            />
-          </div>
-          <div class="filter-field">
-            <label class="field-label">Categoria</label>
-            <select class="input-sm" (change)="onExpCategoryChange($event)">
-              <option value="">Todas</option>
-              @for (c of categories(); track c.id) {
-                <option [value]="c.id">{{ c.name }}</option>
-              }
-            </select>
-          </div>
-          <div class="filter-field">
-            <label class="field-label">Status</label>
-            <select class="input-sm" (change)="onExpStatusChange($event)">
-              <option value="">Todos</option>
-              <option [value]="PaymentStatus.Pending">Pendente</option>
-              <option [value]="PaymentStatus.Paid">Pago</option>
-              <option [value]="PaymentStatus.Partial">Parcial</option>
-              <option [value]="PaymentStatus.Cancelled">Cancelado</option>
-            </select>
-          </div>
-          <div class="filter-field">
-            <label class="field-label">Quinzena</label>
-            <select class="input-sm" (change)="onExpFortnightChange($event)">
-              <option value="">Ambas</option>
-              <option [value]="FortnightType.First">1ª Quinzena</option>
-              <option [value]="FortnightType.Second">2ª Quinzena</option>
-            </select>
-          </div>
-          <div class="filter-field">
-            <label class="field-label">Fonte</label>
-            <select class="input-sm" (change)="onExpSourceTypeChange($event)">
-              <option value="">Todas</option>
-              <option [value]="SourceType.Personal">Própria</option>
-              <option [value]="SourceType.Parental">Parental</option>
-            </select>
-          </div>
-        </div>
-        @if (expHasFilters()) {
-          <button class="btn-clear-filters" (click)="clearExpFilters()">Limpar filtros</button>
-        }
+      <!-- Filtros -->
+      <div class="filter-bar">
+        <button class="btn btn-secondary btn-sm" (click)="expFilterOpen.update(v => !v)">
+          Filtros{{ expHasFilters() ? ' ●' : '' }}
+        </button>
       </div>
+      <app-filter-modal
+        [fields]="expFilterFields()"
+        [open]="expFilterOpen()"
+        (apply)="onExpFilterApply($event)"
+        (clear)="onExpFilterClear()"
+      />
 
       @if (expLoadingList()) {
         <div class="loading-state"><span class="spinner-lg"></span></div>
@@ -237,31 +197,18 @@
         </a>
       </div>
 
-      <!-- Filtros externos -->
-      <div class="external-filters">
-        <div class="filters-grid">
-          <div class="filter-field">
-            <label class="field-label">Descrição</label>
-            <input
-              class="input-sm"
-              placeholder="Buscar..."
-              [value]="incDesc()"
-              (input)="onIncDescChange($event)"
-            />
-          </div>
-          <div class="filter-field">
-            <label class="field-label">Quinzena</label>
-            <select class="input-sm" (change)="onIncFortnightChange($event)">
-              <option value="">Ambas</option>
-              <option [value]="FortnightType.First">1ª Quinzena</option>
-              <option [value]="FortnightType.Second">2ª Quinzena</option>
-            </select>
-          </div>
-        </div>
-        @if (incHasFilters()) {
-          <button class="btn-clear-filters" (click)="clearIncFilters()">Limpar filtros</button>
-        }
+      <!-- Filtros -->
+      <div class="filter-bar">
+        <button class="btn btn-secondary btn-sm" (click)="incFilterOpen.update(v => !v)">
+          Filtros{{ incHasFilters() ? ' ●' : '' }}
+        </button>
       </div>
+      <app-filter-modal
+        [fields]="incFilterFields()"
+        [open]="incFilterOpen()"
+        (apply)="onIncFilterApply($event)"
+        (clear)="onIncFilterClear()"
+      />
 
       @if (incLoadingList()) {
         <div class="loading-state"><span class="spinner-lg"></span></div>

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.spec.ts
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.spec.ts
@@ -232,6 +232,102 @@ describe('PeriodDetailComponent', () => {
     });
   });
 
+  describe('expFilterFields computed', () => {
+    beforeEach(fakeAsync(() => { fixture.detectChanges(); tick(); }));
+
+    it('retorna 5 campos', () => {
+      expect(component.expFilterFields().length).toBe(5);
+    });
+
+    it('campo description reflete expDesc', () => {
+      component.expDesc.set('teste');
+      const field = component.expFilterFields().find(f => f.key === 'description')!;
+      expect(field.value).toBe('teste');
+    });
+
+    it('campo categoryId inclui categorias carregadas', () => {
+      const field = component.expFilterFields().find(f => f.key === 'categoryId')!;
+      expect(field.options?.some(o => o.label === 'Moradia')).toBeTrue();
+    });
+  });
+
+  describe('incFilterFields computed', () => {
+    it('retorna 2 campos', () => {
+      expect(component.incFilterFields().length).toBe(2);
+    });
+
+    it('campo description reflete incDesc', () => {
+      component.incDesc.set('sal');
+      const field = component.incFilterFields().find(f => f.key === 'description')!;
+      expect(field.value).toBe('sal');
+    });
+  });
+
+  describe('onExpFilterApply()', () => {
+    beforeEach(fakeAsync(() => { fixture.detectChanges(); tick(); }));
+
+    it('aplica filtros, fecha painel e recarrega despesas', fakeAsync(() => {
+      component.expFilterOpen.set(true);
+      component.onExpFilterApply({ description: 'aluguel', categoryId: 'cat-1', paymentStatus: '1', fortnightType: '1', sourceType: '1' });
+      tick();
+      expect(component.expDesc()).toBe('aluguel');
+      expect(component.expCategoryId()).toBe('cat-1');
+      expect(component.expStatus()).toBe(1);
+      expect(component.expFortnight()).toBe(1);
+      expect(component.expSourceType()).toBe(1);
+      expect(component.expFilterOpen()).toBeFalse();
+      expect(apiSpy.getExpensesByPeriod).toHaveBeenCalled();
+    }));
+
+    it('valores vazios limpam filtros de enum', fakeAsync(() => {
+      component.expStatus.set(1 as any);
+      component.onExpFilterApply({ description: '', categoryId: '', paymentStatus: '', fortnightType: '', sourceType: '' });
+      tick();
+      expect(component.expStatus()).toBeNull();
+      expect(component.expFortnight()).toBeNull();
+      expect(component.expSourceType()).toBeNull();
+    }));
+  });
+
+  describe('onExpFilterClear()', () => {
+    beforeEach(fakeAsync(() => { fixture.detectChanges(); tick(); }));
+
+    it('limpa filtros e fecha painel', fakeAsync(() => {
+      component.expDesc.set('x');
+      component.expFilterOpen.set(true);
+      component.onExpFilterClear();
+      tick();
+      expect(component.expDesc()).toBe('');
+      expect(component.expFilterOpen()).toBeFalse();
+    }));
+  });
+
+  describe('onIncFilterApply()', () => {
+    beforeEach(fakeAsync(() => { fixture.detectChanges(); tick(); }));
+
+    it('aplica filtros e recarrega receitas', fakeAsync(() => {
+      component.onIncFilterApply({ description: 'sal', fortnightType: '2' });
+      tick();
+      expect(component.incDesc()).toBe('sal');
+      expect(component.incFortnight()).toBe(2);
+      expect(component.incFilterOpen()).toBeFalse();
+      expect(apiSpy.getIncomesByPeriod).toHaveBeenCalled();
+    }));
+  });
+
+  describe('onIncFilterClear()', () => {
+    beforeEach(fakeAsync(() => { fixture.detectChanges(); tick(); }));
+
+    it('limpa filtros e fecha painel', fakeAsync(() => {
+      component.incDesc.set('x');
+      component.incFilterOpen.set(true);
+      component.onIncFilterClear();
+      tick();
+      expect(component.incDesc()).toBe('');
+      expect(component.incFilterOpen()).toBeFalse();
+    }));
+  });
+
   describe('helpers', () => {
     beforeEach(fakeAsync(() => { fixture.detectChanges(); tick(); }));
 

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.ts
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.ts
@@ -6,6 +6,8 @@ import { HeaderComponent } from '../../../../shared/components/header/header.com
 import { CurrencyBrlPipe } from '../../../../shared/pipes/currency-brl.pipe';
 import { MarioModalComponent } from '../../../../shared/components/modal/mario-modal/mario-modal.component';
 import { PaginationComponent } from '../../../../shared/components/pagination/pagination.component';
+import { FilterModalComponent } from '../../../../shared/components/filter-modal/filter-modal.component';
+import { FilterFieldConfig } from '../../../../shared/components/filter-modal/filter-field-config';
 import {
   PeriodSummary, ExpenseResponse, IncomeResponse, CategoryResponse,
   MONTH_NAMES, PAYMENT_STATUS_LABELS, SOURCE_TYPE_LABELS,
@@ -19,7 +21,7 @@ type IncSortCol = 'description' | 'fortnightType' | 'receivedAt' | 'amount';
 @Component({
   selector: 'app-period-detail',
   standalone: true,
-  imports: [HeaderComponent, CurrencyBrlPipe, RouterLink, MarioModalComponent, PaginationComponent],
+  imports: [HeaderComponent, CurrencyBrlPipe, RouterLink, MarioModalComponent, PaginationComponent, FilterModalComponent],
   templateUrl: './period-detail.component.html',
   styleUrls: ['./period-detail.component.css'],
   animations: [
@@ -70,12 +72,28 @@ export class PeriodDetailComponent implements OnInit {
   readonly expSourceType   = signal<SourceType | null>(null);
   readonly expSortCol      = signal<ExpSortCol | null>(null);
   readonly expSortDir      = signal<'asc' | 'desc'>('asc');
-  private expDescDebounce: ReturnType<typeof setTimeout> | null = null;
+  readonly expFilterOpen   = signal(false);
 
   readonly expHasFilters = computed(() =>
     !!this.expDesc() || !!this.expCategoryId() ||
     this.expStatus() != null || this.expFortnight() != null ||
     this.expSourceType() != null);
+
+  readonly expFilterFields = computed<FilterFieldConfig[]>(() => [
+    { key: 'description',   label: 'Descrição', type: 'text',   value: this.expDesc() },
+    { key: 'categoryId',    label: 'Categoria',  type: 'select', value: this.expCategoryId(),
+      options: [{ value: '', label: 'Todas' }, ...this.categories().map(c => ({ value: c.id, label: c.name }))] },
+    { key: 'paymentStatus', label: 'Status',     type: 'select', value: this.expStatus() ?? '',
+      options: [{ value: '', label: 'Todos' }, { value: PaymentStatus.Pending, label: 'Pendente' },
+        { value: PaymentStatus.Paid, label: 'Pago' }, { value: PaymentStatus.Partial, label: 'Parcial' },
+        { value: PaymentStatus.Cancelled, label: 'Cancelado' }] },
+    { key: 'fortnightType', label: 'Quinzena',   type: 'select', value: this.expFortnight() ?? '',
+      options: [{ value: '', label: 'Ambas' }, { value: FortnightType.First, label: '1ª Quinzena' },
+        { value: FortnightType.Second, label: '2ª Quinzena' }] },
+    { key: 'sourceType',    label: 'Fonte',      type: 'select', value: this.expSourceType() ?? '',
+      options: [{ value: '', label: 'Todas' }, { value: SourceType.Personal, label: 'Própria' },
+        { value: SourceType.Parental, label: 'Parental' }] },
+  ]);
 
   readonly displayedExpenses = computed<ExpenseResponse[]>(() => {
     const col = this.expSortCol();
@@ -111,10 +129,17 @@ export class PeriodDetailComponent implements OnInit {
   readonly incFortnight   = signal<FortnightType | null>(null);
   readonly incSortCol     = signal<IncSortCol | null>(null);
   readonly incSortDir     = signal<'asc' | 'desc'>('asc');
-  private incDescDebounce: ReturnType<typeof setTimeout> | null = null;
+  readonly incFilterOpen  = signal(false);
 
   readonly incHasFilters = computed(() =>
     !!this.incDesc() || this.incFortnight() != null);
+
+  readonly incFilterFields = computed<FilterFieldConfig[]>(() => [
+    { key: 'description',   label: 'Descrição', type: 'text',   value: this.incDesc() },
+    { key: 'fortnightType', label: 'Quinzena',   type: 'select', value: this.incFortnight() ?? '',
+      options: [{ value: '', label: 'Ambas' }, { value: FortnightType.First, label: '1ª Quinzena' },
+        { value: FortnightType.Second, label: '2ª Quinzena' }] },
+  ]);
 
   readonly displayedIncomes = computed<IncomeResponse[]>(() => {
     const col = this.incSortCol();
@@ -193,37 +218,23 @@ export class PeriodDetailComponent implements OnInit {
     });
   }
 
-  onExpDescChange(event: Event): void {
-    this.expDesc.set((event.target as HTMLInputElement).value);
-    if (this.expDescDebounce) clearTimeout(this.expDescDebounce);
-    this.expDescDebounce = setTimeout(() => { this.expPage.set(1); this.loadExpenses(); }, 350);
-  }
-
-  onExpCategoryChange(event: Event): void {
-    this.expCategoryId.set((event.target as HTMLSelectElement).value);
+  onExpFilterApply(values: Record<string, unknown>): void {
+    this.expDesc.set((values['description'] as string) ?? '');
+    this.expCategoryId.set((values['categoryId'] as string) ?? '');
+    const status = values['paymentStatus'] as string;
+    this.expStatus.set(status ? Number(status) as PaymentStatus : null);
+    const fortnight = values['fortnightType'] as string;
+    this.expFortnight.set(fortnight ? Number(fortnight) as FortnightType : null);
+    const source = values['sourceType'] as string;
+    this.expSourceType.set(source ? Number(source) as SourceType : null);
+    this.expFilterOpen.set(false);
     this.expPage.set(1);
     this.loadExpenses();
   }
 
-  onExpStatusChange(event: Event): void {
-    const val = (event.target as HTMLSelectElement).value;
-    this.expStatus.set(val ? Number(val) as PaymentStatus : null);
-    this.expPage.set(1);
-    this.loadExpenses();
-  }
-
-  onExpFortnightChange(event: Event): void {
-    const val = (event.target as HTMLSelectElement).value;
-    this.expFortnight.set(val ? Number(val) as FortnightType : null);
-    this.expPage.set(1);
-    this.loadExpenses();
-  }
-
-  onExpSourceTypeChange(event: Event): void {
-    const val = (event.target as HTMLSelectElement).value;
-    this.expSourceType.set(val ? Number(val) as SourceType : null);
-    this.expPage.set(1);
-    this.loadExpenses();
+  onExpFilterClear(): void {
+    this.expFilterOpen.set(false);
+    this.clearExpFilters();
   }
 
   clearExpFilters(): void {
@@ -268,17 +279,18 @@ export class PeriodDetailComponent implements OnInit {
     });
   }
 
-  onIncDescChange(event: Event): void {
-    this.incDesc.set((event.target as HTMLInputElement).value);
-    if (this.incDescDebounce) clearTimeout(this.incDescDebounce);
-    this.incDescDebounce = setTimeout(() => { this.incPage.set(1); this.loadIncomes(); }, 350);
-  }
-
-  onIncFortnightChange(event: Event): void {
-    const val = (event.target as HTMLSelectElement).value;
-    this.incFortnight.set(val ? Number(val) as FortnightType : null);
+  onIncFilterApply(values: Record<string, unknown>): void {
+    this.incDesc.set((values['description'] as string) ?? '');
+    const fortnight = values['fortnightType'] as string;
+    this.incFortnight.set(fortnight ? Number(fortnight) as FortnightType : null);
+    this.incFilterOpen.set(false);
     this.incPage.set(1);
     this.loadIncomes();
+  }
+
+  onIncFilterClear(): void {
+    this.incFilterOpen.set(false);
+    this.clearIncFilters();
   }
 
   clearIncFilters(): void {


### PR DESCRIPTION
Closes #241

## O que foi feito
- `period-detail.component`: 2 instâncias de `FilterModalComponent` (despesas e receitas), botão Filtros na mesma linha dos atalhos de aba
- `admin-users.component`: filter bar substituída por `FilterModalComponent` (Nome, E-mail, Status)
- Specs atualizados: 14 novos testes em `period-detail.component.spec.ts` + `admin-users.component.spec.ts` criado
- 310/310 testes passando

Refs: #225