### PR TITLE
fix(#241): unifica botão Filtros na mesma linha que o atalho de tab

### DIFF
--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.html
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.html
@@ -104,10 +104,6 @@
         <a routerLink="/expenses" [queryParams]="{ periodId: id() }" class="btn btn-purple btn-sm">
           Ir para Despesas →
         </a>
-      </div>
-
-      <!-- Filtros -->
-      <div class="filter-bar">
         <button class="btn btn-secondary btn-sm" (click)="expFilterOpen.update(v => !v)">
           Filtros{{ expHasFilters() ? ' ●' : '' }}
         </button>
@@ -195,10 +191,6 @@
         <a routerLink="/incomes" [queryParams]="{ periodId: id() }" class="btn btn-purple btn-sm">
           Ir para Receitas →
         </a>
-      </div>
-
-      <!-- Filtros -->
-      <div class="filter-bar">
         <button class="btn btn-secondary btn-sm" (click)="incFilterOpen.update(v => !v)">
           Filtros{{ incHasFilters() ? ' ●' : '' }}
         </button>


### PR DESCRIPTION
Ajuste visual: botão "Filtros" movido para dentro do `div.tab-shortcut`, ficando na mesma linha que "Ir para Despesas →" / "Ir para Receitas →".

Refs: #241