### PR TITLE
fix(#241): posiciona Filtros à esquerda e atalho de tab à direita

### DIFF
--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.html
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.html
@@ -101,12 +101,12 @@
     <!-- ── Despesas ── -->
     @if (activeTab() === 'expenses') {
       <div class="tab-shortcut">
-        <a routerLink="/expenses" [queryParams]="{ periodId: id() }" class="btn btn-purple btn-sm">
-          Ir para Despesas →
-        </a>
         <button class="btn btn-secondary btn-sm" (click)="expFilterOpen.update(v => !v)">
           Filtros{{ expHasFilters() ? ' ●' : '' }}
         </button>
+        <a routerLink="/expenses" [queryParams]="{ periodId: id() }" class="btn btn-purple btn-sm" style="margin-left: auto">
+          Ir para Despesas →
+        </a>
       </div>
       <app-filter-modal
         [fields]="expFilterFields()"
@@ -188,12 +188,12 @@
     <!-- ── Receitas ── -->
     @if (activeTab() === 'incomes') {
       <div class="tab-shortcut">
-        <a routerLink="/incomes" [queryParams]="{ periodId: id() }" class="btn btn-purple btn-sm">
-          Ir para Receitas →
-        </a>
         <button class="btn btn-secondary btn-sm" (click)="incFilterOpen.update(v => !v)">
           Filtros{{ incHasFilters() ? ' ●' : '' }}
         </button>
+        <a routerLink="/incomes" [queryParams]="{ periodId: id() }" class="btn btn-purple btn-sm" style="margin-left: auto">
+          Ir para Receitas →
+        </a>
       </div>
       <app-filter-modal
         [fields]="incFilterFields()"


### PR DESCRIPTION
Ajuste visual: botão "Filtros" à esquerda, botão de atalho (Ir para Despesas/Receitas) à direita via `margin-left: auto`.

Refs: #241