### PR TITLE
feat(#247): replicação de despesas recorrentes ao criar período

### DIFF
--- a/personal-finance/src/app/core/models/models.ts
+++ b/personal-finance/src/app/core/models/models.ts
@@ -107,6 +107,14 @@ export interface ExpenseResponse {
   paymentDate:    string | null;
   notes:          string | null;
   isActive:       boolean;
+  isRecurring:    boolean;
+}
+
+export interface RecurringExpenseResponse {
+  id:          string;
+  description: string;
+  notes:       string | null;
+  amount:      number;
 }
 
 export interface CreateExpenseRequest {
@@ -118,6 +126,7 @@ export interface CreateExpenseRequest {
   amount:        number;
   dueDate:       string;
   notes?:        string;
+  isRecurring?:  boolean;
 }
 
 export interface UpdateExpenseRequest {
@@ -129,6 +138,7 @@ export interface UpdateExpenseRequest {
   dueDate:       string;
   notes?:        string;
   status:        PaymentStatus;
+  isRecurring?:  boolean;
 }
 
 export interface MarkAsPaidRequest {

--- a/personal-finance/src/app/core/services/api.service.ts
+++ b/personal-finance/src/app/core/services/api.service.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import {
   CategoryResponse, CreateCategoryRequest, UpdateCategoryRequest,
-  PeriodResponse, CreatePeriodRequest, PeriodSummary,
+  PeriodResponse, CreatePeriodRequest, PeriodSummary, RecurringExpenseResponse,
   ExpenseResponse, CreateExpenseRequest, UpdateExpenseRequest, MarkAsPaidRequest, ExpenseOrderItem,
   PagedResult, ExpenseFilterParams, IncomeFilterParams,
   IncomeResponse, CreateIncomeRequest,
@@ -67,6 +67,14 @@ export class ApiService {
 
   getPeriodSummary(id: string): Observable<PeriodSummary> {
     return this.http.get<PeriodSummary>(`${this.base}/periods/${id}/summary`);
+  }
+
+  getRecurringExpenses(periodId: string): Observable<RecurringExpenseResponse[]> {
+    return this.http.get<RecurringExpenseResponse[]>(`${this.base}/periods/${periodId}/recurring-expenses`);
+  }
+
+  replicateExpenses(periodId: string, expenseIds: string[]): Observable<void> {
+    return this.http.post<void>(`${this.base}/periods/${periodId}/replicate-expenses`, expenseIds);
   }
 
   // ── Expenses ──────────────────────────────────────────────────────────────

--- a/personal-finance/src/app/features/periods/components/periods/periods.component.html
+++ b/personal-finance/src/app/features/periods/components/periods/periods.component.html
@@ -226,6 +226,16 @@
     }
   }
 
+  <!-- Modal de despesas recorrentes -->
+  @if (recurringModalOpen()) {
+    <app-recurring-expenses-modal
+      [expenses]="recurringExpenses()"
+      [loading]="recurringLoading()"
+      (replicate)="onReplicateExpenses($event)"
+      (closed)="closeRecurringModal()"
+    />
+  }
+
   <!-- Feedback de erro de ação -->
   @if (actionError()) {
     <div class="action-error">

--- a/personal-finance/src/app/features/periods/components/periods/periods.component.ts
+++ b/personal-finance/src/app/features/periods/components/periods/periods.component.ts
@@ -1,16 +1,33 @@
 import { Component, inject, signal, computed, OnInit } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+import { trigger, style, animate, transition } from '@angular/animations';
 import { ApiService } from '../../../../core/services/api.service';
 import { HeaderComponent } from '../../../../shared/components/header/header.component';
-import { PeriodResponse, MONTH_NAMES } from '../../../../core/models/models';
+import { RecurringExpensesModalComponent } from '../../../../shared/components/modal/recurring-expenses-modal/recurring-expenses-modal.component';
+import { PeriodResponse, RecurringExpenseResponse, MONTH_NAMES } from '../../../../core/models/models';
 
 @Component({
   selector: 'app-periods',
   standalone: true,
-  imports: [HeaderComponent, RouterLink, ReactiveFormsModule],
+  imports: [HeaderComponent, RouterLink, ReactiveFormsModule, RecurringExpensesModalComponent],
   templateUrl: './periods.component.html',
   styleUrls: ['./periods.component.css'],
+  animations: [
+    trigger('backdropAnim', [
+      transition(':enter', [style({ opacity: 0 }), animate('200ms ease', style({ opacity: 1 }))]),
+      transition(':leave', [animate('180ms ease', style({ opacity: 0 }))])
+    ]),
+    trigger('modalAnim', [
+      transition(':enter', [
+        style({ opacity: 0, transform: 'scale(0.88) translateY(-16px)' }),
+        animate('260ms cubic-bezier(0.34,1.56,0.64,1)', style({ opacity: 1, transform: 'scale(1) translateY(0)' }))
+      ]),
+      transition(':leave', [
+        animate('180ms ease-in', style({ opacity: 0, transform: 'scale(0.93) translateY(10px)' }))
+      ])
+    ])
+  ]
 })
 export class PeriodsComponent implements OnInit {
   private readonly api = inject(ApiService);
@@ -24,6 +41,12 @@ export class PeriodsComponent implements OnInit {
   readonly apiError      = signal<string | null>(null);
   readonly actionLoading = signal<string | null>(null);
   readonly actionError   = signal<string | null>(null);
+
+  // ── Modal de despesas recorrentes ─────────────────────────────────────────
+  readonly recurringModalOpen     = signal(false);
+  readonly recurringExpenses      = signal<RecurringExpenseResponse[]>([]);
+  readonly recurringTargetPeriodId = signal<string | null>(null);
+  readonly recurringLoading       = signal(false);
 
   // ── Filtros ───────────────────────────────────────────────────────────────
   readonly selectedYear = signal<number | null>(new Date().getFullYear());
@@ -124,6 +147,7 @@ export class PeriodsComponent implements OnInit {
         this.periods.update(list => [p, ...list]);
         this.cancelForm();
         this.loading.set(false);
+        this.openRecurringModal(p.id);
       },
       error: err => {
         this.apiError.set(err.error?.message ?? 'Erro ao criar período.');
@@ -183,5 +207,36 @@ export class PeriodsComponent implements OnInit {
 
   monthName(month: number): string {
     return MONTH_NAMES[month - 1];
+  }
+
+  openRecurringModal(periodId: string): void {
+    this.api.getRecurringExpenses(periodId).subscribe({
+      next: expenses => {
+        if (expenses.length === 0) return;
+        this.recurringExpenses.set(expenses);
+        this.recurringTargetPeriodId.set(periodId);
+        this.recurringModalOpen.set(true);
+      }
+    });
+  }
+
+  closeRecurringModal(): void {
+    this.recurringModalOpen.set(false);
+    this.recurringExpenses.set([]);
+    this.recurringTargetPeriodId.set(null);
+  }
+
+  onReplicateExpenses(expenseIds: string[]): void {
+    const periodId = this.recurringTargetPeriodId();
+    if (!periodId) return;
+
+    this.recurringLoading.set(true);
+    this.api.replicateExpenses(periodId, expenseIds).subscribe({
+      next: () => {
+        this.recurringLoading.set(false);
+        this.closeRecurringModal();
+      },
+      error: () => this.recurringLoading.set(false)
+    });
   }
 }

--- a/personal-finance/src/app/shared/components/modal/recurring-expenses-modal/recurring-expenses-modal.component.html
+++ b/personal-finance/src/app/shared/components/modal/recurring-expenses-modal/recurring-expenses-modal.component.html
@@ -1,0 +1,57 @@
+<div class="modal-overlay" @backdropAnim (click)="closed.emit()"></div>
+<div class="modal-center" @modalAnim>
+  <app-sonic-modal title="Despesas Recorrentes" (closed)="closed.emit()">
+
+    @if (expenses().length === 0) {
+      <p class="empty-text">Nenhuma despesa recorrente encontrada no período anterior.</p>
+    } @else {
+      <div class="select-all-row">
+        <label class="expense-item">
+          <input
+            type="checkbox"
+            class="expense-checkbox"
+            [checked]="allSelected()"
+            (change)="toggleAll()"
+          />
+          <span class="select-all-label">Selecionar todas</span>
+        </label>
+      </div>
+
+      <ul class="expense-list">
+        @for (expense of expenses(); track expense.id) {
+          <li
+            class="expense-item"
+            [class.selected]="isSelected(expense.id)"
+            (click)="toggle(expense.id)"
+          >
+            <input
+              type="checkbox"
+              class="expense-checkbox"
+              [checked]="isSelected(expense.id)"
+              (click)="$event.stopPropagation()"
+              (change)="toggle(expense.id)"
+            />
+            <div class="expense-info">
+              <span class="expense-description">{{ expense.description }}</span>
+              @if (expense.notes) {
+                <span class="expense-notes">{{ expense.notes }}</span>
+              }
+            </div>
+            <span class="expense-amount">R$ {{ expense.amount | number: '1.2-2' }}</span>
+          </li>
+        }
+      </ul>
+
+      <div class="modal-footer">
+        <button
+          class="btn btn-primary"
+          [disabled]="selectedIds().size === 0 || loading()"
+          (click)="onReplicate()"
+        >
+          {{ loading() ? 'Replicando...' : 'Replicar Despesas' }}
+        </button>
+      </div>
+    }
+
+  </app-sonic-modal>
+</div>

--- a/personal-finance/src/app/shared/components/modal/recurring-expenses-modal/recurring-expenses-modal.component.scss
+++ b/personal-finance/src/app/shared/components/modal/recurring-expenses-modal/recurring-expenses-modal.component.scss
@@ -1,0 +1,121 @@
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  z-index: 200;
+}
+
+.modal-center {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 201;
+  padding: 48px 24px;
+  pointer-events: none;
+
+  > * { pointer-events: auto; }
+}
+
+.empty-text {
+  color: var(--ink3);
+  font-size: 0.875rem;
+  text-align: center;
+  padding: 8px 0 16px;
+}
+
+.select-all-row {
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 4px;
+}
+
+.select-all-label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--ink2);
+  cursor: pointer;
+}
+
+.expense-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.expense-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background 0.15s, border-color 0.15s;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.04);
+  }
+
+  &.selected {
+    background: rgba(var(--accent-rgb, 99, 102, 241), 0.08);
+    border-color: rgba(var(--accent-rgb, 99, 102, 241), 0.2);
+  }
+}
+
+.expense-checkbox {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  cursor: pointer;
+  accent-color: var(--accent, #6366f1);
+}
+
+.expense-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.expense-description {
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: var(--ink);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.expense-notes {
+  font-size: 0.75rem;
+  color: var(--ink3);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.expense-amount {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--ink2);
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 16px;
+  margin-top: 12px;
+  border-top: 1px solid var(--border);
+}

--- a/personal-finance/src/app/shared/components/modal/recurring-expenses-modal/recurring-expenses-modal.component.ts
+++ b/personal-finance/src/app/shared/components/modal/recurring-expenses-modal/recurring-expenses-modal.component.ts
@@ -1,0 +1,64 @@
+import { Component, input, output, signal, computed } from '@angular/core';
+import { DecimalPipe } from '@angular/common';
+import { trigger, style, animate, transition } from '@angular/animations';
+import { SonicModalComponent } from '../sonic-modal/sonic-modal.component';
+import { RecurringExpenseResponse } from '../../../../core/models/models';
+
+@Component({
+  selector: 'app-recurring-expenses-modal',
+  standalone: true,
+  imports: [SonicModalComponent, DecimalPipe],
+  templateUrl: './recurring-expenses-modal.component.html',
+  styleUrls: ['./recurring-expenses-modal.component.scss'],
+  animations: [
+    trigger('backdropAnim', [
+      transition(':enter', [style({ opacity: 0 }), animate('200ms ease', style({ opacity: 1 }))]),
+      transition(':leave', [animate('180ms ease', style({ opacity: 0 }))])
+    ]),
+    trigger('modalAnim', [
+      transition(':enter', [
+        style({ opacity: 0, transform: 'scale(0.88) translateY(-16px)' }),
+        animate('260ms cubic-bezier(0.34,1.56,0.64,1)', style({ opacity: 1, transform: 'scale(1) translateY(0)' }))
+      ]),
+      transition(':leave', [
+        animate('180ms ease-in', style({ opacity: 0, transform: 'scale(0.93) translateY(10px)' }))
+      ])
+    ])
+  ]
+})
+export class RecurringExpensesModalComponent {
+  readonly expenses  = input.required<RecurringExpenseResponse[]>();
+  readonly loading   = input(false);
+  readonly replicate = output<string[]>();
+  readonly closed    = output<void>();
+
+  readonly selectedIds = signal<Set<string>>(new Set());
+
+  readonly allSelected = computed(() =>
+    this.expenses().length > 0 && this.selectedIds().size === this.expenses().length
+  );
+
+  toggle(id: string): void {
+    this.selectedIds.update(set => {
+      const next = new Set(set);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  }
+
+  toggleAll(): void {
+    if (this.allSelected()) {
+      this.selectedIds.set(new Set());
+    } else {
+      this.selectedIds.set(new Set(this.expenses().map(e => e.id)));
+    }
+  }
+
+  isSelected(id: string): boolean {
+    return this.selectedIds().has(id);
+  }
+
+  onReplicate(): void {
+    this.replicate.emit([...this.selectedIds()]);
+  }
+}

--- a/src/PersonalFinance.Api/Controllers/V1/Financial/PeriodsController.cs
+++ b/src/PersonalFinance.Api/Controllers/V1/Financial/PeriodsController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using PersonalFinance.Application.DTOs.Financial;
+using PersonalFinance.Application.UseCases.Financial.Expenses;
 using PersonalFinance.Application.UseCases.Financial.Periods;
 
 namespace PersonalFinance.Api.Controllers.V1;
@@ -7,27 +8,33 @@ namespace PersonalFinance.Api.Controllers.V1;
 [Route("api/v1/periods")]
 public sealed class PeriodsController : ApiControllerBase
 {
-    private readonly GetPeriodsByUserUseCase  _getListUseCase;
-    private readonly GetPeriodByIdUseCase     _getByIdUseCase;
-    private readonly CreatePeriodUseCase      _createUseCase;
-    private readonly GetPeriodSummaryUseCase  _summaryUseCase;
-    private readonly TogglePeriodActiveUseCase _toggleUseCase;
-    private readonly DeletePeriodUseCase      _deleteUseCase;
+    private readonly GetPeriodsByUserUseCase                  _getListUseCase;
+    private readonly GetPeriodByIdUseCase                     _getByIdUseCase;
+    private readonly CreatePeriodUseCase                      _createUseCase;
+    private readonly GetPeriodSummaryUseCase                  _summaryUseCase;
+    private readonly TogglePeriodActiveUseCase                _toggleUseCase;
+    private readonly DeletePeriodUseCase                      _deleteUseCase;
+    private readonly GetRecurringExpensesFromLastPeriodUseCase _recurringUseCase;
+    private readonly ReplicateExpensesUseCase                 _replicateUseCase;
 
     public PeriodsController(
-        GetPeriodsByUserUseCase   getListUseCase,
-        GetPeriodByIdUseCase      getByIdUseCase,
-        CreatePeriodUseCase       createUseCase,
-        GetPeriodSummaryUseCase   summaryUseCase,
-        TogglePeriodActiveUseCase toggleUseCase,
-        DeletePeriodUseCase       deleteUseCase)
+        GetPeriodsByUserUseCase                   getListUseCase,
+        GetPeriodByIdUseCase                      getByIdUseCase,
+        CreatePeriodUseCase                       createUseCase,
+        GetPeriodSummaryUseCase                   summaryUseCase,
+        TogglePeriodActiveUseCase                 toggleUseCase,
+        DeletePeriodUseCase                       deleteUseCase,
+        GetRecurringExpensesFromLastPeriodUseCase  recurringUseCase,
+        ReplicateExpensesUseCase                  replicateUseCase)
     {
-        _getListUseCase = getListUseCase;
-        _getByIdUseCase = getByIdUseCase;
-        _createUseCase  = createUseCase;
-        _summaryUseCase = summaryUseCase;
-        _toggleUseCase  = toggleUseCase;
-        _deleteUseCase  = deleteUseCase;
+        _getListUseCase   = getListUseCase;
+        _getByIdUseCase   = getByIdUseCase;
+        _createUseCase    = createUseCase;
+        _summaryUseCase   = summaryUseCase;
+        _toggleUseCase    = toggleUseCase;
+        _deleteUseCase    = deleteUseCase;
+        _recurringUseCase = recurringUseCase;
+        _replicateUseCase = replicateUseCase;
     }
 
     /// <summary>Lista todos os períodos do usuário ordenados por ano/mês descendente.</summary>
@@ -87,4 +94,25 @@ public sealed class PeriodsController : ApiControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> GetSummary(Guid id, CancellationToken ct)
         => Ok(await _summaryUseCase.ExecuteAsync(id, CurrentUserId, ct));
+
+    /// <summary>Retorna as despesas recorrentes do período anterior ao informado.</summary>
+    [HttpGet("{id:guid}/recurring-expenses")]
+    [ProducesResponseType(typeof(IEnumerable<RecurringExpenseDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetRecurringExpenses(Guid id, CancellationToken ct)
+        => Ok(await _recurringUseCase.ExecuteAsync(CurrentUserId, id, ct));
+
+    /// <summary>Replica despesas recorrentes selecionadas para o período informado.</summary>
+    [HttpPost("{id:guid}/replicate-expenses")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> ReplicateExpenses(
+        Guid id,
+        [FromBody] IReadOnlyList<Guid> expenseIds,
+        CancellationToken ct)
+    {
+        await _replicateUseCase.ExecuteAsync(
+            new ReplicateExpensesDto(CurrentUserId, id, expenseIds), ct);
+        return NoContent();
+    }
 }

--- a/src/PersonalFinance.Api/Extensions/ApplicationExtensions.cs
+++ b/src/PersonalFinance.Api/Extensions/ApplicationExtensions.cs
@@ -66,6 +66,8 @@ public static class ApplicationExtensions
         services.AddScoped<PayExpensesBatchUseCase>();
         services.AddScoped<CancelExpensesBatchUseCase>();
         services.AddScoped<SaveExpenseOrderUseCase>();
+        services.AddScoped<GetRecurringExpensesFromLastPeriodUseCase>();
+        services.AddScoped<ReplicateExpensesUseCase>();
 
         // ── Financial — Incomes ───────────────────────────────────────────────
         services.AddScoped<GetIncomesByPeriodUseCase>();

--- a/src/PersonalFinance.Application/DTOs/Financial/FinancialDtos.cs
+++ b/src/PersonalFinance.Application/DTOs/Financial/FinancialDtos.cs
@@ -29,7 +29,8 @@ public sealed record CreateExpenseDto(
     string        Description,
     decimal       Amount,
     DateOnly      DueDate,
-    string?       Notes = null
+    string?       Notes = null,
+    bool          IsRecurring = false
 );
 
 public sealed record UpdateExpenseDto(
@@ -42,7 +43,8 @@ public sealed record UpdateExpenseDto(
     decimal       Amount,
     DateOnly      DueDate,
     string?       Notes,
-    PaymentStatus Status
+    PaymentStatus Status,
+    bool          IsRecurring = false
 );
 
 public sealed record ExpenseResponseDto(
@@ -58,7 +60,21 @@ public sealed record ExpenseResponseDto(
     DateOnly      DueDate,
     DateOnly?     PaymentDate,
     string?       Notes,
-    bool          IsActive
+    bool          IsActive,
+    bool          IsRecurring
+);
+
+public sealed record RecurringExpenseDto(
+    Guid    Id,
+    string  Description,
+    string? Notes,
+    decimal Amount
+);
+
+public sealed record ReplicateExpensesDto(
+    Guid             UserId,
+    Guid             TargetPeriodId,
+    IReadOnlyList<Guid> ExpenseIds
 );
 
 public sealed record ExpenseFilterDto(

--- a/src/PersonalFinance.Application/UseCases/Financial/Expenses/ExpenseUseCases.cs
+++ b/src/PersonalFinance.Application/UseCases/Financial/Expenses/ExpenseUseCases.cs
@@ -64,7 +64,8 @@ public sealed class CreateExpenseUseCase
             amount:        dto.Amount,
             dueDate:       dto.DueDate,
             paymentDate:   null,
-            notes:         dto.Notes
+            notes:         dto.Notes,
+            isRecurring:   dto.IsRecurring
         );
 
         await _expenseRepository.AddAsync(expense, ct);
@@ -77,7 +78,7 @@ public sealed class CreateExpenseUseCase
         new(e.Id, e.PeriodId, e.UserId, e.CategoryId,
             e.SourceType, e.FortnightType, e.PaymentStatus,
             e.Description, e.Amount, e.DueDate, e.PaymentDate,
-            e.Notes, e.IsActive);
+            e.Notes, e.IsActive, e.IsRecurring);
 }
 
 // ══════════════════════════════════════════════════════════════════════════════
@@ -132,7 +133,8 @@ public sealed class UpdateExpenseUseCase
             description:   dto.Description,
             amount:        dto.Amount,
             dueDate:       dto.DueDate,
-            notes:         dto.Notes
+            notes:         dto.Notes,
+            isRecurring:   dto.IsRecurring
         );
 
         if (dto.Status != expense.PaymentStatus)

--- a/src/PersonalFinance.Application/UseCases/Financial/Expenses/GetExpenseByIdUseCase.cs
+++ b/src/PersonalFinance.Application/UseCases/Financial/Expenses/GetExpenseByIdUseCase.cs
@@ -23,7 +23,7 @@ namespace PersonalFinance.Application.UseCases.Financial.Expenses
                 expense.Id, expense.PeriodId, expense.UserId, expense.CategoryId,
                 expense.SourceType, expense.FortnightType, expense.PaymentStatus,
                 expense.Description, expense.Amount, expense.DueDate, expense.PaymentDate,
-                expense.Notes, expense.IsActive);
+                expense.Notes, expense.IsActive, expense.IsRecurring);
         }
     }
 }

--- a/src/PersonalFinance.Application/UseCases/Financial/Expenses/GetExpensesByPeriodUseCase.cs
+++ b/src/PersonalFinance.Application/UseCases/Financial/Expenses/GetExpensesByPeriodUseCase.cs
@@ -49,6 +49,6 @@ namespace PersonalFinance.Application.UseCases.Financial.Expenses
             new(e.Id, e.PeriodId, e.UserId, e.CategoryId,
                 e.SourceType, e.FortnightType, e.PaymentStatus,
                 e.Description, e.Amount, e.DueDate, e.PaymentDate,
-                e.Notes, e.IsActive);
+                e.Notes, e.IsActive, e.IsRecurring);
     }
 }

--- a/src/PersonalFinance.Application/UseCases/Financial/Expenses/GetRecurringExpensesFromLastPeriodUseCase.cs
+++ b/src/PersonalFinance.Application/UseCases/Financial/Expenses/GetRecurringExpensesFromLastPeriodUseCase.cs
@@ -1,0 +1,27 @@
+using PersonalFinance.Application.DTOs.Financial;
+using PersonalFinance.Domain.Interfaces.Repositories;
+
+namespace PersonalFinance.Application.UseCases.Financial.Expenses;
+
+/// <summary>
+/// Retorna as despesas recorrentes do período mais recente do usuário,
+/// excluindo o período informado (recém-criado).
+/// </summary>
+public sealed class GetRecurringExpensesFromLastPeriodUseCase
+{
+    private readonly IExpenseRepository _expenseRepository;
+
+    public GetRecurringExpensesFromLastPeriodUseCase(IExpenseRepository expenseRepository)
+        => _expenseRepository = expenseRepository;
+
+    public async Task<IEnumerable<RecurringExpenseDto>> ExecuteAsync(
+        Guid userId,
+        Guid excludePeriodId,
+        CancellationToken ct = default)
+    {
+        var expenses = await _expenseRepository
+            .GetRecurringExpensesFromLastPeriodAsync(userId, excludePeriodId, ct);
+
+        return expenses.Select(e => new RecurringExpenseDto(e.Id, e.Description, e.Notes, e.Amount));
+    }
+}

--- a/src/PersonalFinance.Application/UseCases/Financial/Expenses/ReplicateExpensesUseCase.cs
+++ b/src/PersonalFinance.Application/UseCases/Financial/Expenses/ReplicateExpensesUseCase.cs
@@ -1,0 +1,86 @@
+using PersonalFinance.Application.DTOs.Financial;
+using PersonalFinance.Domain.Entities.Financial;
+using PersonalFinance.Domain.Enums;
+using PersonalFinance.Domain.Exceptions;
+using PersonalFinance.Domain.Interfaces.Repositories;
+
+namespace PersonalFinance.Application.UseCases.Financial.Expenses;
+
+/// <summary>
+/// Replica despesas recorrentes selecionadas para um período destino.
+/// - DueDate ajustado para o mês/ano do período destino, mantendo o dia original
+/// - PaymentStatus = Pending, PaymentDate = null
+/// - Idempotente: ignora despesas já replicadas no período destino (via SourceExpenseId)
+/// </summary>
+public sealed class ReplicateExpensesUseCase
+{
+    private readonly IExpenseRepository _expenseRepository;
+    private readonly IPeriodRepository  _periodRepository;
+    private readonly IUnitOfWork        _unitOfWork;
+
+    public ReplicateExpensesUseCase(
+        IExpenseRepository expenseRepository,
+        IPeriodRepository  periodRepository,
+        IUnitOfWork        unitOfWork)
+    {
+        _expenseRepository = expenseRepository;
+        _periodRepository  = periodRepository;
+        _unitOfWork        = unitOfWork;
+    }
+
+    public async Task ExecuteAsync(ReplicateExpensesDto dto, CancellationToken ct = default)
+    {
+        if (dto.ExpenseIds.Count == 0)
+            throw new DomainException("A lista de despesas não pode ser vazia.");
+
+        var period = await _periodRepository.GetByIdAndUserAsync(dto.TargetPeriodId, dto.UserId, ct)
+            ?? throw new DomainException("Período destino não encontrado ou sem permissão de acesso.");
+
+        var sourceExpenses = (await _expenseRepository
+            .GetByIdsAndUserAsync(dto.ExpenseIds, dto.UserId, ct)).ToList();
+
+        if (sourceExpenses.Count == 0)
+            throw new DomainException("Nenhuma despesa encontrada ou sem permissão de acesso.");
+
+        var toAdd = new List<Expense>();
+
+        foreach (var source in sourceExpenses)
+        {
+            // Idempotência: pula se já replicada neste período
+            var alreadyReplicated = await _expenseRepository
+                .HasReplicatedExpenseAsync(source.Id, dto.TargetPeriodId, ct);
+
+            if (alreadyReplicated)
+                continue;
+
+            // Ajusta DueDate para mês/ano do período destino, mantendo o dia original
+            var day = Math.Min(source.DueDate.Day,
+                DateTime.DaysInMonth(period.Year, period.Month));
+            var dueDate = new DateOnly(period.Year, period.Month, day);
+
+            var replicated = Expense.Create(
+                periodId:        dto.TargetPeriodId,
+                userId:          dto.UserId,
+                categoryId:      source.CategoryId,
+                sourceType:      source.SourceType,
+                fortnightType:   source.FortnightType,
+                paymentStatus:   PaymentStatus.Pending,
+                description:     source.Description,
+                amount:          source.Amount,
+                dueDate:         dueDate,
+                paymentDate:     null,
+                notes:           source.Notes,
+                isRecurring:     source.IsRecurring,
+                sourceExpenseId: source.Id
+            );
+
+            toAdd.Add(replicated);
+        }
+
+        if (toAdd.Count > 0)
+        {
+            await _expenseRepository.AddRangeAsync(toAdd, ct);
+            await _unitOfWork.CommitAsync(ct);
+        }
+    }
+}

--- a/src/PersonalFinance.Domain/Entities/Financial/Expense.cs
+++ b/src/PersonalFinance.Domain/Entities/Financial/Expense.cs
@@ -48,6 +48,12 @@ public sealed class Expense : EntityBase
     /// <summary>Observações livres. Nullable.</summary>
     public string? Notes { get; private set; }
 
+    /// <summary>Indica se a despesa deve ser replicada em novos períodos.</summary>
+    public bool IsRecurring { get; private set; }
+
+    /// <summary>Referência à despesa original quando replicada de outro período. Nullable.</summary>
+    public Guid? SourceExpenseId { get; private set; }
+
     // ── EF Core ───────────────────────────────────────────────────────────────
     private Expense() { }
 
@@ -64,7 +70,9 @@ public sealed class Expense : EntityBase
         decimal amount,
         DateOnly dueDate,
         DateOnly? paymentDate,
-        string? notes)
+        string? notes,
+        bool isRecurring = false,
+        Guid? sourceExpenseId = null)
     {
         ValidateId(periodId,   "O PeriodId da despesa é obrigatório.");
         ValidateId(userId,     "O UserId da despesa é obrigatório.");
@@ -74,17 +82,19 @@ public sealed class Expense : EntityBase
 
         return new Expense
         {
-            PeriodId      = periodId,
-            UserId        = userId,
-            CategoryId    = categoryId,
-            SourceType    = sourceType,
-            FortnightType = fortnightType,
-            PaymentStatus = paymentStatus,
-            Description   = description.Trim(),
-            Amount        = amount,
-            DueDate       = dueDate,
-            PaymentDate   = paymentDate,
-            Notes         = notes?.Trim()
+            PeriodId        = periodId,
+            UserId          = userId,
+            CategoryId      = categoryId,
+            SourceType      = sourceType,
+            FortnightType   = fortnightType,
+            PaymentStatus   = paymentStatus,
+            Description     = description.Trim(),
+            Amount          = amount,
+            DueDate         = dueDate,
+            PaymentDate     = paymentDate,
+            Notes           = notes?.Trim(),
+            IsRecurring     = isRecurring,
+            SourceExpenseId = sourceExpenseId
         };
     }
 
@@ -140,7 +150,8 @@ public sealed class Expense : EntityBase
         string description,
         decimal amount,
         DateOnly dueDate,
-        string? notes)
+        string? notes,
+        bool isRecurring = false)
     {
         ValidateId(categoryId, "O CategoryId da despesa é obrigatório.");
         ValidateDescription(description);
@@ -153,6 +164,7 @@ public sealed class Expense : EntityBase
         Amount        = amount;
         DueDate       = dueDate;
         Notes         = notes?.Trim();
+        IsRecurring   = isRecurring;
         SetUpdatedAt();
     }
 

--- a/src/PersonalFinance.Domain/Interfaces/Repositories/IExpenseRepository.cs
+++ b/src/PersonalFinance.Domain/Interfaces/Repositories/IExpenseRepository.cs
@@ -47,4 +47,16 @@ public interface IExpenseRepository
     /// Usado pelo DeleteCategoryUseCase para impedir exclusão com dependências.
     /// </summary>
     Task<bool> HasExpensesByCategoryAsync(Guid categoryId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Retorna as despesas recorrentes do período mais recente do usuário (excluindo o período informado).
+    /// </summary>
+    Task<IEnumerable<Expense>> GetRecurringExpensesFromLastPeriodAsync(Guid userId, Guid excludePeriodId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Verifica se já existe uma despesa replicada a partir da despesa origem no período destino.
+    /// </summary>
+    Task<bool> HasReplicatedExpenseAsync(Guid sourceExpenseId, Guid targetPeriodId, CancellationToken ct = default);
+
+    Task AddRangeAsync(IEnumerable<Expense> expenses, CancellationToken ct = default);
 }

--- a/src/PersonalFinance.Infrastructure/Migrations/20260501153944_AddExpenseRecurringAndSourceExpenseId.Designer.cs
+++ b/src/PersonalFinance.Infrastructure/Migrations/20260501153944_AddExpenseRecurringAndSourceExpenseId.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using PersonalFinance.Infrastructure.Persistence.Context;
 
@@ -11,9 +12,11 @@ using PersonalFinance.Infrastructure.Persistence.Context;
 namespace PersonalFinance.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260501153944_AddExpenseRecurringAndSourceExpenseId")]
+    partial class AddExpenseRecurringAndSourceExpenseId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/PersonalFinance.Infrastructure/Migrations/20260501153944_AddExpenseRecurringAndSourceExpenseId.cs
+++ b/src/PersonalFinance.Infrastructure/Migrations/20260501153944_AddExpenseRecurringAndSourceExpenseId.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PersonalFinance.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExpenseRecurringAndSourceExpenseId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsRecurring",
+                table: "Expense",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "SourceExpenseId",
+                table: "Expense",
+                type: "uniqueidentifier",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Expense_SourceExpenseId",
+                table: "Expense",
+                column: "SourceExpenseId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Expense_Expense_SourceExpenseId",
+                table: "Expense",
+                column: "SourceExpenseId",
+                principalTable: "Expense",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Expense_Expense_SourceExpenseId",
+                table: "Expense");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Expense_SourceExpenseId",
+                table: "Expense");
+
+            migrationBuilder.DropColumn(
+                name: "IsRecurring",
+                table: "Expense");
+
+            migrationBuilder.DropColumn(
+                name: "SourceExpenseId",
+                table: "Expense");
+        }
+    }
+}

--- a/src/PersonalFinance.Infrastructure/Persistence/Configurations/Financial/FinancialConfigurations.cs
+++ b/src/PersonalFinance.Infrastructure/Persistence/Configurations/Financial/FinancialConfigurations.cs
@@ -140,6 +140,16 @@ public sealed class ExpenseConfiguration : IEntityTypeConfiguration<Expense>
                .HasColumnType("nvarchar(500)")
                .IsRequired(false);
 
+        builder.Property(e => e.IsRecurring)
+               .HasColumnName("IsRecurring")
+               .HasColumnType("bit")
+               .IsRequired();
+
+        builder.Property(e => e.SourceExpenseId)
+               .HasColumnName("SourceExpenseId")
+               .HasColumnType("uniqueidentifier")
+               .IsRequired(false);
+
         // CHECK constraint — valor sempre positivo
         builder.ToTable(t => t.HasCheckConstraint(
             "CK_Expense_Amount", "[Amount] > 0"));
@@ -158,6 +168,11 @@ public sealed class ExpenseConfiguration : IEntityTypeConfiguration<Expense>
         builder.HasOne<Category>()
                .WithMany()
                .HasForeignKey(e => e.CategoryId)
+               .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne<Expense>()
+               .WithMany()
+               .HasForeignKey(e => e.SourceExpenseId)
                .OnDelete(DeleteBehavior.Restrict);
 
         // Índices

--- a/src/PersonalFinance.Infrastructure/Persistence/Repositories/Financial/ExpenseRepository.cs
+++ b/src/PersonalFinance.Infrastructure/Persistence/Repositories/Financial/ExpenseRepository.cs
@@ -122,7 +122,35 @@ public sealed class ExpenseRepository : IExpenseRepository
     }
 
     public async Task<bool> HasExpensesByCategoryAsync(
-    Guid categoryId, CancellationToken ct = default)
-    => await _context.Expenses
-           .AnyAsync(e => e.CategoryId == categoryId, ct);
+        Guid categoryId, CancellationToken ct = default)
+        => await _context.Expenses
+               .AnyAsync(e => e.CategoryId == categoryId, ct);
+
+    public async Task<IEnumerable<Expense>> GetRecurringExpensesFromLastPeriodAsync(
+        Guid userId, Guid excludePeriodId, CancellationToken ct = default)
+    {
+        // Busca o período mais recente do usuário (excluindo o período recém-criado)
+        var lastPeriod = await _context.Periods
+            .Where(p => p.UserId == userId && p.Id != excludePeriodId)
+            .OrderByDescending(p => p.Year)
+            .ThenByDescending(p => p.Month)
+            .FirstOrDefaultAsync(ct);
+
+        if (lastPeriod is null)
+            return [];
+
+        return await _context.Expenses
+            .Where(e => e.PeriodId == lastPeriod.Id && e.UserId == userId && e.IsRecurring)
+            .OrderBy(e => e.FortnightType)
+            .ThenBy(e => e.DueDate)
+            .ToListAsync(ct);
+    }
+
+    public async Task<bool> HasReplicatedExpenseAsync(
+        Guid sourceExpenseId, Guid targetPeriodId, CancellationToken ct = default)
+        => await _context.Expenses
+               .AnyAsync(e => e.SourceExpenseId == sourceExpenseId && e.PeriodId == targetPeriodId, ct);
+
+    public async Task AddRangeAsync(IEnumerable<Expense> expenses, CancellationToken ct = default)
+        => await _context.Expenses.AddRangeAsync(expenses, ct);
 }

--- a/tests/PersonalFinance.Application.Tests/Unit/Financial/GetRecurringExpensesFromLastPeriodUseCaseTests.cs
+++ b/tests/PersonalFinance.Application.Tests/Unit/Financial/GetRecurringExpensesFromLastPeriodUseCaseTests.cs
@@ -1,0 +1,54 @@
+using FluentAssertions;
+using Moq;
+using PersonalFinance.Application.UseCases.Financial.Expenses;
+using PersonalFinance.Domain.Entities.Financial;
+using PersonalFinance.Domain.Enums;
+using PersonalFinance.Domain.Interfaces.Repositories;
+using Xunit;
+
+namespace PersonalFinance.Application.Tests.Unit.Financial;
+
+public class GetRecurringExpensesFromLastPeriodUseCaseTests
+{
+    private readonly Mock<IExpenseRepository> _repo = new();
+
+    private static Expense MakeRecurringExpense(Guid userId) =>
+        Expense.Create(
+            Guid.NewGuid(), userId, Guid.NewGuid(),
+            SourceType.Personal, FortnightType.First, PaymentStatus.Pending,
+            "Aluguel", 1500m, new DateOnly(2025, 4, 10), null, "obs",
+            isRecurring: true);
+
+    [Fact(DisplayName = "Deve retornar apenas despesas recorrentes do último período")]
+    public async Task ShouldReturnRecurringExpenses()
+    {
+        var userId          = Guid.NewGuid();
+        var excludePeriodId = Guid.NewGuid();
+        var expenses        = new[] { MakeRecurringExpense(userId), MakeRecurringExpense(userId) };
+
+        _repo.Setup(r => r.GetRecurringExpensesFromLastPeriodAsync(userId, excludePeriodId, default))
+             .ReturnsAsync(expenses);
+
+        var sut    = new GetRecurringExpensesFromLastPeriodUseCase(_repo.Object);
+        var result = (await sut.ExecuteAsync(userId, excludePeriodId)).ToList();
+
+        result.Should().HaveCount(2);
+        result.Should().AllSatisfy(r => r.Amount.Should().BeGreaterThan(0));
+        result.Should().AllSatisfy(r => r.Description.Should().NotBeNullOrEmpty());
+    }
+
+    [Fact(DisplayName = "Deve retornar lista vazia quando não há despesas recorrentes")]
+    public async Task ShouldReturnEmptyWhenNoRecurring()
+    {
+        var userId          = Guid.NewGuid();
+        var excludePeriodId = Guid.NewGuid();
+
+        _repo.Setup(r => r.GetRecurringExpensesFromLastPeriodAsync(userId, excludePeriodId, default))
+             .ReturnsAsync([]);
+
+        var sut    = new GetRecurringExpensesFromLastPeriodUseCase(_repo.Object);
+        var result = await sut.ExecuteAsync(userId, excludePeriodId);
+
+        result.Should().BeEmpty();
+    }
+}

--- a/tests/PersonalFinance.Application.Tests/Unit/Financial/ReplicateExpensesUseCaseTests.cs
+++ b/tests/PersonalFinance.Application.Tests/Unit/Financial/ReplicateExpensesUseCaseTests.cs
@@ -1,0 +1,101 @@
+using FluentAssertions;
+using Moq;
+using PersonalFinance.Application.DTOs.Financial;
+using PersonalFinance.Application.UseCases.Financial.Expenses;
+using PersonalFinance.Domain.Entities.Financial;
+using PersonalFinance.Domain.Enums;
+using PersonalFinance.Domain.Exceptions;
+using PersonalFinance.Domain.Interfaces.Repositories;
+using Xunit;
+
+namespace PersonalFinance.Application.Tests.Unit.Financial;
+
+public class ReplicateExpensesUseCaseTests
+{
+    private readonly Mock<IExpenseRepository> _expRepo  = new();
+    private readonly Mock<IPeriodRepository>  _perRepo  = new();
+    private readonly Mock<IUnitOfWork>        _uow      = new();
+
+    private static Period MakePeriod(Guid userId, int year = 2025, int month = 5)
+        => Period.Create(userId, year, month);
+
+    private static Expense MakeRecurringExpense(Guid userId, int day = 10)
+        => Expense.Create(
+            Guid.NewGuid(), userId, Guid.NewGuid(),
+            SourceType.Personal, FortnightType.First, PaymentStatus.Pending,
+            "Aluguel", 1500m, new DateOnly(2025, 4, day), null, null,
+            isRecurring: true);
+
+    [Fact(DisplayName = "Deve replicar despesas com DueDate ajustado para o período destino")]
+    public async Task ShouldReplicateWithAdjustedDueDate()
+    {
+        var userId   = Guid.NewGuid();
+        var period   = MakePeriod(userId, 2025, 5);
+        var source   = MakeRecurringExpense(userId, day: 10);
+        var ids      = new List<Guid> { source.Id };
+
+        _perRepo.Setup(r => r.GetByIdAndUserAsync(period.Id, userId, default))
+                .ReturnsAsync(period);
+        _expRepo.Setup(r => r.GetByIdsAndUserAsync(ids, userId, default))
+                .ReturnsAsync([source]);
+        _expRepo.Setup(r => r.HasReplicatedExpenseAsync(source.Id, period.Id, default))
+                .ReturnsAsync(false);
+
+        List<Expense>? captured = null;
+        _expRepo.Setup(r => r.AddRangeAsync(It.IsAny<IEnumerable<Expense>>(), default))
+                .Callback<IEnumerable<Expense>, CancellationToken>((e, _) => captured = e.ToList())
+                .Returns(Task.CompletedTask);
+
+        var sut = new ReplicateExpensesUseCase(_expRepo.Object, _perRepo.Object, _uow.Object);
+        await sut.ExecuteAsync(new ReplicateExpensesDto(userId, period.Id, ids));
+
+        captured.Should().HaveCount(1);
+        captured![0].DueDate.Should().Be(new DateOnly(2025, 5, 10));
+        captured[0].PaymentStatus.Should().Be(PaymentStatus.Pending);
+        captured[0].PaymentDate.Should().BeNull();
+        captured[0].SourceExpenseId.Should().Be(source.Id);
+        _uow.Verify(u => u.CommitAsync(default), Times.Once);
+    }
+
+    [Fact(DisplayName = "Deve ignorar despesas já replicadas no período (idempotência)")]
+    public async Task ShouldSkipAlreadyReplicatedExpenses()
+    {
+        var userId = Guid.NewGuid();
+        var period = MakePeriod(userId, 2025, 5);
+        var source = MakeRecurringExpense(userId);
+        var ids    = new List<Guid> { source.Id };
+
+        _perRepo.Setup(r => r.GetByIdAndUserAsync(period.Id, userId, default))
+                .ReturnsAsync(period);
+        _expRepo.Setup(r => r.GetByIdsAndUserAsync(ids, userId, default))
+                .ReturnsAsync([source]);
+        _expRepo.Setup(r => r.HasReplicatedExpenseAsync(source.Id, period.Id, default))
+                .ReturnsAsync(true); // já replicada
+
+        var sut = new ReplicateExpensesUseCase(_expRepo.Object, _perRepo.Object, _uow.Object);
+        await sut.ExecuteAsync(new ReplicateExpensesDto(userId, period.Id, ids));
+
+        _expRepo.Verify(r => r.AddRangeAsync(It.IsAny<IEnumerable<Expense>>(), default), Times.Never);
+        _uow.Verify(u => u.CommitAsync(default), Times.Never);
+    }
+
+    [Fact(DisplayName = "Lista vazia deve lançar DomainException")]
+    public async Task EmptyList_ShouldThrow()
+    {
+        var sut = new ReplicateExpensesUseCase(_expRepo.Object, _perRepo.Object, _uow.Object);
+        var act = () => sut.ExecuteAsync(new ReplicateExpensesDto(Guid.NewGuid(), Guid.NewGuid(), []));
+        await act.Should().ThrowAsync<DomainException>();
+    }
+
+    [Fact(DisplayName = "Período não encontrado deve lançar DomainException")]
+    public async Task PeriodNotFound_ShouldThrow()
+    {
+        var ids = new List<Guid> { Guid.NewGuid() };
+        _perRepo.Setup(r => r.GetByIdAndUserAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), default))
+                .ReturnsAsync((Period?)null);
+
+        var sut = new ReplicateExpensesUseCase(_expRepo.Object, _perRepo.Object, _uow.Object);
+        var act = () => sut.ExecuteAsync(new ReplicateExpensesDto(Guid.NewGuid(), Guid.NewGuid(), ids));
+        await act.Should().ThrowAsync<DomainException>();
+    }
+}


### PR DESCRIPTION
Closes #247

## Resumo
- Campo `IsRecurring` + `SourceExpenseId` em `Expense` com migration
- `GetRecurringExpensesFromLastPeriodUseCase` retorna recorrentes do último período
- `ReplicateExpensesUseCase` replica com DueDate ajustado ao novo período, status Pendente, idempotente via `SourceExpenseId`
- Endpoints `GET /periods/{id}/recurring-expenses` e `POST /periods/{id}/replicate-expenses`
- `RecurringExpensesModal` (Sonic modal) abre automaticamente após criação de período com despesas recorrentes
- 6 testes unitários novos