### PR TITLE
fix(#247): ExistsAsync ignora soft-deleted ao verificar unicidade de período

### DIFF
--- a/src/PersonalFinance.Infrastructure/Persistence/Repositories/Financial/PeriodRepository.cs
+++ b/src/PersonalFinance.Infrastructure/Persistence/Repositories/Financial/PeriodRepository.cs
@@ -44,6 +44,7 @@ public sealed class PeriodRepository : IPeriodRepository
         Guid userId, int year, int month,
         CancellationToken ct = default)
         => await _context.Periods
+               .IgnoreQueryFilters()
                .AnyAsync(p => p.UserId == userId &&
                               p.Year   == year    &&
                               p.Month  == month, ct);


### PR DESCRIPTION
Closes #247

## Resumo
- `ExistsAsync` em `PeriodRepository` passa a usar `IgnoreQueryFilters()` para detectar períodos soft-deleted antes de tentar inserir, evitando violação de UNIQUE KEY constraint.