### PR TITLE
fix(#247): restaura período soft-deleted ao criar duplicata

### DIFF
--- a/src/PersonalFinance.Application/UseCases/Financial/Periods/PeriodUseCases.cs
+++ b/src/PersonalFinance.Application/UseCases/Financial/Periods/PeriodUseCases.cs
@@ -31,12 +31,22 @@ public sealed class CreatePeriodUseCase
         CreatePeriodDto dto,
         CancellationToken ct = default)
     {
-        var exists = await _periodRepository
-            .ExistsAsync(dto.UserId, dto.Year, dto.Month, ct);
+        var existing = await _periodRepository
+            .GetByUserYearMonthAsync(dto.UserId, dto.Year, dto.Month, ct);
 
-        if (exists)
-            throw new DomainException(
-                $"Já existe um período para {dto.Month:D2}/{dto.Year}.");
+        if (existing is not null)
+        {
+            // Período ativo — rejeita duplicata
+            if (!existing.IsDeleted)
+                throw new DomainException(
+                    $"Já existe um período para {dto.Month:D2}/{dto.Year}.");
+
+            // Período soft-deleted — restaura em vez de criar novo
+            existing.Reactivate();
+            await _periodRepository.UpdateAsync(existing, ct);
+            await _unitOfWork.CommitAsync(ct);
+            return ToDto(existing);
+        }
 
         var period = Period.Create(dto.UserId, dto.Year, dto.Month);
 

--- a/src/PersonalFinance.Domain/Interfaces/Repositories/IPeriodRepository.cs
+++ b/src/PersonalFinance.Domain/Interfaces/Repositories/IPeriodRepository.cs
@@ -21,6 +21,7 @@ public interface IPeriodRepository
         CancellationToken ct = default);
 
     Task AddAsync(Period period, CancellationToken ct = default);
+    Task UpdateAsync(Period period, CancellationToken ct = default);
 
     /// <summary>
     /// Retorna true se o período existir e pertencer ao usuário informado.

--- a/src/PersonalFinance.Infrastructure/Persistence/Repositories/Financial/PeriodRepository.cs
+++ b/src/PersonalFinance.Infrastructure/Persistence/Repositories/Financial/PeriodRepository.cs
@@ -52,6 +52,12 @@ public sealed class PeriodRepository : IPeriodRepository
     public async Task AddAsync(Period period, CancellationToken ct = default)
         => await _context.Periods.AddAsync(period, ct);
 
+    public Task UpdateAsync(Period period, CancellationToken ct = default)
+    {
+        _context.Periods.Update(period);
+        return Task.CompletedTask;
+    }
+
     public async Task<bool> ExistsByIdAndUserAsync(
     Guid id, Guid userId, CancellationToken ct = default)
     => await _context.Periods


### PR DESCRIPTION
Closes #247

## Resumo
- `CreatePeriodUseCase` agora usa `GetByUserYearMonthAsync` (com `IgnoreQueryFilters`) para detectar período excluído
- Se soft-deleted: chama `Reactivate()` e persiste — sem criar novo registro
- Se ativo: mantém o erro `DomainException` de duplicata
- Adicionado `UpdateAsync` em `IPeriodRepository` e `PeriodRepository`