### PR TITLE
fix(#247): toggle de período usa Deactivate() em vez de SoftDelete()

### DIFF
--- a/src/PersonalFinance.Application/UseCases/Financial/Periods/TogglePeriodActiveUseCase.cs
+++ b/src/PersonalFinance.Application/UseCases/Financial/Periods/TogglePeriodActiveUseCase.cs
@@ -31,10 +31,11 @@ public sealed class TogglePeriodActiveUseCase
                 "Período não encontrado ou sem permissão de acesso.");
 
         if (period.IsActive)
-            period.SoftDelete();
+            period.Deactivate();
         else
             period.Reactivate();
 
+        await _periodRepository.UpdateAsync(period, ct);
         await _unitOfWork.CommitAsync(ct);
     }
 }

--- a/src/PersonalFinance.Domain/Entities/Shared/EntityBase.cs
+++ b/src/PersonalFinance.Domain/Entities/Shared/EntityBase.cs
@@ -36,6 +36,15 @@ public abstract class EntityBase
     }
 
     /// <summary>
+    /// Desativa o registro sem excluí-lo logicamente (DeletedAt permanece null).
+    /// </summary>
+    public void Deactivate()
+    {
+        IsActive = false;
+        SetUpdatedAt();
+    }
+
+    /// <summary>
     /// Reativa um registro previamente excluído logicamente.
     /// Limpa DeletedAt e seta IsActive = true.
     /// </summary>


### PR DESCRIPTION
Closes #247

## Resumo
- `Deactivate()` adicionado em `EntityBase`: seta `IsActive = false` sem tocar em `DeletedAt`
- `TogglePeriodActiveUseCase` passa a usar `Deactivate()` ao desativar, evitando que o período desapareça do query filter e impeça a reativação