### PR TITLE
feat(#247): checkbox isRecurring no formulário de despesas

### DIFF
--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.css
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.css
@@ -329,3 +329,20 @@
 }
 
 @keyframes spin { to { transform: rotate(360deg); } }
+
+.checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.875rem;
+  color: var(--ink2);
+  cursor: pointer;
+  user-select: none;
+}
+
+.checkbox-label input[type="checkbox"] {
+  width: 15px;
+  height: 15px;
+  accent-color: var(--accent, #6366f1);
+  cursor: pointer;
+}

--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.html
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.html
@@ -314,6 +314,13 @@
             <input formControlName="notes" class="input" placeholder="Opcional..." />
           </div>
 
+          <div class="field field-full">
+            <label class="checkbox-label">
+              <input type="checkbox" formControlName="isRecurring" />
+              Despesa recorrente
+            </label>
+          </div>
+
         </div>
 
         @if (apiError()) {

--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.ts
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.ts
@@ -202,6 +202,7 @@ export class ExpensesComponent implements OnInit {
     fortnightType: [FortnightType.First],
     notes:         [''],
     status:        [PaymentStatus.Pending],
+    isRecurring:   [false],
   });
 
   ngOnInit(): void {
@@ -267,6 +268,7 @@ export class ExpensesComponent implements OnInit {
       fortnightType: expense.fortnightType,
       notes:         expense.notes ?? '',
       status:        expense.paymentStatus,
+      isRecurring:   expense.isRecurring,
     });
     this.modalOpen.set(true);
   }
@@ -365,6 +367,7 @@ export class ExpensesComponent implements OnInit {
         sourceType:    Number(v.sourceType) as SourceType,
         fortnightType: Number(v.fortnightType) as FortnightType,
         notes:         v.notes || undefined,
+        isRecurring:   v.isRecurring ?? false,
       }).subscribe({
         next: () => {
           this.closeModal();
@@ -392,6 +395,7 @@ export class ExpensesComponent implements OnInit {
         fortnightType,
         notes:         v.notes || undefined,
         status,
+        isRecurring:   v.isRecurring ?? false,
       }).subscribe({
         next: () => {
           this.expenses.update(list =>


### PR DESCRIPTION
Closes #247

## Resumo
- Checkbox "Despesa recorrente" adicionado no modal de criar/editar despesa
- Campo `isRecurring` incluído nos submits de criação e edição
- `openEditModal` carrega o valor atual de `isRecurring` ao editar