### PR TITLE
fix(#247): corrige testes quebrados pelas mudanças de comportamento

### DIFF
--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.spec.ts
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.spec.ts
@@ -16,7 +16,7 @@ const EXPENSE: ExpenseResponse = {
   id: 'e-1', periodId: 'p-1', userId: 'u', categoryId: 'cat-1', description: 'Aluguel',
   amount: 1000, dueDate: '2024-04-05T00:00:00', paymentStatus: PaymentStatus.Pending,
   paymentDate: null, sourceType: SourceType.Personal, fortnightType: FortnightType.First,
-  notes: null, isActive: true,
+  notes: null, isActive: true, isRecurring: false,
 };
 
 describe('ExpensesComponent', () => {

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.spec.ts
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.spec.ts
@@ -38,6 +38,7 @@ const EXPENSE: ExpenseResponse = {
   fortnightType:  FortnightType.First,
   notes:          null,
   isActive:       true,
+  isRecurring:    false,
 };
 
 const INCOME: IncomeResponse = {

--- a/personal-finance/src/app/features/periods/components/periods/periods.component.spec.ts
+++ b/personal-finance/src/app/features/periods/components/periods/periods.component.spec.ts
@@ -20,8 +20,9 @@ describe('PeriodsComponent', () => {
 
   beforeEach(async () => {
     apiSpy = jasmine.createSpyObj('ApiService', [
-      'getPeriods', 'createPeriod', 'togglePeriodActive', 'deletePeriod'
+      'getPeriods', 'createPeriod', 'togglePeriodActive', 'deletePeriod', 'getRecurringExpenses'
     ]);
+    apiSpy.getRecurringExpenses.and.returnValue(of([]));
     apiSpy.getPeriods.and.returnValue(of(MOCK_PERIODS));
 
     await TestBed.configureTestingModule({

--- a/tests/PersonalFinance.Application.Tests/Unit/Financial/FinancialUseCaseTests.cs
+++ b/tests/PersonalFinance.Application.Tests/Unit/Financial/FinancialUseCaseTests.cs
@@ -30,8 +30,8 @@ public class CreatePeriodUseCaseTests
     [Fact(DisplayName = "Deve criar período com dados válidos")]
     public async Task Execute_WithValidData_ShouldCreatePeriod()
     {
-        _periodRepo.Setup(r => r.ExistsAsync(UserId, 2026, 4, default))
-                   .ReturnsAsync(false);
+        _periodRepo.Setup(r => r.GetByUserYearMonthAsync(UserId, 2026, 4, default))
+                   .ReturnsAsync((Period?)null);
 
         var result = await _sut.ExecuteAsync(new CreatePeriodDto(UserId, 2026, 4));
 
@@ -44,8 +44,9 @@ public class CreatePeriodUseCaseTests
     [Fact(DisplayName = "Deve lançar exceção para período já existente no mês")]
     public async Task Execute_WithDuplicatePeriod_ShouldThrow()
     {
-        _periodRepo.Setup(r => r.ExistsAsync(UserId, 2026, 4, default))
-                   .ReturnsAsync(true);
+        var existing = Period.Create(UserId, 2026, 4);
+        _periodRepo.Setup(r => r.GetByUserYearMonthAsync(UserId, 2026, 4, default))
+                   .ReturnsAsync(existing);
 
         var act = () => _sut.ExecuteAsync(new CreatePeriodDto(UserId, 2026, 4));
 

--- a/tests/PersonalFinance.Application.Tests/Unit/Financial/TogglePeriodActiveUseCaseTests.cs
+++ b/tests/PersonalFinance.Application.Tests/Unit/Financial/TogglePeriodActiveUseCaseTests.cs
@@ -32,7 +32,7 @@ public class TogglePeriodActiveUseCaseTests
         await _sut.ExecuteAsync(PeriodId, UserId);
 
         period.IsActive.Should().BeFalse();
-        period.IsDeleted.Should().BeTrue();
+        period.IsDeleted.Should().BeFalse();
         _uow.Verify(u => u.CommitAsync(default), Times.Once);
     }
 
@@ -40,7 +40,7 @@ public class TogglePeriodActiveUseCaseTests
     public async Task Execute_InactivePeriod_ShouldReactivate()
     {
         var period = Period.Create(UserId, 2026, 4);
-        period.SoftDelete();
+        period.Deactivate();
         _periodRepo.Setup(r => r.GetByIdAndUserAsync(PeriodId, UserId, default))
                    .ReturnsAsync(period);
 


### PR DESCRIPTION
Closes #247

## Resumo
- `TogglePeriodActiveUseCaseTests`: `IsDeleted` deve ser `false` após `Deactivate()` (não `SoftDelete`)
- `CreatePeriodUseCaseTests`: mock trocado de `ExistsAsync` para `GetByUserYearMonthAsync`
- specs frontend: `isRecurring: false` adicionado nos fixtures `ExpenseResponse`
- `periods.component.spec`: `getRecurringExpenses` adicionado ao spy com retorno vazio