### PR TITLE
feat(#244): animação Mario Block na tela de login

### DIFF
--- a/personal-finance/src/app/features/auth/components/login/login.component.css
+++ b/personal-finance/src/app/features/auth/components/login/login.component.css
@@ -200,13 +200,19 @@
 @keyframes spin { to { transform: rotate(360deg); } }
 
 /* ── Mario Block ── */
+.mario-block-area {
+  position: relative;
+  width: 44px;
+  height: 44px;
+  flex-shrink: 0;
+}
+
 .mario-block-wrap {
   position: relative;
   width: 44px;
   height: 44px;
   cursor: pointer;
   user-select: none;
-  flex-shrink: 0;
 }
 
 .mario-block-img {
@@ -228,36 +234,51 @@
   100% { transform: translateY(0); }
 }
 
-/* ── Coin ── */
-.coin {
+/* ── Coin — outer controla X (linear), inner controla Y (física) ── */
+.coin-x {
   position: absolute;
-  width: 24px;
-  height: 24px;
   top: 0;
   left: 10px;
   pointer-events: none;
+}
+
+.coin-x-flying {
+  animation: coin-fly-x 1.5s linear forwards;
+}
+
+@keyframes coin-fly-x {
+  from { transform: translateX(0px); }
+  to   { transform: translateX(var(--cx)); }
+}
+
+.coin-y {
+  width: 24px;
+  height: 24px;
+  display: block;
   image-rendering: pixelated;
 }
 
-.coin-flying {
-  animation: coin-fly 1.5s ease-out forwards;
+.coin-y-flying {
+  animation: coin-fly-y 1.5s linear forwards;
 }
 
-@keyframes coin-fly {
-  0%   { transform: translate(0px, 0px); }
-  20%  { transform: translate(calc(var(--cx) * 0.2), -90px); }
-  55%  { transform: translate(var(--cx), 65px); }
-  70%  { transform: translate(var(--cx), 45px); }
-  82%  { transform: translate(var(--cx), 62px); }
-  90%  { transform: translate(var(--cx), 58px); }
-  100% { transform: translate(var(--cx), 60px); }
+/* easeOutCubic = deceleração (subida / quique para cima) */
+/* easeInCubic  = aceleração  (queda)                     */
+@keyframes coin-fly-y {
+  0%   { transform: translateY(0px);   animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1); }
+  32%  { transform: translateY(-88px); animation-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19); }
+  62%  { transform: translateY(60px);  animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1); }
+  76%  { transform: translateY(22px);  animation-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19); }
+  88%  { transform: translateY(60px);  animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1); }
+  94%  { transform: translateY(46px);  animation-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19); }
+  100% { transform: translateY(60px); }
 }
 
-@keyframes blink {
-  0%, 100% { opacity: 1; }
-  50%       { opacity: 0; }
+@keyframes blink-rest {
+  0%, 100% { transform: translateY(60px); opacity: 1; }
+  50%       { transform: translateY(60px); opacity: 0; }
 }
 
-.coin-slow   { animation: blink 0.8s linear infinite; }
-.coin-medium { animation: blink 0.35s linear infinite; }
-.coin-fast   { animation: blink 0.15s linear infinite; }
+.coin-slow   { animation: blink-rest 0.8s  linear infinite; }
+.coin-medium { animation: blink-rest 0.35s linear infinite; }
+.coin-fast   { animation: blink-rest 0.15s linear infinite; }

--- a/personal-finance/src/app/features/auth/components/login/login.component.css
+++ b/personal-finance/src/app/features/auth/components/login/login.component.css
@@ -198,3 +198,66 @@
 }
 
 @keyframes spin { to { transform: rotate(360deg); } }
+
+/* ── Mario Block ── */
+.mario-block-wrap {
+  position: relative;
+  width: 44px;
+  height: 44px;
+  cursor: pointer;
+  user-select: none;
+  flex-shrink: 0;
+}
+
+.mario-block-img {
+  width: 44px;
+  height: 44px;
+  display: block;
+  image-rendering: pixelated;
+}
+
+.block-bounce {
+  animation: block-bounce 0.4s ease;
+}
+
+@keyframes block-bounce {
+  0%   { transform: translateY(0); }
+  30%  { transform: translateY(-10px); }
+  60%  { transform: translateY(2px); }
+  80%  { transform: translateY(-4px); }
+  100% { transform: translateY(0); }
+}
+
+/* ── Coin ── */
+.coin {
+  position: absolute;
+  width: 24px;
+  height: 24px;
+  top: 0;
+  left: 10px;
+  pointer-events: none;
+  image-rendering: pixelated;
+}
+
+.coin-flying {
+  animation: coin-fly 1.5s ease-out forwards;
+}
+
+@keyframes coin-fly {
+  0%   { transform: translate(0px, 0px); }
+  20%  { transform: translate(calc(var(--cx) * 0.2), -90px); }
+  55%  { transform: translate(var(--cx), 65px); }
+  70%  { transform: translate(var(--cx), 45px); }
+  82%  { transform: translate(var(--cx), 62px); }
+  90%  { transform: translate(var(--cx), 58px); }
+  100% { transform: translate(var(--cx), 60px); }
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0; }
+}
+
+.coin-slow   { animation: blink 0.8s linear infinite; }
+.coin-medium { animation: blink 0.35s linear infinite; }
+.coin-fast   { animation: blink 0.15s linear infinite; }

--- a/personal-finance/src/app/features/auth/components/login/login.component.html
+++ b/personal-finance/src/app/features/auth/components/login/login.component.html
@@ -3,7 +3,22 @@
   <div class="login-aside">
     <div class="login-aside-inner">
       <div class="login-brand">
-        <span class="login-brand-mark">₿</span>
+        <div class="mario-block-wrap" #blockEl (click)="onBlockClick()">
+          <img src="mario-block.gif" class="mario-block-img" alt="?" />
+          @for (coin of coins(); track coin.id) {
+            <img
+              src="coin.gif"
+              class="coin"
+              [class.coin-flying]="coin.phase === 'flying'"
+              [class.coin-slow]="coin.phase === 'slow'"
+              [class.coin-medium]="coin.phase === 'medium'"
+              [class.coin-fast]="coin.phase === 'fast'"
+              [style.--cx]="coin.x + 'px'"
+              [style.transform]="coin.phase !== 'flying' ? 'translate(' + coin.x + 'px, 60px)' : null"
+              alt=""
+            />
+          }
+        </div>
         <span class="login-brand-name">Personal Finance</span>
       </div>
       <blockquote class="login-quote">

--- a/personal-finance/src/app/features/auth/components/login/login.component.html
+++ b/personal-finance/src/app/features/auth/components/login/login.component.html
@@ -3,20 +3,27 @@
   <div class="login-aside">
     <div class="login-aside-inner">
       <div class="login-brand">
-        <div class="mario-block-wrap" #blockEl (click)="onBlockClick()">
-          <img src="mario-block.gif" class="mario-block-img" alt="?" />
+        <div class="mario-block-area">
+          <div class="mario-block-wrap" #blockEl (click)="onBlockClick()">
+            <img src="mario-block.gif" class="mario-block-img" alt="?" />
+          </div>
           @for (coin of coins(); track coin.id) {
-            <img
-              src="coin.gif"
-              class="coin"
-              [class.coin-flying]="coin.phase === 'flying'"
-              [class.coin-slow]="coin.phase === 'slow'"
-              [class.coin-medium]="coin.phase === 'medium'"
-              [class.coin-fast]="coin.phase === 'fast'"
+            <div
+              class="coin-x"
+              [class.coin-x-flying]="coin.phase === 'flying'"
               [style.--cx]="coin.x + 'px'"
-              [style.transform]="coin.phase !== 'flying' ? 'translate(' + coin.x + 'px, 60px)' : null"
-              alt=""
-            />
+              [style.transform]="coin.phase !== 'flying' ? 'translateX(' + coin.x + 'px)' : null"
+            >
+              <img
+                src="coin.gif"
+                class="coin-y"
+                [class.coin-y-flying]="coin.phase === 'flying'"
+                [class.coin-slow]="coin.phase === 'slow'"
+                [class.coin-medium]="coin.phase === 'medium'"
+                [class.coin-fast]="coin.phase === 'fast'"
+                alt=""
+              />
+            </div>
           }
         </div>
         <span class="login-brand-name">Personal Finance</span>

--- a/personal-finance/src/app/features/auth/components/login/login.component.ts
+++ b/personal-finance/src/app/features/auth/components/login/login.component.ts
@@ -1,7 +1,15 @@
-import { Component, inject, signal } from '@angular/core';
+import { Component, ElementRef, inject, OnDestroy, signal, ViewChild } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { AuthService } from '../../../../core/auth/auth.service';
+
+interface Coin {
+  id: number;
+  x: number;
+  phase: 'flying' | 'slow' | 'medium' | 'fast';
+}
+
+const MAX_COINS = 10;
 
 @Component({
   selector: 'app-login',
@@ -10,19 +18,61 @@ import { AuthService } from '../../../../core/auth/auth.service';
   templateUrl: './login.component.html',
   styleUrls: ['./login.component.css']
 })
-export class LoginComponent {
+export class LoginComponent implements OnDestroy {
   private readonly auth   = inject(AuthService);
   private readonly router = inject(Router);
   private readonly fb     = inject(FormBuilder);
 
+  @ViewChild('blockEl') private blockEl!: ElementRef<HTMLDivElement>;
+
   readonly loading      = signal(false);
   readonly apiError     = signal<string | null>(null);
   readonly showPassword = signal(false);
+  readonly coins        = signal<Coin[]>([]);
+
+  private clickCount    = 0;
+  private coinId        = 0;
+  private readonly timers: ReturnType<typeof setTimeout>[] = [];
 
   readonly form = this.fb.group({
     email:    ['', [Validators.required, Validators.email]],
     password: ['', [Validators.required]],
   });
+
+  onBlockClick(): void {
+    const el = this.blockEl.nativeElement;
+    el.classList.remove('block-bounce');
+    void el.offsetWidth;
+    el.classList.add('block-bounce');
+
+    if (this.clickCount >= MAX_COINS) return;
+    this.clickCount++;
+
+    const id = this.coinId++;
+    const x  = Math.floor(Math.random() * 161) - 80;
+
+    this.coins.update(c => [...c, { id, x, phase: 'flying' }]);
+
+    const setPhase = (phase: Coin['phase'], delay: number) => {
+      const t = setTimeout(() => {
+        this.coins.update(c => c.map(coin => coin.id === id ? { ...coin, phase } : coin));
+      }, delay);
+      this.timers.push(t);
+    };
+
+    setPhase('slow',   1500);
+    setPhase('medium', 4500);
+    setPhase('fast',   7500);
+
+    const t = setTimeout(() => {
+      this.coins.update(c => c.filter(coin => coin.id !== id));
+    }, 11500);
+    this.timers.push(t);
+  }
+
+  ngOnDestroy(): void {
+    this.timers.forEach(t => clearTimeout(t));
+  }
 
   showError(field: string): boolean {
     const ctrl = this.form.get(field);


### PR DESCRIPTION
Closes #244

## Resumo
- Substitui logo `₿` por `mario-block.gif` clicável na tela de login
- Clique no bloco: bounce curto + moeda (`coin.gif`) com trajetória parabólica oblíqua e bounce físico
- Moeda visível por 10s: 3s pisca lento → 3s médio → 4s rápido → some
- Limite de 10 moedas emitidas; após isso apenas bounce no bloco

🤖 Generated with [Claude Code](https://claude.com/claude-code)