### PR TITLE
ci(sync): sync de branches só após deploy bem-sucedido

### DIFF
--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -1,13 +1,14 @@
 name: Sync develop and release from master
 
 on:
-  push:
-    branches:
-      - master
+  workflow_run:
+    workflows: ["CI — Tests & Deploy"]
+    types: [completed]
 
 jobs:
   sync:
     name: Sync develop and release from master
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Troca o trigger do `sync-branches.yml` de `push` para `workflow_run`
- Sync de `develop` e `release` ← `master` só ocorre após o workflow `CI — Tests & Deploy` concluir com `success`
- Garante que testes + deploy nos ambientes sejam obrigatórios antes de replicar para as demais branches

Closes nenhuma issue — ajuste de pipeline.