### PR TITLE
feat(period-detail): adiciona indicador Saldo após pagamento

### DIFF
--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.css
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.css
@@ -9,7 +9,7 @@
 /* ── Summary KPI bar ── */
 .summary-bar {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  grid-template-columns: repeat(6, 1fr);
   gap: 16px;
 }
 
@@ -33,6 +33,7 @@
 .kpi-card:nth-child(3) { animation-delay: 0.15s; }
 .kpi-card:nth-child(4) { animation-delay: 0.20s; }
 .kpi-card:nth-child(5) { animation-delay: 0.25s; }
+.kpi-card:nth-child(6) { animation-delay: 0.30s; }
 
 .kpi-header {
   display: flex;
@@ -461,7 +462,7 @@
 }
 
 /* ── Responsividade ── */
-@media (max-width: 1100px) {
+@media (max-width: 1400px) {
   .summary-bar { grid-template-columns: repeat(3, 1fr); }
 }
 

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.html
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.html
@@ -85,6 +85,25 @@
           ></div>
         </div>
 
+        <div class="kpi-card">
+          <div class="kpi-header">
+            <span class="kpi-dot"
+              [style.background]="balanceAfterPayment() >= 0 ? 'var(--olive)' : 'var(--terracotta)'"
+              [style.box-shadow]="balanceAfterPayment() >= 0 ? '0 0 8px rgba(123,140,95,0.5)' : '0 0 8px rgba(196,103,74,0.5)'"
+            ></span>
+            <span class="kpi-label">Saldo após pag.</span>
+            <button class="mario-q" (click)="openMario('saldoAposPagamento')" title="Detalhes do Saldo após pagamento">?</button>
+          </div>
+          <div class="kpi-value"
+            [class]="balanceAfterPayment() >= 0 ? 'kpi-value--olive' : 'kpi-value--terra'"
+          >{{ balanceAfterPayment() | currencyBrl: true }}</div>
+          <div class="kpi-bar"
+            [style.background]="balanceAfterPayment() >= 0
+              ? 'linear-gradient(to right,rgba(123,140,95,0.7),rgba(123,140,95,0.1))'
+              : 'linear-gradient(to right,rgba(196,103,74,0.7),rgba(196,103,74,0.1))'"
+          ></div>
+        </div>
+
       </div>
     }
 

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.spec.ts
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.spec.ts
@@ -231,6 +231,34 @@ describe('PeriodDetailComponent', () => {
       expect(component.marioContent()).toContain('Despesas');
       expect(component.marioContent()).toContain('Saldo');
     });
+
+    it('target "saldoAposPagamento" — exibe titulo e calculo correto', () => {
+      component.openMario('saldoAposPagamento');
+      expect(component.marioTitle()).toBe('SALDO APOS PAGAMENTO');
+      expect(component.marioContent()).toContain('Receitas');
+      expect(component.marioContent()).toContain('Total de despesas');
+      expect(component.marioContent()).toContain('Saldo apos pagamento');
+      expect(component.marioOpen()).toBeTrue();
+    });
+  });
+
+  describe('balanceAfterPayment computed', () => {
+    it('retorna 0 sem summary', () => {
+      expect(component.balanceAfterPayment()).toBe(0);
+    });
+
+    it('retorna totalIncome - totalExpense', fakeAsync(() => {
+      fixture.detectChanges();
+      tick();
+      expect(component.balanceAfterPayment()).toBe(SUMMARY.totalIncome - SUMMARY.totalExpense);
+    }));
+
+    it('retorna valor negativo quando despesas superam receitas', fakeAsync(() => {
+      apiSpy.getPeriodSummary.and.returnValue(of({ ...SUMMARY, totalIncome: 500, totalExpense: 1500 }));
+      fixture.detectChanges();
+      tick();
+      expect(component.balanceAfterPayment()).toBe(-1000);
+    }));
   });
 
   describe('expFilterFields computed', () => {

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.ts
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.ts
@@ -14,7 +14,7 @@ import {
   FORTNIGHT_TYPE_LABELS, PaymentStatus, FortnightType, SourceType
 } from '../../../../core/models/models';
 
-type MarioTarget = 'receitas' | 'despesas' | 'pago' | 'apagar' | 'saldo';
+type MarioTarget = 'receitas' | 'despesas' | 'pago' | 'apagar' | 'saldo' | 'saldoAposPagamento';
 type ExpSortCol = 'description' | 'category' | 'fortnightType' | 'dueDate' | 'amount' | 'paymentStatus' | 'sourceType';
 type IncSortCol = 'description' | 'fortnightType' | 'receivedAt' | 'amount';
 
@@ -175,6 +175,11 @@ export class PeriodDetailComponent implements OnInit {
   });
 
   readonly year = computed(() => this.summary()?.year ?? null);
+
+  readonly balanceAfterPayment = computed(() => {
+    const s = this.summary();
+    return s ? s.totalIncome - s.totalExpense : 0;
+  });
 
   // Exposição de enums para o template
   readonly PaymentStatus  = PaymentStatus;
@@ -400,6 +405,21 @@ export class PeriodDetailComponent implements OnInit {
           '',
           `(=) Saldo:`,
           `  ${this.fmt(s.balance)}`,
+        ];
+        break;
+      }
+      case 'saldoAposPagamento': {
+        const val = s.totalIncome - s.totalExpense;
+        title = 'SALDO APOS PAGAMENTO';
+        lines = [
+          `Receitas:`,
+          `  ${this.fmt(s.totalIncome)}`,
+          '',
+          `(-) Total de despesas:`,
+          `  ${this.fmt(s.totalExpense)}`,
+          '',
+          `(=) Saldo apos pagamento:`,
+          `  ${this.fmt(val)}`,
         ];
         break;
       }


### PR DESCRIPTION
Closes #285

## Alterações
- Novo 6º KPI card "Saldo após pag." — valor calculado no frontend como `totalIncome - totalExpense`
- `balanceAfterPayment` computed signal adicionado ao componente
- Novo tipo `'saldoAposPagamento'` em `MarioTarget` com `case` correspondente no `openMario()`
- CSS: grid atualizado para `repeat(6, 1fr)`, breakpoint responsivo ajustado para `1400px`, `animation-delay` do 6º card adicionado
- Testes: 4 novos specs cobrindo o computed e o mario dialog do novo indicador (326/326 ✅)