### PR TITLE
feat(period-detail): KPIs derivados da lista filtrada quando filtros estão ativos

### DIFF
--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.html
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.html
@@ -32,7 +32,7 @@
             <span class="kpi-label">Receitas</span>
             <button class="mario-q" (click)="openMario('receitas')" title="Detalhes de Receitas">?</button>
           </div>
-          <div class="kpi-value kpi-value--olive">{{ summary()!.totalIncome | currencyBrl }}</div>
+          <div class="kpi-value kpi-value--olive">{{ kpiIncomeTotal() | currencyBrl }}</div>
           <div class="kpi-bar" style="background:linear-gradient(to right,rgba(123,140,95,0.7),rgba(123,140,95,0.1))"></div>
         </div>
 
@@ -42,7 +42,7 @@
             <span class="kpi-label">Despesas</span>
             <button class="mario-q" (click)="openMario('despesas')" title="Detalhes de Despesas">?</button>
           </div>
-          <div class="kpi-value kpi-value--terra">{{ summary()!.totalExpense | currencyBrl }}</div>
+          <div class="kpi-value kpi-value--terra">{{ kpiExpenseTotal() | currencyBrl }}</div>
           <div class="kpi-bar" style="background:linear-gradient(to right,rgba(196,103,74,0.7),rgba(196,103,74,0.1))"></div>
         </div>
 
@@ -52,7 +52,7 @@
             <span class="kpi-label">Pago</span>
             <button class="mario-q" (click)="openMario('pago')" title="Detalhes de Pago">?</button>
           </div>
-          <div class="kpi-value kpi-value--olive">{{ summary()!.totalPaid | currencyBrl }}</div>
+          <div class="kpi-value kpi-value--olive">{{ kpiPaid() | currencyBrl }}</div>
           <div class="kpi-bar" style="background:linear-gradient(to right,rgba(123,140,95,0.7),rgba(123,140,95,0.1))"></div>
         </div>
 
@@ -62,24 +62,24 @@
             <span class="kpi-label">A pagar</span>
             <button class="mario-q" (click)="openMario('apagar')" title="Detalhes de A pagar">?</button>
           </div>
-          <div class="kpi-value kpi-value--amber">{{ summary()!.totalOwed | currencyBrl }}</div>
+          <div class="kpi-value kpi-value--amber">{{ kpiOwed() | currencyBrl }}</div>
           <div class="kpi-bar" style="background:linear-gradient(to right,rgba(196,146,74,0.7),rgba(196,146,74,0.1))"></div>
         </div>
 
         <div class="kpi-card">
           <div class="kpi-header">
             <span class="kpi-dot"
-              [style.background]="summary()!.balance >= 0 ? 'var(--olive)' : 'var(--terracotta)'"
-              [style.box-shadow]="summary()!.balance >= 0 ? '0 0 8px rgba(123,140,95,0.5)' : '0 0 8px rgba(196,103,74,0.5)'"
+              [style.background]="kpiBalance() >= 0 ? 'var(--olive)' : 'var(--terracotta)'"
+              [style.box-shadow]="kpiBalance() >= 0 ? '0 0 8px rgba(123,140,95,0.5)' : '0 0 8px rgba(196,103,74,0.5)'"
             ></span>
             <span class="kpi-label">Saldo</span>
             <button class="mario-q" (click)="openMario('saldo')" title="Detalhes do Saldo">?</button>
           </div>
           <div class="kpi-value"
-            [class]="summary()!.balance >= 0 ? 'kpi-value--olive' : 'kpi-value--terra'"
-          >{{ summary()!.balance | currencyBrl: true }}</div>
+            [class]="kpiBalance() >= 0 ? 'kpi-value--olive' : 'kpi-value--terra'"
+          >{{ kpiBalance() | currencyBrl: true }}</div>
           <div class="kpi-bar"
-            [style.background]="summary()!.balance >= 0
+            [style.background]="kpiBalance() >= 0
               ? 'linear-gradient(to right,rgba(123,140,95,0.7),rgba(123,140,95,0.1))'
               : 'linear-gradient(to right,rgba(196,103,74,0.7),rgba(196,103,74,0.1))'"
           ></div>
@@ -88,17 +88,17 @@
         <div class="kpi-card">
           <div class="kpi-header">
             <span class="kpi-dot"
-              [style.background]="balanceAfterPayment() >= 0 ? 'var(--olive)' : 'var(--terracotta)'"
-              [style.box-shadow]="balanceAfterPayment() >= 0 ? '0 0 8px rgba(123,140,95,0.5)' : '0 0 8px rgba(196,103,74,0.5)'"
+              [style.background]="kpiBalanceAfterPayment() >= 0 ? 'var(--olive)' : 'var(--terracotta)'"
+              [style.box-shadow]="kpiBalanceAfterPayment() >= 0 ? '0 0 8px rgba(123,140,95,0.5)' : '0 0 8px rgba(196,103,74,0.5)'"
             ></span>
             <span class="kpi-label">Saldo após pag.</span>
             <button class="mario-q" (click)="openMario('saldoAposPagamento')" title="Detalhes do Saldo após pagamento">?</button>
           </div>
           <div class="kpi-value"
-            [class]="balanceAfterPayment() >= 0 ? 'kpi-value--olive' : 'kpi-value--terra'"
-          >{{ balanceAfterPayment() | currencyBrl: true }}</div>
+            [class]="kpiBalanceAfterPayment() >= 0 ? 'kpi-value--olive' : 'kpi-value--terra'"
+          >{{ kpiBalanceAfterPayment() | currencyBrl: true }}</div>
           <div class="kpi-bar"
-            [style.background]="balanceAfterPayment() >= 0
+            [style.background]="kpiBalanceAfterPayment() >= 0
               ? 'linear-gradient(to right,rgba(123,140,95,0.7),rgba(123,140,95,0.1))'
               : 'linear-gradient(to right,rgba(196,103,74,0.7),rgba(196,103,74,0.1))'"
           ></div>

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.spec.ts
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.spec.ts
@@ -242,23 +242,99 @@ describe('PeriodDetailComponent', () => {
     });
   });
 
-  describe('balanceAfterPayment computed', () => {
-    it('retorna 0 sem summary', () => {
-      expect(component.balanceAfterPayment()).toBe(0);
+  describe('KPI computeds — sem filtros ativos', () => {
+    beforeEach(fakeAsync(() => { fixture.detectChanges(); tick(); }));
+
+    it('kpiIncomeTotal retorna summary.totalIncome', () => {
+      expect(component.kpiIncomeTotal()).toBe(SUMMARY.totalIncome);
     });
 
-    it('retorna totalIncome - totalExpense', fakeAsync(() => {
-      fixture.detectChanges();
-      tick();
-      expect(component.balanceAfterPayment()).toBe(SUMMARY.totalIncome - SUMMARY.totalExpense);
-    }));
+    it('kpiExpenseTotal retorna summary.totalExpense', () => {
+      expect(component.kpiExpenseTotal()).toBe(SUMMARY.totalExpense);
+    });
 
+    it('kpiPaid retorna summary.totalPaid', () => {
+      expect(component.kpiPaid()).toBe(SUMMARY.totalPaid);
+    });
+
+    it('kpiOwed retorna summary.totalOwed', () => {
+      expect(component.kpiOwed()).toBe(SUMMARY.totalOwed);
+    });
+
+    it('kpiBalance retorna summary.balance', () => {
+      expect(component.kpiBalance()).toBe(SUMMARY.balance);
+    });
+
+    it('kpiBalanceAfterPayment retorna totalIncome - totalExpense', () => {
+      expect(component.kpiBalanceAfterPayment()).toBe(SUMMARY.totalIncome - SUMMARY.totalExpense);
+    });
+
+  });
+
+  describe('kpiBalanceAfterPayment — summary negativo', () => {
     it('retorna valor negativo quando despesas superam receitas', fakeAsync(() => {
       apiSpy.getPeriodSummary.and.returnValue(of({ ...SUMMARY, totalIncome: 500, totalExpense: 1500 }));
       fixture.detectChanges();
       tick();
-      expect(component.balanceAfterPayment()).toBe(-1000);
+      expect(component.kpiBalanceAfterPayment()).toBe(-1000);
     }));
+  });
+
+  describe('KPI computeds — com filtros de despesas ativos', () => {
+    beforeEach(fakeAsync(() => { fixture.detectChanges(); tick(); }));
+
+    it('kpiExpenseTotal soma allFilteredExpenses', () => {
+      component.expDesc.set('x');
+      component.allFilteredExpenses.set([
+        { ...EXPENSE, amount: 300 },
+        { ...EXPENSE, amount: 200, paymentStatus: PaymentStatus.Pending },
+      ]);
+      expect(component.kpiExpenseTotal()).toBe(500);
+    });
+
+    it('kpiPaid soma somente despesas Paid de allFilteredExpenses', () => {
+      component.expDesc.set('x');
+      component.allFilteredExpenses.set([
+        { ...EXPENSE, amount: 300, paymentStatus: PaymentStatus.Paid },
+        { ...EXPENSE, amount: 200, paymentStatus: PaymentStatus.Pending },
+      ]);
+      expect(component.kpiPaid()).toBe(300);
+    });
+
+    it('kpiOwed soma Pending e Partial de allFilteredExpenses', () => {
+      component.expDesc.set('x');
+      component.allFilteredExpenses.set([
+        { ...EXPENSE, amount: 300, paymentStatus: PaymentStatus.Paid },
+        { ...EXPENSE, amount: 200, paymentStatus: PaymentStatus.Pending },
+        { ...EXPENSE, amount: 100, paymentStatus: PaymentStatus.Partial },
+      ]);
+      expect(component.kpiOwed()).toBe(300);
+    });
+
+    it('kpiBalance deriva de kpiIncomeTotal - kpiExpenseTotal com filtros ativos', () => {
+      component.expDesc.set('x');
+      component.allFilteredExpenses.set([{ ...EXPENSE, amount: 400 }]);
+      expect(component.kpiBalance()).toBe(SUMMARY.totalIncome - 400);
+    });
+  });
+
+  describe('KPI computeds — com filtros de receitas ativos', () => {
+    beforeEach(fakeAsync(() => { fixture.detectChanges(); tick(); }));
+
+    it('kpiIncomeTotal soma allFilteredIncomes', () => {
+      component.incDesc.set('sal');
+      component.allFilteredIncomes.set([
+        { ...INCOME, amount: 1500 },
+        { ...INCOME, amount: 500 },
+      ]);
+      expect(component.kpiIncomeTotal()).toBe(2000);
+    });
+
+    it('kpiBalance deriva de kpiIncomeTotal - kpiExpenseTotal com filtros ativos', () => {
+      component.incDesc.set('sal');
+      component.allFilteredIncomes.set([{ ...INCOME, amount: 2000 }]);
+      expect(component.kpiBalance()).toBe(2000 - SUMMARY.totalExpense);
+    });
   });
 
   describe('expFilterFields computed', () => {

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.ts
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.ts
@@ -74,6 +74,9 @@ export class PeriodDetailComponent implements OnInit {
   readonly expSortDir      = signal<'asc' | 'desc'>('asc');
   readonly expFilterOpen   = signal(false);
 
+  readonly allFilteredExpenses = signal<ExpenseResponse[]>([]);
+  readonly allFilteredIncomes  = signal<IncomeResponse[]>([]);
+
   readonly expHasFilters = computed(() =>
     !!this.expDesc() || !!this.expCategoryId() ||
     this.expStatus() != null || this.expFortnight() != null ||
@@ -176,10 +179,38 @@ export class PeriodDetailComponent implements OnInit {
 
   readonly year = computed(() => this.summary()?.year ?? null);
 
-  readonly balanceAfterPayment = computed(() => {
-    const s = this.summary();
-    return s ? s.totalIncome - s.totalExpense : 0;
+  readonly kpiIncomeTotal = computed(() =>
+    this.incHasFilters()
+      ? this.allFilteredIncomes().reduce((sum, i) => sum + i.amount, 0)
+      : (this.summary()?.totalIncome ?? 0));
+
+  readonly kpiExpenseTotal = computed(() =>
+    this.expHasFilters()
+      ? this.allFilteredExpenses().reduce((sum, e) => sum + e.amount, 0)
+      : (this.summary()?.totalExpense ?? 0));
+
+  readonly kpiPaid = computed(() =>
+    this.expHasFilters()
+      ? this.allFilteredExpenses()
+          .filter(e => e.paymentStatus === PaymentStatus.Paid)
+          .reduce((sum, e) => sum + e.amount, 0)
+      : (this.summary()?.totalPaid ?? 0));
+
+  readonly kpiOwed = computed(() =>
+    this.expHasFilters()
+      ? this.allFilteredExpenses()
+          .filter(e => e.paymentStatus === PaymentStatus.Pending || e.paymentStatus === PaymentStatus.Partial)
+          .reduce((sum, e) => sum + e.amount, 0)
+      : (this.summary()?.totalOwed ?? 0));
+
+  readonly kpiBalance = computed(() => {
+    if (this.expHasFilters() || this.incHasFilters())
+      return this.kpiIncomeTotal() - this.kpiExpenseTotal();
+    return this.summary()?.balance ?? 0;
   });
+
+  readonly kpiBalanceAfterPayment = computed(() =>
+    this.kpiIncomeTotal() - this.kpiExpenseTotal());
 
   // Exposição de enums para o template
   readonly PaymentStatus  = PaymentStatus;
@@ -202,6 +233,29 @@ export class PeriodDetailComponent implements OnInit {
   }
 
   // ── Despesas ─────────────────────────────────────────────────────────────
+
+  private loadAllFilteredExpenses(): void {
+    if (!this.expHasFilters()) { this.allFilteredExpenses.set([]); return; }
+    this.api.getExpensesByPeriod(this.id(), {
+      pageNumber:    1,
+      pageSize:      9999,
+      description:   this.expDesc()       || undefined,
+      categoryId:    this.expCategoryId() || undefined,
+      paymentStatus: this.expStatus()      ?? undefined,
+      fortnightType: this.expFortnight()   ?? undefined,
+      sourceType:    this.expSourceType()  ?? undefined,
+    }).subscribe({ next: r => this.allFilteredExpenses.set(r.items) });
+  }
+
+  private loadAllFilteredIncomes(): void {
+    if (!this.incHasFilters()) { this.allFilteredIncomes.set([]); return; }
+    this.api.getIncomesByPeriod(this.id(), {
+      pageNumber:    1,
+      pageSize:      9999,
+      description:   this.incDesc()      || undefined,
+      fortnightType: this.incFortnight() ?? undefined,
+    }).subscribe({ next: r => this.allFilteredIncomes.set(r.items) });
+  }
 
   private loadExpenses(): void {
     this.expLoadingList.set(true);
@@ -235,6 +289,7 @@ export class PeriodDetailComponent implements OnInit {
     this.expFilterOpen.set(false);
     this.expPage.set(1);
     this.loadExpenses();
+    this.loadAllFilteredExpenses();
   }
 
   onExpFilterClear(): void {
@@ -249,6 +304,7 @@ export class PeriodDetailComponent implements OnInit {
     this.expFortnight.set(null);
     this.expSourceType.set(null);
     this.expPage.set(1);
+    this.allFilteredExpenses.set([]);
     this.loadExpenses();
   }
 
@@ -291,6 +347,7 @@ export class PeriodDetailComponent implements OnInit {
     this.incFilterOpen.set(false);
     this.incPage.set(1);
     this.loadIncomes();
+    this.loadAllFilteredIncomes();
   }
 
   onIncFilterClear(): void {
@@ -302,6 +359,7 @@ export class PeriodDetailComponent implements OnInit {
     this.incDesc.set('');
     this.incFortnight.set(null);
     this.incPage.set(1);
+    this.allFilteredIncomes.set([]);
     this.loadIncomes();
   }
 


### PR DESCRIPTION
Closes #288

## Resumo
- Novos signals `allFilteredExpenses` / `allFilteredIncomes` carregados com `pageSize: 9999` ao aplicar filtros
- Novos computeds `kpiExpenseTotal`, `kpiPaid`, `kpiOwed`, `kpiIncomeTotal`, `kpiBalance`, `kpiBalanceAfterPayment`
- KPI cards usam os computeds: exibem valores filtrados quando há filtros ativos, valores do summary quando sem filtros
- Testes cobrindo os cenários com e sem filtros ativos