### PR TITLE
feat(period-detail): filtros descrição/quinzena compartilhados entre despesas e receitas

### DIFF
--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.spec.ts
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.spec.ts
@@ -284,7 +284,7 @@ describe('PeriodDetailComponent', () => {
     beforeEach(fakeAsync(() => { fixture.detectChanges(); tick(); }));
 
     it('kpiExpenseTotal soma allFilteredExpenses', () => {
-      component.expDesc.set('x');
+      component.filterDesc.set('x');
       component.allFilteredExpenses.set([
         { ...EXPENSE, amount: 300 },
         { ...EXPENSE, amount: 200, paymentStatus: PaymentStatus.Pending },
@@ -293,7 +293,7 @@ describe('PeriodDetailComponent', () => {
     });
 
     it('kpiPaid soma somente despesas Paid de allFilteredExpenses', () => {
-      component.expDesc.set('x');
+      component.filterDesc.set('x');
       component.allFilteredExpenses.set([
         { ...EXPENSE, amount: 300, paymentStatus: PaymentStatus.Paid },
         { ...EXPENSE, amount: 200, paymentStatus: PaymentStatus.Pending },
@@ -302,7 +302,7 @@ describe('PeriodDetailComponent', () => {
     });
 
     it('kpiOwed soma Pending e Partial de allFilteredExpenses', () => {
-      component.expDesc.set('x');
+      component.filterDesc.set('x');
       component.allFilteredExpenses.set([
         { ...EXPENSE, amount: 300, paymentStatus: PaymentStatus.Paid },
         { ...EXPENSE, amount: 200, paymentStatus: PaymentStatus.Pending },
@@ -312,8 +312,9 @@ describe('PeriodDetailComponent', () => {
     });
 
     it('kpiBalance deriva de kpiIncomeTotal - kpiExpenseTotal com filtros ativos', () => {
-      component.expDesc.set('x');
+      component.filterDesc.set('x');
       component.allFilteredExpenses.set([{ ...EXPENSE, amount: 400 }]);
+      component.allFilteredIncomes.set([{ ...INCOME, amount: SUMMARY.totalIncome }]);
       expect(component.kpiBalance()).toBe(SUMMARY.totalIncome - 400);
     });
   });
@@ -322,7 +323,7 @@ describe('PeriodDetailComponent', () => {
     beforeEach(fakeAsync(() => { fixture.detectChanges(); tick(); }));
 
     it('kpiIncomeTotal soma allFilteredIncomes', () => {
-      component.incDesc.set('sal');
+      component.filterDesc.set('sal');
       component.allFilteredIncomes.set([
         { ...INCOME, amount: 1500 },
         { ...INCOME, amount: 500 },
@@ -331,8 +332,9 @@ describe('PeriodDetailComponent', () => {
     });
 
     it('kpiBalance deriva de kpiIncomeTotal - kpiExpenseTotal com filtros ativos', () => {
-      component.incDesc.set('sal');
+      component.filterDesc.set('sal');
       component.allFilteredIncomes.set([{ ...INCOME, amount: 2000 }]);
+      component.allFilteredExpenses.set([{ ...EXPENSE, amount: SUMMARY.totalExpense }]);
       expect(component.kpiBalance()).toBe(2000 - SUMMARY.totalExpense);
     });
   });
@@ -344,8 +346,8 @@ describe('PeriodDetailComponent', () => {
       expect(component.expFilterFields().length).toBe(5);
     });
 
-    it('campo description reflete expDesc', () => {
-      component.expDesc.set('teste');
+    it('campo description reflete filterDesc', () => {
+      component.filterDesc.set('teste');
       const field = component.expFilterFields().find(f => f.key === 'description')!;
       expect(field.value).toBe('teste');
     });
@@ -361,8 +363,8 @@ describe('PeriodDetailComponent', () => {
       expect(component.incFilterFields().length).toBe(2);
     });
 
-    it('campo description reflete incDesc', () => {
-      component.incDesc.set('sal');
+    it('campo description reflete filterDesc', () => {
+      component.filterDesc.set('sal');
       const field = component.incFilterFields().find(f => f.key === 'description')!;
       expect(field.value).toBe('sal');
     });
@@ -375,10 +377,10 @@ describe('PeriodDetailComponent', () => {
       component.expFilterOpen.set(true);
       component.onExpFilterApply({ description: 'aluguel', categoryId: 'cat-1', paymentStatus: '1', fortnightType: '1', sourceType: '1' });
       tick();
-      expect(component.expDesc()).toBe('aluguel');
+      expect(component.filterDesc()).toBe('aluguel');
       expect(component.expCategoryId()).toBe('cat-1');
       expect(component.expStatus()).toBe(1);
-      expect(component.expFortnight()).toBe(1);
+      expect(component.filterFortnight()).toBe(1);
       expect(component.expSourceType()).toBe(1);
       expect(component.expFilterOpen()).toBeFalse();
       expect(apiSpy.getExpensesByPeriod).toHaveBeenCalled();
@@ -389,7 +391,7 @@ describe('PeriodDetailComponent', () => {
       component.onExpFilterApply({ description: '', categoryId: '', paymentStatus: '', fortnightType: '', sourceType: '' });
       tick();
       expect(component.expStatus()).toBeNull();
-      expect(component.expFortnight()).toBeNull();
+      expect(component.filterFortnight()).toBeNull();
       expect(component.expSourceType()).toBeNull();
     }));
   });
@@ -398,11 +400,11 @@ describe('PeriodDetailComponent', () => {
     beforeEach(fakeAsync(() => { fixture.detectChanges(); tick(); }));
 
     it('limpa filtros e fecha painel', fakeAsync(() => {
-      component.expDesc.set('x');
+      component.filterDesc.set('x');
       component.expFilterOpen.set(true);
       component.onExpFilterClear();
       tick();
-      expect(component.expDesc()).toBe('');
+      expect(component.filterDesc()).toBe('');
       expect(component.expFilterOpen()).toBeFalse();
     }));
   });
@@ -413,8 +415,8 @@ describe('PeriodDetailComponent', () => {
     it('aplica filtros e recarrega receitas', fakeAsync(() => {
       component.onIncFilterApply({ description: 'sal', fortnightType: '2' });
       tick();
-      expect(component.incDesc()).toBe('sal');
-      expect(component.incFortnight()).toBe(2);
+      expect(component.filterDesc()).toBe('sal');
+      expect(component.filterFortnight()).toBe(2);
       expect(component.incFilterOpen()).toBeFalse();
       expect(apiSpy.getIncomesByPeriod).toHaveBeenCalled();
     }));
@@ -424,11 +426,11 @@ describe('PeriodDetailComponent', () => {
     beforeEach(fakeAsync(() => { fixture.detectChanges(); tick(); }));
 
     it('limpa filtros e fecha painel', fakeAsync(() => {
-      component.incDesc.set('x');
+      component.filterDesc.set('x');
       component.incFilterOpen.set(true);
       component.onIncFilterClear();
       tick();
-      expect(component.incDesc()).toBe('');
+      expect(component.filterDesc()).toBe('');
       expect(component.incFilterOpen()).toBeFalse();
     }));
   });

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.ts
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.ts
@@ -65,10 +65,12 @@ export class PeriodDetailComponent implements OnInit {
   readonly expPageSize     = signal(20);
   readonly expTotal        = signal(0);
   readonly expLoadingList  = signal(false);
-  readonly expDesc         = signal('');
+  // Filtros compartilhados entre despesas e receitas
+  readonly filterDesc      = signal('');
+  readonly filterFortnight = signal<FortnightType | null>(null);
+
   readonly expCategoryId   = signal('');
   readonly expStatus       = signal<PaymentStatus | null>(null);
-  readonly expFortnight    = signal<FortnightType | null>(null);
   readonly expSourceType   = signal<SourceType | null>(null);
   readonly expSortCol      = signal<ExpSortCol | null>(null);
   readonly expSortDir      = signal<'asc' | 'desc'>('asc');
@@ -78,19 +80,19 @@ export class PeriodDetailComponent implements OnInit {
   readonly allFilteredIncomes  = signal<IncomeResponse[]>([]);
 
   readonly expHasFilters = computed(() =>
-    !!this.expDesc() || !!this.expCategoryId() ||
-    this.expStatus() != null || this.expFortnight() != null ||
+    !!this.filterDesc() || !!this.expCategoryId() ||
+    this.expStatus() != null || this.filterFortnight() != null ||
     this.expSourceType() != null);
 
   readonly expFilterFields = computed<FilterFieldConfig[]>(() => [
-    { key: 'description',   label: 'Descrição', type: 'text',   value: this.expDesc() },
+    { key: 'description',   label: 'Descrição', type: 'text',   value: this.filterDesc() },
     { key: 'categoryId',    label: 'Categoria',  type: 'select', value: this.expCategoryId(),
       options: [{ value: '', label: 'Todas' }, ...this.categories().map(c => ({ value: c.id, label: c.name }))] },
     { key: 'paymentStatus', label: 'Status',     type: 'select', value: this.expStatus() ?? '',
       options: [{ value: '', label: 'Todos' }, { value: PaymentStatus.Pending, label: 'Pendente' },
         { value: PaymentStatus.Paid, label: 'Pago' }, { value: PaymentStatus.Partial, label: 'Parcial' },
         { value: PaymentStatus.Cancelled, label: 'Cancelado' }] },
-    { key: 'fortnightType', label: 'Quinzena',   type: 'select', value: this.expFortnight() ?? '',
+    { key: 'fortnightType', label: 'Quinzena',   type: 'select', value: this.filterFortnight() ?? '',
       options: [{ value: '', label: 'Ambas' }, { value: FortnightType.First, label: '1ª Quinzena' },
         { value: FortnightType.Second, label: '2ª Quinzena' }] },
     { key: 'sourceType',    label: 'Fonte',      type: 'select', value: this.expSourceType() ?? '',
@@ -128,18 +130,16 @@ export class PeriodDetailComponent implements OnInit {
   readonly incPageSize    = signal(20);
   readonly incTotal       = signal(0);
   readonly incLoadingList = signal(false);
-  readonly incDesc        = signal('');
-  readonly incFortnight   = signal<FortnightType | null>(null);
   readonly incSortCol     = signal<IncSortCol | null>(null);
   readonly incSortDir     = signal<'asc' | 'desc'>('asc');
   readonly incFilterOpen  = signal(false);
 
   readonly incHasFilters = computed(() =>
-    !!this.incDesc() || this.incFortnight() != null);
+    !!this.filterDesc() || this.filterFortnight() != null);
 
   readonly incFilterFields = computed<FilterFieldConfig[]>(() => [
-    { key: 'description',   label: 'Descrição', type: 'text',   value: this.incDesc() },
-    { key: 'fortnightType', label: 'Quinzena',   type: 'select', value: this.incFortnight() ?? '',
+    { key: 'description',   label: 'Descrição', type: 'text',   value: this.filterDesc() },
+    { key: 'fortnightType', label: 'Quinzena',   type: 'select', value: this.filterFortnight() ?? '',
       options: [{ value: '', label: 'Ambas' }, { value: FortnightType.First, label: '1ª Quinzena' },
         { value: FortnightType.Second, label: '2ª Quinzena' }] },
   ]);
@@ -239,11 +239,11 @@ export class PeriodDetailComponent implements OnInit {
     this.api.getExpensesByPeriod(this.id(), {
       pageNumber:    1,
       pageSize:      9999,
-      description:   this.expDesc()       || undefined,
-      categoryId:    this.expCategoryId() || undefined,
-      paymentStatus: this.expStatus()      ?? undefined,
-      fortnightType: this.expFortnight()   ?? undefined,
-      sourceType:    this.expSourceType()  ?? undefined,
+      description:   this.filterDesc()      || undefined,
+      categoryId:    this.expCategoryId()   || undefined,
+      paymentStatus: this.expStatus()        ?? undefined,
+      fortnightType: this.filterFortnight()  ?? undefined,
+      sourceType:    this.expSourceType()    ?? undefined,
     }).subscribe({ next: r => this.allFilteredExpenses.set(r.items) });
   }
 
@@ -252,8 +252,8 @@ export class PeriodDetailComponent implements OnInit {
     this.api.getIncomesByPeriod(this.id(), {
       pageNumber:    1,
       pageSize:      9999,
-      description:   this.incDesc()      || undefined,
-      fortnightType: this.incFortnight() ?? undefined,
+      description:   this.filterDesc()      || undefined,
+      fortnightType: this.filterFortnight()  ?? undefined,
     }).subscribe({ next: r => this.allFilteredIncomes.set(r.items) });
   }
 
@@ -262,11 +262,11 @@ export class PeriodDetailComponent implements OnInit {
     this.api.getExpensesByPeriod(this.id(), {
       pageNumber:    this.expPage(),
       pageSize:      this.expPageSize(),
-      description:   this.expDesc()       || undefined,
-      categoryId:    this.expCategoryId() || undefined,
-      paymentStatus: this.expStatus()      ?? undefined,
-      fortnightType: this.expFortnight()   ?? undefined,
-      sourceType:    this.expSourceType()  ?? undefined,
+      description:   this.filterDesc()      || undefined,
+      categoryId:    this.expCategoryId()   || undefined,
+      paymentStatus: this.expStatus()        ?? undefined,
+      fortnightType: this.filterFortnight()  ?? undefined,
+      sourceType:    this.expSourceType()    ?? undefined,
     }).subscribe({
       next: result => {
         this.expenses.set(result.items);
@@ -278,18 +278,21 @@ export class PeriodDetailComponent implements OnInit {
   }
 
   onExpFilterApply(values: Record<string, unknown>): void {
-    this.expDesc.set((values['description'] as string) ?? '');
+    this.filterDesc.set((values['description'] as string) ?? '');
     this.expCategoryId.set((values['categoryId'] as string) ?? '');
     const status = values['paymentStatus'] as string;
     this.expStatus.set(status ? Number(status) as PaymentStatus : null);
     const fortnight = values['fortnightType'] as string;
-    this.expFortnight.set(fortnight ? Number(fortnight) as FortnightType : null);
+    this.filterFortnight.set(fortnight ? Number(fortnight) as FortnightType : null);
     const source = values['sourceType'] as string;
     this.expSourceType.set(source ? Number(source) as SourceType : null);
     this.expFilterOpen.set(false);
     this.expPage.set(1);
+    this.incPage.set(1);
     this.loadExpenses();
     this.loadAllFilteredExpenses();
+    this.loadIncomes();
+    this.loadAllFilteredIncomes();
   }
 
   onExpFilterClear(): void {
@@ -298,14 +301,17 @@ export class PeriodDetailComponent implements OnInit {
   }
 
   clearExpFilters(): void {
-    this.expDesc.set('');
+    this.filterDesc.set('');
+    this.filterFortnight.set(null);
     this.expCategoryId.set('');
     this.expStatus.set(null);
-    this.expFortnight.set(null);
     this.expSourceType.set(null);
     this.expPage.set(1);
+    this.incPage.set(1);
     this.allFilteredExpenses.set([]);
+    this.allFilteredIncomes.set([]);
     this.loadExpenses();
+    this.loadIncomes();
   }
 
   onExpPageChange(page: number): void { this.expPage.set(page); this.loadExpenses(); }
@@ -328,8 +334,8 @@ export class PeriodDetailComponent implements OnInit {
     this.api.getIncomesByPeriod(this.id(), {
       pageNumber:    this.incPage(),
       pageSize:      this.incPageSize(),
-      description:   this.incDesc()      || undefined,
-      fortnightType: this.incFortnight() ?? undefined,
+      description:   this.filterDesc()      || undefined,
+      fortnightType: this.filterFortnight()  ?? undefined,
     }).subscribe({
       next: result => {
         this.incomes.set(result.items);
@@ -341,13 +347,16 @@ export class PeriodDetailComponent implements OnInit {
   }
 
   onIncFilterApply(values: Record<string, unknown>): void {
-    this.incDesc.set((values['description'] as string) ?? '');
+    this.filterDesc.set((values['description'] as string) ?? '');
     const fortnight = values['fortnightType'] as string;
-    this.incFortnight.set(fortnight ? Number(fortnight) as FortnightType : null);
+    this.filterFortnight.set(fortnight ? Number(fortnight) as FortnightType : null);
     this.incFilterOpen.set(false);
     this.incPage.set(1);
+    this.expPage.set(1);
     this.loadIncomes();
     this.loadAllFilteredIncomes();
+    this.loadExpenses();
+    this.loadAllFilteredExpenses();
   }
 
   onIncFilterClear(): void {
@@ -356,11 +365,14 @@ export class PeriodDetailComponent implements OnInit {
   }
 
   clearIncFilters(): void {
-    this.incDesc.set('');
-    this.incFortnight.set(null);
+    this.filterDesc.set('');
+    this.filterFortnight.set(null);
     this.incPage.set(1);
+    this.expPage.set(1);
     this.allFilteredIncomes.set([]);
+    this.allFilteredExpenses.set([]);
     this.loadIncomes();
+    this.loadExpenses();
   }
 
   onIncPageChange(page: number): void { this.incPage.set(page); this.loadIncomes(); }


### PR DESCRIPTION
Closes #288

## Resumo
- `filterDesc` e `filterFortnight` substituem os signals separados `expDesc`/`incDesc` e `expFortnight`/`incFortnight`
- Ao aplicar filtro em qualquer aba, ambas as listas (despesas e receitas) são recarregadas
- Os KPI cards refletem os filtros ativos independentemente de qual aba está selecionada
- Limpar filtros em qualquer aba reseta os dados compartilhados das duas abas