### PR TITLE
feat(period-detail): mario modal reflete filtros ativos com info dos campos aplicados

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,6 +220,19 @@ Integration: `WebApplicationFactory<Program>` + banco InMemory. Unit: xUnit + Mo
 
 ---
 
+## Autonomia por contexto
+
+| Contexto | Nível de autonomia |
+|----------|--------------------|
+| **Worktree** (`claude/`) | **Livre** — ler arquivos, implementar, rodar testes, ler GitHub/board, alterar status da issue sem pedir permissão |
+| **Planning** | **Livre** — ler arquivos e board para levantamento; confirmar ordem/escopo antes de executar |
+| **Branch `feat/`** | **Restrito** — confirmar antes de push, criação de PR e alterações fora do escopo |
+| **Deploy / ambientes** | **Restrito** — sempre confirmar antes de qualquer ação |
+
+Regra geral: **worktree é espaço de implementação autônomo**. Volta ao modo restrito quando a ação afeta branches do Caique, PRs públicas ou ambientes.
+
+---
+
 ## Otimização de tokens
 
 - Respostas curtas — sem repetir código ou contexto anterior

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.spec.ts
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.spec.ts
@@ -242,6 +242,85 @@ describe('PeriodDetailComponent', () => {
     });
   });
 
+  describe('openMario() — com filtros ativos', () => {
+    beforeEach(fakeAsync(() => {
+      fixture.detectChanges();
+      tick();
+    }));
+
+    it('receitas com incHasFilters — usa allFilteredIncomes e exibe info de filtro', () => {
+      component.filterDesc.set('sal');
+      component.allFilteredIncomes.set([{ ...INCOME, amount: 1500 }]);
+      component.openMario('receitas');
+      expect(component.marioTitle()).toBe('RECEITAS DO PERIODO');
+      expect(component.marioContent()).toContain('[FILTROS APLICADOS]');
+      expect(component.marioContent()).toContain('"sal"');
+      expect(component.marioContent()).toContain('Salário');
+    });
+
+    it('receitas filtradas sem resultados — mensagem adequada', () => {
+      component.filterDesc.set('xyz');
+      component.allFilteredIncomes.set([]);
+      component.openMario('receitas');
+      expect(component.marioContent()).toContain('Nenhuma receita');
+      expect(component.marioContent()).toContain('[FILTROS APLICADOS]');
+    });
+
+    it('despesas com expHasFilters — usa allFilteredExpenses e exibe info de filtro', () => {
+      component.filterDesc.set('alu');
+      component.allFilteredExpenses.set([{ ...EXPENSE, amount: 800 }]);
+      component.openMario('despesas');
+      expect(component.marioTitle()).toBe('DESPESAS DO PERIODO');
+      expect(component.marioContent()).toContain('[FILTROS APLICADOS]');
+      expect(component.marioContent()).toContain('"alu"');
+      expect(component.marioContent()).toContain('Aluguel');
+    });
+
+    it('pago com expHasFilters — filtra Paid de allFilteredExpenses', () => {
+      component.filterDesc.set('x');
+      component.allFilteredExpenses.set([
+        { ...EXPENSE, amount: 500, paymentStatus: PaymentStatus.Paid },
+        { ...EXPENSE, amount: 200, paymentStatus: PaymentStatus.Pending },
+      ]);
+      component.openMario('pago');
+      expect(component.marioTitle()).toBe('DESPESAS PAGAS');
+      expect(component.marioContent()).toContain('[FILTROS APLICADOS]');
+      expect(component.marioContent()).toContain('Aluguel');
+      expect(component.marioContent()).not.toContain('R$ 200');
+    });
+
+    it('apagar com expHasFilters — filtra Pending/Partial de allFilteredExpenses', () => {
+      component.filterDesc.set('x');
+      component.allFilteredExpenses.set([
+        { ...EXPENSE, amount: 300, paymentStatus: PaymentStatus.Pending },
+        { ...EXPENSE, amount: 100, paymentStatus: PaymentStatus.Partial },
+        { ...EXPENSE, amount: 600, paymentStatus: PaymentStatus.Paid },
+      ]);
+      component.openMario('apagar');
+      expect(component.marioTitle()).toBe('DESPESAS A PAGAR');
+      expect(component.marioContent()).toContain('[FILTROS APLICADOS]');
+      expect(component.marioContent()).toContain('parcial');
+    });
+
+    it('saldo com filtros — exibe info de filtro e usa kpi values', () => {
+      component.filterDesc.set('x');
+      component.allFilteredExpenses.set([{ ...EXPENSE, amount: 400 }]);
+      component.allFilteredIncomes.set([{ ...INCOME, amount: 2000 }]);
+      component.openMario('saldo');
+      expect(component.marioTitle()).toBe('CALCULO DO SALDO');
+      expect(component.marioContent()).toContain('[FILTROS APLICADOS]');
+    });
+
+    it('saldoAposPagamento com filtros — exibe info de filtro', () => {
+      component.filterDesc.set('x');
+      component.allFilteredExpenses.set([{ ...EXPENSE, amount: 400 }]);
+      component.allFilteredIncomes.set([{ ...INCOME, amount: 2000 }]);
+      component.openMario('saldoAposPagamento');
+      expect(component.marioTitle()).toBe('SALDO APOS PAGAMENTO');
+      expect(component.marioContent()).toContain('[FILTROS APLICADOS]');
+    });
+  });
+
   describe('KPI computeds — sem filtros ativos', () => {
     beforeEach(fakeAsync(() => { fixture.detectChanges(); tick(); }));
 

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.ts
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.ts
@@ -390,106 +390,178 @@ export class PeriodDetailComponent implements OnInit {
 
   // ── Mario modal ───────────────────────────────────────────────────────────
 
+  private marioFilterInfo(target: 'expenses' | 'incomes' | 'balance'): string[] {
+    const hasExp = this.expHasFilters();
+    const hasInc = this.incHasFilters();
+    const relevant = target === 'expenses' ? hasExp : target === 'incomes' ? hasInc : hasExp || hasInc;
+    if (!relevant) return [];
+
+    const lines: string[] = ['[FILTROS APLICADOS]'];
+    if (this.filterDesc())       lines.push(`Descricao: "${this.filterDesc()}"`);
+    if (this.filterFortnight() != null) lines.push(`Quinzena: ${FORTNIGHT_TYPE_LABELS[this.filterFortnight()!]}`);
+    if (target !== 'incomes') {
+      if (this.expCategoryId()) {
+        const cat = this.categories().find(c => c.id === this.expCategoryId());
+        if (cat) lines.push(`Categoria: ${cat.name}`);
+      }
+      if (this.expStatus()     != null) lines.push(`Status: ${PAYMENT_STATUS_LABELS[this.expStatus()!]}`);
+      if (this.expSourceType() != null) lines.push(`Fonte: ${SOURCE_TYPE_LABELS[this.expSourceType()! as keyof typeof SOURCE_TYPE_LABELS]}`);
+    }
+    lines.push('');
+    return lines;
+  }
+
   openMario(target: MarioTarget): void {
     const s = this.summary()!;
-    const exps = this.expenses();
     let title = '';
     let lines: string[] = [];
 
     switch (target) {
       case 'receitas': {
-        this.api.getIncomesByPeriod(this.id(), { pageNumber: 1, pageSize: 1000 })
-          .subscribe(result => {
-            const receitas = result.items;
-            if (receitas.length === 0) {
-              lines = ['Nenhuma receita\nregistrada neste periodo.'];
-            } else {
-              lines = receitas.map(i => `• ${i.description}\n  ${this.fmt(i.amount)}`);
-              lines.push('', `TOTAL: ${this.fmt(s.totalIncome)}`);
-            }
-            this.marioTitle.set('RECEITAS DO PERIODO');
-            this.marioContent.set(lines.join('\n'));
-            this.marioOpen.set(true);
-          });
+        if (this.incHasFilters()) {
+          const items = this.allFilteredIncomes();
+          lines = [...this.marioFilterInfo('incomes')];
+          if (items.length === 0) {
+            lines.push('Nenhuma receita\nencontrada com os filtros.');
+          } else {
+            lines.push(...items.map(i => `• ${i.description}\n  ${this.fmt(i.amount)}`));
+            lines.push('', `TOTAL: ${this.fmt(this.kpiIncomeTotal())}`);
+          }
+          this.marioTitle.set('RECEITAS DO PERIODO');
+          this.marioContent.set(lines.join('\n'));
+          this.marioOpen.set(true);
+        } else {
+          this.api.getIncomesByPeriod(this.id(), { pageNumber: 1, pageSize: 1000 })
+            .subscribe(result => {
+              const receitas = result.items;
+              lines = receitas.length === 0
+                ? ['Nenhuma receita\nregistrada neste periodo.']
+                : [...receitas.map(i => `• ${i.description}\n  ${this.fmt(i.amount)}`), '', `TOTAL: ${this.fmt(s.totalIncome)}`];
+              this.marioTitle.set('RECEITAS DO PERIODO');
+              this.marioContent.set(lines.join('\n'));
+              this.marioOpen.set(true);
+            });
+        }
         return;
       }
       case 'despesas': {
-        this.api.getExpensesByPeriod(this.id(), { pageNumber: 1, pageSize: 1000 })
-          .subscribe(result => {
-            const despesas = result.items;
-            if (despesas.length === 0) {
-              lines = ['Nenhuma despesa\nregistrada neste periodo.'];
-            } else {
-              lines = despesas.map(e => `• ${e.description}\n  ${this.fmt(e.amount)}`);
-              lines.push('', `TOTAL: ${this.fmt(s.totalExpense)}`);
-            }
-            this.marioTitle.set('DESPESAS DO PERIODO');
-            this.marioContent.set(lines.join('\n'));
-            this.marioOpen.set(true);
-          });
+        if (this.expHasFilters()) {
+          const items = this.allFilteredExpenses();
+          lines = [...this.marioFilterInfo('expenses')];
+          if (items.length === 0) {
+            lines.push('Nenhuma despesa\nencontrada com os filtros.');
+          } else {
+            lines.push(...items.map(e => `• ${e.description}\n  ${this.fmt(e.amount)}`));
+            lines.push('', `TOTAL: ${this.fmt(this.kpiExpenseTotal())}`);
+          }
+          this.marioTitle.set('DESPESAS DO PERIODO');
+          this.marioContent.set(lines.join('\n'));
+          this.marioOpen.set(true);
+        } else {
+          this.api.getExpensesByPeriod(this.id(), { pageNumber: 1, pageSize: 1000 })
+            .subscribe(result => {
+              const despesas = result.items;
+              lines = despesas.length === 0
+                ? ['Nenhuma despesa\nregistrada neste periodo.']
+                : [...despesas.map(e => `• ${e.description}\n  ${this.fmt(e.amount)}`), '', `TOTAL: ${this.fmt(s.totalExpense)}`];
+              this.marioTitle.set('DESPESAS DO PERIODO');
+              this.marioContent.set(lines.join('\n'));
+              this.marioOpen.set(true);
+            });
+        }
         return;
       }
       case 'pago': {
-        this.api.getExpensesByPeriod(this.id(), { pageNumber: 1, pageSize: 1000, paymentStatus: PaymentStatus.Paid })
-          .subscribe(result => {
-            const pagas = result.items;
-            if (pagas.length === 0) {
-              lines = ['Nenhuma despesa\npaga neste periodo.'];
-            } else {
-              lines = pagas.map(e => `• ${e.description}\n  ${this.fmt(e.amount)}`);
-              lines.push('', `TOTAL PAGO: ${this.fmt(s.totalPaid)}`);
-            }
-            this.marioTitle.set('DESPESAS PAGAS');
-            this.marioContent.set(lines.join('\n'));
-            this.marioOpen.set(true);
-          });
+        if (this.expHasFilters()) {
+          const pagas = this.allFilteredExpenses().filter(e => e.paymentStatus === PaymentStatus.Paid);
+          lines = [...this.marioFilterInfo('expenses')];
+          if (pagas.length === 0) {
+            lines.push('Nenhuma despesa\npaga com os filtros.');
+          } else {
+            lines.push(...pagas.map(e => `• ${e.description}\n  ${this.fmt(e.amount)}`));
+            lines.push('', `TOTAL PAGO: ${this.fmt(this.kpiPaid())}`);
+          }
+          this.marioTitle.set('DESPESAS PAGAS');
+          this.marioContent.set(lines.join('\n'));
+          this.marioOpen.set(true);
+        } else {
+          this.api.getExpensesByPeriod(this.id(), { pageNumber: 1, pageSize: 1000, paymentStatus: PaymentStatus.Paid })
+            .subscribe(result => {
+              const pagas = result.items;
+              lines = pagas.length === 0
+                ? ['Nenhuma despesa\npaga neste periodo.']
+                : [...pagas.map(e => `• ${e.description}\n  ${this.fmt(e.amount)}`), '', `TOTAL PAGO: ${this.fmt(s.totalPaid)}`];
+              this.marioTitle.set('DESPESAS PAGAS');
+              this.marioContent.set(lines.join('\n'));
+              this.marioOpen.set(true);
+            });
+        }
         return;
       }
       case 'apagar': {
-        this.api.getExpensesByPeriod(this.id(), { pageNumber: 1, pageSize: 1000, paymentStatus: PaymentStatus.Pending })
-          .subscribe(result => {
-            const pendentes = result.items;
-            if (pendentes.length === 0) {
-              lines = ['Nenhuma despesa\npendente neste periodo.'];
-            } else {
-              lines = pendentes.map(e => {
-                const suffix = e.paymentStatus === PaymentStatus.Partial ? ' (parcial)' : '';
-                return `• ${e.description}${suffix}\n  ${this.fmt(e.amount)}`;
-              });
-              lines.push('', `TOTAL A PAGAR: ${this.fmt(s.totalOwed)}`);
-            }
-            this.marioTitle.set('DESPESAS A PAGAR');
-            this.marioContent.set(lines.join('\n'));
-            this.marioOpen.set(true);
-          });
+        if (this.expHasFilters()) {
+          const pendentes = this.allFilteredExpenses()
+            .filter(e => e.paymentStatus === PaymentStatus.Pending || e.paymentStatus === PaymentStatus.Partial);
+          lines = [...this.marioFilterInfo('expenses')];
+          if (pendentes.length === 0) {
+            lines.push('Nenhuma despesa\npendente com os filtros.');
+          } else {
+            lines.push(...pendentes.map(e => {
+              const suffix = e.paymentStatus === PaymentStatus.Partial ? ' (parcial)' : '';
+              return `• ${e.description}${suffix}\n  ${this.fmt(e.amount)}`;
+            }));
+            lines.push('', `TOTAL A PAGAR: ${this.fmt(this.kpiOwed())}`);
+          }
+          this.marioTitle.set('DESPESAS A PAGAR');
+          this.marioContent.set(lines.join('\n'));
+          this.marioOpen.set(true);
+        } else {
+          this.api.getExpensesByPeriod(this.id(), { pageNumber: 1, pageSize: 1000, paymentStatus: PaymentStatus.Pending })
+            .subscribe(result => {
+              const pendentes = result.items;
+              if (pendentes.length === 0) {
+                lines = ['Nenhuma despesa\npendente neste periodo.'];
+              } else {
+                lines = pendentes.map(e => {
+                  const suffix = e.paymentStatus === PaymentStatus.Partial ? ' (parcial)' : '';
+                  return `• ${e.description}${suffix}\n  ${this.fmt(e.amount)}`;
+                });
+                lines.push('', `TOTAL A PAGAR: ${this.fmt(s.totalOwed)}`);
+              }
+              this.marioTitle.set('DESPESAS A PAGAR');
+              this.marioContent.set(lines.join('\n'));
+              this.marioOpen.set(true);
+            });
+        }
         return;
       }
       case 'saldo': {
         title = 'CALCULO DO SALDO';
         lines = [
+          ...this.marioFilterInfo('balance'),
           `Receitas:`,
-          `  ${this.fmt(s.totalIncome)}`,
+          `  ${this.fmt(this.kpiIncomeTotal())}`,
           '',
           `(-) Despesas:`,
-          `  ${this.fmt(s.totalExpense)}`,
+          `  ${this.fmt(this.kpiExpenseTotal())}`,
           '',
           `(=) Saldo:`,
-          `  ${this.fmt(s.balance)}`,
+          `  ${this.fmt(this.kpiBalance())}`,
         ];
         break;
       }
       case 'saldoAposPagamento': {
-        const val = s.totalIncome - s.totalExpense;
         title = 'SALDO APOS PAGAMENTO';
         lines = [
+          ...this.marioFilterInfo('balance'),
           `Receitas:`,
-          `  ${this.fmt(s.totalIncome)}`,
+          `  ${this.fmt(this.kpiIncomeTotal())}`,
           '',
           `(-) Total de despesas:`,
-          `  ${this.fmt(s.totalExpense)}`,
+          `  ${this.fmt(this.kpiExpenseTotal())}`,
           '',
           `(=) Saldo apos pagamento:`,
-          `  ${this.fmt(val)}`,
+          `  ${this.fmt(this.kpiBalanceAfterPayment())}`,
         ];
         break;
       }


### PR DESCRIPTION
Closes #288

## Resumo
- Quando filtros estão ativos, os modais Mario usam os dados já carregados (`allFilteredExpenses`/`allFilteredIncomes`) em vez de fazer nova chamada à API
- Cada modal exibe um bloco `[FILTROS APLICADOS]` no início do conteúdo, listando os campos e valores ativos
- Modais de saldo/saldo após pag. passam a usar os KPI computeds (valores já filtrados)
- `pago` e `apagar` filtram `allFilteredExpenses` por status quando filtros ativos
- CLAUDE.md atualizado com diretrizes de autonomia por contexto de execução