### PR TITLE
feat(period-detail): aplicação de filtros nos KPIs e modal Mario (#288)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,6 +220,19 @@ Integration: `WebApplicationFactory<Program>` + banco InMemory. Unit: xUnit + Mo
 
 ---
 
+## Autonomia por contexto
+
+| Contexto | Nível de autonomia |
+|----------|--------------------|
+| **Worktree** (`claude/`) | **Livre** — ler arquivos, implementar, rodar testes, ler GitHub/board, alterar status da issue sem pedir permissão |
+| **Planning** | **Livre** — ler arquivos e board para levantamento; confirmar ordem/escopo antes de executar |
+| **Branch `feat/`** | **Restrito** — confirmar antes de push, criação de PR e alterações fora do escopo |
+| **Deploy / ambientes** | **Restrito** — sempre confirmar antes de qualquer ação |
+
+Regra geral: **worktree é espaço de implementação autônomo**. Volta ao modo restrito quando a ação afeta branches do Caique, PRs públicas ou ambientes.
+
+---
+
 ## Otimização de tokens
 
 - Respostas curtas — sem repetir código ou contexto anterior

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.html
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.html
@@ -32,7 +32,7 @@
             <span class="kpi-label">Receitas</span>
             <button class="mario-q" (click)="openMario('receitas')" title="Detalhes de Receitas">?</button>
           </div>
-          <div class="kpi-value kpi-value--olive">{{ summary()!.totalIncome | currencyBrl }}</div>
+          <div class="kpi-value kpi-value--olive">{{ kpiIncomeTotal() | currencyBrl }}</div>
           <div class="kpi-bar" style="background:linear-gradient(to right,rgba(123,140,95,0.7),rgba(123,140,95,0.1))"></div>
         </div>
 
@@ -42,7 +42,7 @@
             <span class="kpi-label">Despesas</span>
             <button class="mario-q" (click)="openMario('despesas')" title="Detalhes de Despesas">?</button>
           </div>
-          <div class="kpi-value kpi-value--terra">{{ summary()!.totalExpense | currencyBrl }}</div>
+          <div class="kpi-value kpi-value--terra">{{ kpiExpenseTotal() | currencyBrl }}</div>
           <div class="kpi-bar" style="background:linear-gradient(to right,rgba(196,103,74,0.7),rgba(196,103,74,0.1))"></div>
         </div>
 
@@ -52,7 +52,7 @@
             <span class="kpi-label">Pago</span>
             <button class="mario-q" (click)="openMario('pago')" title="Detalhes de Pago">?</button>
           </div>
-          <div class="kpi-value kpi-value--olive">{{ summary()!.totalPaid | currencyBrl }}</div>
+          <div class="kpi-value kpi-value--olive">{{ kpiPaid() | currencyBrl }}</div>
           <div class="kpi-bar" style="background:linear-gradient(to right,rgba(123,140,95,0.7),rgba(123,140,95,0.1))"></div>
         </div>
 
@@ -62,24 +62,24 @@
             <span class="kpi-label">A pagar</span>
             <button class="mario-q" (click)="openMario('apagar')" title="Detalhes de A pagar">?</button>
           </div>
-          <div class="kpi-value kpi-value--amber">{{ summary()!.totalOwed | currencyBrl }}</div>
+          <div class="kpi-value kpi-value--amber">{{ kpiOwed() | currencyBrl }}</div>
           <div class="kpi-bar" style="background:linear-gradient(to right,rgba(196,146,74,0.7),rgba(196,146,74,0.1))"></div>
         </div>
 
         <div class="kpi-card">
           <div class="kpi-header">
             <span class="kpi-dot"
-              [style.background]="summary()!.balance >= 0 ? 'var(--olive)' : 'var(--terracotta)'"
-              [style.box-shadow]="summary()!.balance >= 0 ? '0 0 8px rgba(123,140,95,0.5)' : '0 0 8px rgba(196,103,74,0.5)'"
+              [style.background]="kpiBalance() >= 0 ? 'var(--olive)' : 'var(--terracotta)'"
+              [style.box-shadow]="kpiBalance() >= 0 ? '0 0 8px rgba(123,140,95,0.5)' : '0 0 8px rgba(196,103,74,0.5)'"
             ></span>
             <span class="kpi-label">Saldo</span>
             <button class="mario-q" (click)="openMario('saldo')" title="Detalhes do Saldo">?</button>
           </div>
           <div class="kpi-value"
-            [class]="summary()!.balance >= 0 ? 'kpi-value--olive' : 'kpi-value--terra'"
-          >{{ summary()!.balance | currencyBrl: true }}</div>
+            [class]="kpiBalance() >= 0 ? 'kpi-value--olive' : 'kpi-value--terra'"
+          >{{ kpiBalance() | currencyBrl: true }}</div>
           <div class="kpi-bar"
-            [style.background]="summary()!.balance >= 0
+            [style.background]="kpiBalance() >= 0
               ? 'linear-gradient(to right,rgba(123,140,95,0.7),rgba(123,140,95,0.1))'
               : 'linear-gradient(to right,rgba(196,103,74,0.7),rgba(196,103,74,0.1))'"
           ></div>
@@ -88,17 +88,17 @@
         <div class="kpi-card">
           <div class="kpi-header">
             <span class="kpi-dot"
-              [style.background]="balanceAfterPayment() >= 0 ? 'var(--olive)' : 'var(--terracotta)'"
-              [style.box-shadow]="balanceAfterPayment() >= 0 ? '0 0 8px rgba(123,140,95,0.5)' : '0 0 8px rgba(196,103,74,0.5)'"
+              [style.background]="kpiBalanceAfterPayment() >= 0 ? 'var(--olive)' : 'var(--terracotta)'"
+              [style.box-shadow]="kpiBalanceAfterPayment() >= 0 ? '0 0 8px rgba(123,140,95,0.5)' : '0 0 8px rgba(196,103,74,0.5)'"
             ></span>
             <span class="kpi-label">Saldo após pag.</span>
             <button class="mario-q" (click)="openMario('saldoAposPagamento')" title="Detalhes do Saldo após pagamento">?</button>
           </div>
           <div class="kpi-value"
-            [class]="balanceAfterPayment() >= 0 ? 'kpi-value--olive' : 'kpi-value--terra'"
-          >{{ balanceAfterPayment() | currencyBrl: true }}</div>
+            [class]="kpiBalanceAfterPayment() >= 0 ? 'kpi-value--olive' : 'kpi-value--terra'"
+          >{{ kpiBalanceAfterPayment() | currencyBrl: true }}</div>
           <div class="kpi-bar"
-            [style.background]="balanceAfterPayment() >= 0
+            [style.background]="kpiBalanceAfterPayment() >= 0
               ? 'linear-gradient(to right,rgba(123,140,95,0.7),rgba(123,140,95,0.1))'
               : 'linear-gradient(to right,rgba(196,103,74,0.7),rgba(196,103,74,0.1))'"
           ></div>

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.spec.ts
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.spec.ts
@@ -242,23 +242,99 @@ describe('PeriodDetailComponent', () => {
     });
   });
 
-  describe('balanceAfterPayment computed', () => {
-    it('retorna 0 sem summary', () => {
-      expect(component.balanceAfterPayment()).toBe(0);
+  describe('KPI computeds — sem filtros ativos', () => {
+    beforeEach(fakeAsync(() => { fixture.detectChanges(); tick(); }));
+
+    it('kpiIncomeTotal retorna summary.totalIncome', () => {
+      expect(component.kpiIncomeTotal()).toBe(SUMMARY.totalIncome);
     });
 
-    it('retorna totalIncome - totalExpense', fakeAsync(() => {
-      fixture.detectChanges();
-      tick();
-      expect(component.balanceAfterPayment()).toBe(SUMMARY.totalIncome - SUMMARY.totalExpense);
-    }));
+    it('kpiExpenseTotal retorna summary.totalExpense', () => {
+      expect(component.kpiExpenseTotal()).toBe(SUMMARY.totalExpense);
+    });
 
+    it('kpiPaid retorna summary.totalPaid', () => {
+      expect(component.kpiPaid()).toBe(SUMMARY.totalPaid);
+    });
+
+    it('kpiOwed retorna summary.totalOwed', () => {
+      expect(component.kpiOwed()).toBe(SUMMARY.totalOwed);
+    });
+
+    it('kpiBalance retorna summary.balance', () => {
+      expect(component.kpiBalance()).toBe(SUMMARY.balance);
+    });
+
+    it('kpiBalanceAfterPayment retorna totalIncome - totalExpense', () => {
+      expect(component.kpiBalanceAfterPayment()).toBe(SUMMARY.totalIncome - SUMMARY.totalExpense);
+    });
+
+  });
+
+  describe('kpiBalanceAfterPayment — summary negativo', () => {
     it('retorna valor negativo quando despesas superam receitas', fakeAsync(() => {
       apiSpy.getPeriodSummary.and.returnValue(of({ ...SUMMARY, totalIncome: 500, totalExpense: 1500 }));
       fixture.detectChanges();
       tick();
-      expect(component.balanceAfterPayment()).toBe(-1000);
+      expect(component.kpiBalanceAfterPayment()).toBe(-1000);
     }));
+  });
+
+  describe('KPI computeds — com filtros de despesas ativos', () => {
+    beforeEach(fakeAsync(() => { fixture.detectChanges(); tick(); }));
+
+    it('kpiExpenseTotal soma allFilteredExpenses', () => {
+      component.expDesc.set('x');
+      component.allFilteredExpenses.set([
+        { ...EXPENSE, amount: 300 },
+        { ...EXPENSE, amount: 200, paymentStatus: PaymentStatus.Pending },
+      ]);
+      expect(component.kpiExpenseTotal()).toBe(500);
+    });
+
+    it('kpiPaid soma somente despesas Paid de allFilteredExpenses', () => {
+      component.expDesc.set('x');
+      component.allFilteredExpenses.set([
+        { ...EXPENSE, amount: 300, paymentStatus: PaymentStatus.Paid },
+        { ...EXPENSE, amount: 200, paymentStatus: PaymentStatus.Pending },
+      ]);
+      expect(component.kpiPaid()).toBe(300);
+    });
+
+    it('kpiOwed soma Pending e Partial de allFilteredExpenses', () => {
+      component.expDesc.set('x');
+      component.allFilteredExpenses.set([
+        { ...EXPENSE, amount: 300, paymentStatus: PaymentStatus.Paid },
+        { ...EXPENSE, amount: 200, paymentStatus: PaymentStatus.Pending },
+        { ...EXPENSE, amount: 100, paymentStatus: PaymentStatus.Partial },
+      ]);
+      expect(component.kpiOwed()).toBe(300);
+    });
+
+    it('kpiBalance deriva de kpiIncomeTotal - kpiExpenseTotal com filtros ativos', () => {
+      component.expDesc.set('x');
+      component.allFilteredExpenses.set([{ ...EXPENSE, amount: 400 }]);
+      expect(component.kpiBalance()).toBe(SUMMARY.totalIncome - 400);
+    });
+  });
+
+  describe('KPI computeds — com filtros de receitas ativos', () => {
+    beforeEach(fakeAsync(() => { fixture.detectChanges(); tick(); }));
+
+    it('kpiIncomeTotal soma allFilteredIncomes', () => {
+      component.incDesc.set('sal');
+      component.allFilteredIncomes.set([
+        { ...INCOME, amount: 1500 },
+        { ...INCOME, amount: 500 },
+      ]);
+      expect(component.kpiIncomeTotal()).toBe(2000);
+    });
+
+    it('kpiBalance deriva de kpiIncomeTotal - kpiExpenseTotal com filtros ativos', () => {
+      component.incDesc.set('sal');
+      component.allFilteredIncomes.set([{ ...INCOME, amount: 2000 }]);
+      expect(component.kpiBalance()).toBe(2000 - SUMMARY.totalExpense);
+    });
   });
 
   describe('expFilterFields computed', () => {

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.spec.ts
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.spec.ts
@@ -284,7 +284,7 @@ describe('PeriodDetailComponent', () => {
     beforeEach(fakeAsync(() => { fixture.detectChanges(); tick(); }));
 
     it('kpiExpenseTotal soma allFilteredExpenses', () => {
-      component.expDesc.set('x');
+      component.filterDesc.set('x');
       component.allFilteredExpenses.set([
         { ...EXPENSE, amount: 300 },
         { ...EXPENSE, amount: 200, paymentStatus: PaymentStatus.Pending },
@@ -293,7 +293,7 @@ describe('PeriodDetailComponent', () => {
     });
 
     it('kpiPaid soma somente despesas Paid de allFilteredExpenses', () => {
-      component.expDesc.set('x');
+      component.filterDesc.set('x');
       component.allFilteredExpenses.set([
         { ...EXPENSE, amount: 300, paymentStatus: PaymentStatus.Paid },
         { ...EXPENSE, amount: 200, paymentStatus: PaymentStatus.Pending },
@@ -302,7 +302,7 @@ describe('PeriodDetailComponent', () => {
     });
 
     it('kpiOwed soma Pending e Partial de allFilteredExpenses', () => {
-      component.expDesc.set('x');
+      component.filterDesc.set('x');
       component.allFilteredExpenses.set([
         { ...EXPENSE, amount: 300, paymentStatus: PaymentStatus.Paid },
         { ...EXPENSE, amount: 200, paymentStatus: PaymentStatus.Pending },
@@ -312,8 +312,9 @@ describe('PeriodDetailComponent', () => {
     });
 
     it('kpiBalance deriva de kpiIncomeTotal - kpiExpenseTotal com filtros ativos', () => {
-      component.expDesc.set('x');
+      component.filterDesc.set('x');
       component.allFilteredExpenses.set([{ ...EXPENSE, amount: 400 }]);
+      component.allFilteredIncomes.set([{ ...INCOME, amount: SUMMARY.totalIncome }]);
       expect(component.kpiBalance()).toBe(SUMMARY.totalIncome - 400);
     });
   });
@@ -322,7 +323,7 @@ describe('PeriodDetailComponent', () => {
     beforeEach(fakeAsync(() => { fixture.detectChanges(); tick(); }));
 
     it('kpiIncomeTotal soma allFilteredIncomes', () => {
-      component.incDesc.set('sal');
+      component.filterDesc.set('sal');
       component.allFilteredIncomes.set([
         { ...INCOME, amount: 1500 },
         { ...INCOME, amount: 500 },
@@ -331,8 +332,9 @@ describe('PeriodDetailComponent', () => {
     });
 
     it('kpiBalance deriva de kpiIncomeTotal - kpiExpenseTotal com filtros ativos', () => {
-      component.incDesc.set('sal');
+      component.filterDesc.set('sal');
       component.allFilteredIncomes.set([{ ...INCOME, amount: 2000 }]);
+      component.allFilteredExpenses.set([{ ...EXPENSE, amount: SUMMARY.totalExpense }]);
       expect(component.kpiBalance()).toBe(2000 - SUMMARY.totalExpense);
     });
   });
@@ -344,8 +346,8 @@ describe('PeriodDetailComponent', () => {
       expect(component.expFilterFields().length).toBe(5);
     });
 
-    it('campo description reflete expDesc', () => {
-      component.expDesc.set('teste');
+    it('campo description reflete filterDesc', () => {
+      component.filterDesc.set('teste');
       const field = component.expFilterFields().find(f => f.key === 'description')!;
       expect(field.value).toBe('teste');
     });
@@ -361,8 +363,8 @@ describe('PeriodDetailComponent', () => {
       expect(component.incFilterFields().length).toBe(2);
     });
 
-    it('campo description reflete incDesc', () => {
-      component.incDesc.set('sal');
+    it('campo description reflete filterDesc', () => {
+      component.filterDesc.set('sal');
       const field = component.incFilterFields().find(f => f.key === 'description')!;
       expect(field.value).toBe('sal');
     });
@@ -375,10 +377,10 @@ describe('PeriodDetailComponent', () => {
       component.expFilterOpen.set(true);
       component.onExpFilterApply({ description: 'aluguel', categoryId: 'cat-1', paymentStatus: '1', fortnightType: '1', sourceType: '1' });
       tick();
-      expect(component.expDesc()).toBe('aluguel');
+      expect(component.filterDesc()).toBe('aluguel');
       expect(component.expCategoryId()).toBe('cat-1');
       expect(component.expStatus()).toBe(1);
-      expect(component.expFortnight()).toBe(1);
+      expect(component.filterFortnight()).toBe(1);
       expect(component.expSourceType()).toBe(1);
       expect(component.expFilterOpen()).toBeFalse();
       expect(apiSpy.getExpensesByPeriod).toHaveBeenCalled();
@@ -389,7 +391,7 @@ describe('PeriodDetailComponent', () => {
       component.onExpFilterApply({ description: '', categoryId: '', paymentStatus: '', fortnightType: '', sourceType: '' });
       tick();
       expect(component.expStatus()).toBeNull();
-      expect(component.expFortnight()).toBeNull();
+      expect(component.filterFortnight()).toBeNull();
       expect(component.expSourceType()).toBeNull();
     }));
   });
@@ -398,11 +400,11 @@ describe('PeriodDetailComponent', () => {
     beforeEach(fakeAsync(() => { fixture.detectChanges(); tick(); }));
 
     it('limpa filtros e fecha painel', fakeAsync(() => {
-      component.expDesc.set('x');
+      component.filterDesc.set('x');
       component.expFilterOpen.set(true);
       component.onExpFilterClear();
       tick();
-      expect(component.expDesc()).toBe('');
+      expect(component.filterDesc()).toBe('');
       expect(component.expFilterOpen()).toBeFalse();
     }));
   });
@@ -413,8 +415,8 @@ describe('PeriodDetailComponent', () => {
     it('aplica filtros e recarrega receitas', fakeAsync(() => {
       component.onIncFilterApply({ description: 'sal', fortnightType: '2' });
       tick();
-      expect(component.incDesc()).toBe('sal');
-      expect(component.incFortnight()).toBe(2);
+      expect(component.filterDesc()).toBe('sal');
+      expect(component.filterFortnight()).toBe(2);
       expect(component.incFilterOpen()).toBeFalse();
       expect(apiSpy.getIncomesByPeriod).toHaveBeenCalled();
     }));
@@ -424,11 +426,11 @@ describe('PeriodDetailComponent', () => {
     beforeEach(fakeAsync(() => { fixture.detectChanges(); tick(); }));
 
     it('limpa filtros e fecha painel', fakeAsync(() => {
-      component.incDesc.set('x');
+      component.filterDesc.set('x');
       component.incFilterOpen.set(true);
       component.onIncFilterClear();
       tick();
-      expect(component.incDesc()).toBe('');
+      expect(component.filterDesc()).toBe('');
       expect(component.incFilterOpen()).toBeFalse();
     }));
   });

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.spec.ts
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.spec.ts
@@ -242,6 +242,85 @@ describe('PeriodDetailComponent', () => {
     });
   });
 
+  describe('openMario() — com filtros ativos', () => {
+    beforeEach(fakeAsync(() => {
+      fixture.detectChanges();
+      tick();
+    }));
+
+    it('receitas com incHasFilters — usa allFilteredIncomes e exibe info de filtro', () => {
+      component.filterDesc.set('sal');
+      component.allFilteredIncomes.set([{ ...INCOME, amount: 1500 }]);
+      component.openMario('receitas');
+      expect(component.marioTitle()).toBe('RECEITAS DO PERIODO');
+      expect(component.marioContent()).toContain('[FILTROS APLICADOS]');
+      expect(component.marioContent()).toContain('"sal"');
+      expect(component.marioContent()).toContain('Salário');
+    });
+
+    it('receitas filtradas sem resultados — mensagem adequada', () => {
+      component.filterDesc.set('xyz');
+      component.allFilteredIncomes.set([]);
+      component.openMario('receitas');
+      expect(component.marioContent()).toContain('Nenhuma receita');
+      expect(component.marioContent()).toContain('[FILTROS APLICADOS]');
+    });
+
+    it('despesas com expHasFilters — usa allFilteredExpenses e exibe info de filtro', () => {
+      component.filterDesc.set('alu');
+      component.allFilteredExpenses.set([{ ...EXPENSE, amount: 800 }]);
+      component.openMario('despesas');
+      expect(component.marioTitle()).toBe('DESPESAS DO PERIODO');
+      expect(component.marioContent()).toContain('[FILTROS APLICADOS]');
+      expect(component.marioContent()).toContain('"alu"');
+      expect(component.marioContent()).toContain('Aluguel');
+    });
+
+    it('pago com expHasFilters — filtra Paid de allFilteredExpenses', () => {
+      component.filterDesc.set('x');
+      component.allFilteredExpenses.set([
+        { ...EXPENSE, amount: 500, paymentStatus: PaymentStatus.Paid },
+        { ...EXPENSE, amount: 200, paymentStatus: PaymentStatus.Pending },
+      ]);
+      component.openMario('pago');
+      expect(component.marioTitle()).toBe('DESPESAS PAGAS');
+      expect(component.marioContent()).toContain('[FILTROS APLICADOS]');
+      expect(component.marioContent()).toContain('Aluguel');
+      expect(component.marioContent()).not.toContain('R$ 200');
+    });
+
+    it('apagar com expHasFilters — filtra Pending/Partial de allFilteredExpenses', () => {
+      component.filterDesc.set('x');
+      component.allFilteredExpenses.set([
+        { ...EXPENSE, amount: 300, paymentStatus: PaymentStatus.Pending },
+        { ...EXPENSE, amount: 100, paymentStatus: PaymentStatus.Partial },
+        { ...EXPENSE, amount: 600, paymentStatus: PaymentStatus.Paid },
+      ]);
+      component.openMario('apagar');
+      expect(component.marioTitle()).toBe('DESPESAS A PAGAR');
+      expect(component.marioContent()).toContain('[FILTROS APLICADOS]');
+      expect(component.marioContent()).toContain('parcial');
+    });
+
+    it('saldo com filtros — exibe info de filtro e usa kpi values', () => {
+      component.filterDesc.set('x');
+      component.allFilteredExpenses.set([{ ...EXPENSE, amount: 400 }]);
+      component.allFilteredIncomes.set([{ ...INCOME, amount: 2000 }]);
+      component.openMario('saldo');
+      expect(component.marioTitle()).toBe('CALCULO DO SALDO');
+      expect(component.marioContent()).toContain('[FILTROS APLICADOS]');
+    });
+
+    it('saldoAposPagamento com filtros — exibe info de filtro', () => {
+      component.filterDesc.set('x');
+      component.allFilteredExpenses.set([{ ...EXPENSE, amount: 400 }]);
+      component.allFilteredIncomes.set([{ ...INCOME, amount: 2000 }]);
+      component.openMario('saldoAposPagamento');
+      expect(component.marioTitle()).toBe('SALDO APOS PAGAMENTO');
+      expect(component.marioContent()).toContain('[FILTROS APLICADOS]');
+    });
+  });
+
   describe('KPI computeds — sem filtros ativos', () => {
     beforeEach(fakeAsync(() => { fixture.detectChanges(); tick(); }));
 

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.ts
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.ts
@@ -390,106 +390,178 @@ export class PeriodDetailComponent implements OnInit {
 
   // ── Mario modal ───────────────────────────────────────────────────────────
 
+  private marioFilterInfo(target: 'expenses' | 'incomes' | 'balance'): string[] {
+    const hasExp = this.expHasFilters();
+    const hasInc = this.incHasFilters();
+    const relevant = target === 'expenses' ? hasExp : target === 'incomes' ? hasInc : hasExp || hasInc;
+    if (!relevant) return [];
+
+    const lines: string[] = ['[FILTROS APLICADOS]'];
+    if (this.filterDesc())       lines.push(`Descricao: "${this.filterDesc()}"`);
+    if (this.filterFortnight() != null) lines.push(`Quinzena: ${FORTNIGHT_TYPE_LABELS[this.filterFortnight()!]}`);
+    if (target !== 'incomes') {
+      if (this.expCategoryId()) {
+        const cat = this.categories().find(c => c.id === this.expCategoryId());
+        if (cat) lines.push(`Categoria: ${cat.name}`);
+      }
+      if (this.expStatus()     != null) lines.push(`Status: ${PAYMENT_STATUS_LABELS[this.expStatus()!]}`);
+      if (this.expSourceType() != null) lines.push(`Fonte: ${SOURCE_TYPE_LABELS[this.expSourceType()! as keyof typeof SOURCE_TYPE_LABELS]}`);
+    }
+    lines.push('');
+    return lines;
+  }
+
   openMario(target: MarioTarget): void {
     const s = this.summary()!;
-    const exps = this.expenses();
     let title = '';
     let lines: string[] = [];
 
     switch (target) {
       case 'receitas': {
-        this.api.getIncomesByPeriod(this.id(), { pageNumber: 1, pageSize: 1000 })
-          .subscribe(result => {
-            const receitas = result.items;
-            if (receitas.length === 0) {
-              lines = ['Nenhuma receita\nregistrada neste periodo.'];
-            } else {
-              lines = receitas.map(i => `• ${i.description}\n  ${this.fmt(i.amount)}`);
-              lines.push('', `TOTAL: ${this.fmt(s.totalIncome)}`);
-            }
-            this.marioTitle.set('RECEITAS DO PERIODO');
-            this.marioContent.set(lines.join('\n'));
-            this.marioOpen.set(true);
-          });
+        if (this.incHasFilters()) {
+          const items = this.allFilteredIncomes();
+          lines = [...this.marioFilterInfo('incomes')];
+          if (items.length === 0) {
+            lines.push('Nenhuma receita\nencontrada com os filtros.');
+          } else {
+            lines.push(...items.map(i => `• ${i.description}\n  ${this.fmt(i.amount)}`));
+            lines.push('', `TOTAL: ${this.fmt(this.kpiIncomeTotal())}`);
+          }
+          this.marioTitle.set('RECEITAS DO PERIODO');
+          this.marioContent.set(lines.join('\n'));
+          this.marioOpen.set(true);
+        } else {
+          this.api.getIncomesByPeriod(this.id(), { pageNumber: 1, pageSize: 1000 })
+            .subscribe(result => {
+              const receitas = result.items;
+              lines = receitas.length === 0
+                ? ['Nenhuma receita\nregistrada neste periodo.']
+                : [...receitas.map(i => `• ${i.description}\n  ${this.fmt(i.amount)}`), '', `TOTAL: ${this.fmt(s.totalIncome)}`];
+              this.marioTitle.set('RECEITAS DO PERIODO');
+              this.marioContent.set(lines.join('\n'));
+              this.marioOpen.set(true);
+            });
+        }
         return;
       }
       case 'despesas': {
-        this.api.getExpensesByPeriod(this.id(), { pageNumber: 1, pageSize: 1000 })
-          .subscribe(result => {
-            const despesas = result.items;
-            if (despesas.length === 0) {
-              lines = ['Nenhuma despesa\nregistrada neste periodo.'];
-            } else {
-              lines = despesas.map(e => `• ${e.description}\n  ${this.fmt(e.amount)}`);
-              lines.push('', `TOTAL: ${this.fmt(s.totalExpense)}`);
-            }
-            this.marioTitle.set('DESPESAS DO PERIODO');
-            this.marioContent.set(lines.join('\n'));
-            this.marioOpen.set(true);
-          });
+        if (this.expHasFilters()) {
+          const items = this.allFilteredExpenses();
+          lines = [...this.marioFilterInfo('expenses')];
+          if (items.length === 0) {
+            lines.push('Nenhuma despesa\nencontrada com os filtros.');
+          } else {
+            lines.push(...items.map(e => `• ${e.description}\n  ${this.fmt(e.amount)}`));
+            lines.push('', `TOTAL: ${this.fmt(this.kpiExpenseTotal())}`);
+          }
+          this.marioTitle.set('DESPESAS DO PERIODO');
+          this.marioContent.set(lines.join('\n'));
+          this.marioOpen.set(true);
+        } else {
+          this.api.getExpensesByPeriod(this.id(), { pageNumber: 1, pageSize: 1000 })
+            .subscribe(result => {
+              const despesas = result.items;
+              lines = despesas.length === 0
+                ? ['Nenhuma despesa\nregistrada neste periodo.']
+                : [...despesas.map(e => `• ${e.description}\n  ${this.fmt(e.amount)}`), '', `TOTAL: ${this.fmt(s.totalExpense)}`];
+              this.marioTitle.set('DESPESAS DO PERIODO');
+              this.marioContent.set(lines.join('\n'));
+              this.marioOpen.set(true);
+            });
+        }
         return;
       }
       case 'pago': {
-        this.api.getExpensesByPeriod(this.id(), { pageNumber: 1, pageSize: 1000, paymentStatus: PaymentStatus.Paid })
-          .subscribe(result => {
-            const pagas = result.items;
-            if (pagas.length === 0) {
-              lines = ['Nenhuma despesa\npaga neste periodo.'];
-            } else {
-              lines = pagas.map(e => `• ${e.description}\n  ${this.fmt(e.amount)}`);
-              lines.push('', `TOTAL PAGO: ${this.fmt(s.totalPaid)}`);
-            }
-            this.marioTitle.set('DESPESAS PAGAS');
-            this.marioContent.set(lines.join('\n'));
-            this.marioOpen.set(true);
-          });
+        if (this.expHasFilters()) {
+          const pagas = this.allFilteredExpenses().filter(e => e.paymentStatus === PaymentStatus.Paid);
+          lines = [...this.marioFilterInfo('expenses')];
+          if (pagas.length === 0) {
+            lines.push('Nenhuma despesa\npaga com os filtros.');
+          } else {
+            lines.push(...pagas.map(e => `• ${e.description}\n  ${this.fmt(e.amount)}`));
+            lines.push('', `TOTAL PAGO: ${this.fmt(this.kpiPaid())}`);
+          }
+          this.marioTitle.set('DESPESAS PAGAS');
+          this.marioContent.set(lines.join('\n'));
+          this.marioOpen.set(true);
+        } else {
+          this.api.getExpensesByPeriod(this.id(), { pageNumber: 1, pageSize: 1000, paymentStatus: PaymentStatus.Paid })
+            .subscribe(result => {
+              const pagas = result.items;
+              lines = pagas.length === 0
+                ? ['Nenhuma despesa\npaga neste periodo.']
+                : [...pagas.map(e => `• ${e.description}\n  ${this.fmt(e.amount)}`), '', `TOTAL PAGO: ${this.fmt(s.totalPaid)}`];
+              this.marioTitle.set('DESPESAS PAGAS');
+              this.marioContent.set(lines.join('\n'));
+              this.marioOpen.set(true);
+            });
+        }
         return;
       }
       case 'apagar': {
-        this.api.getExpensesByPeriod(this.id(), { pageNumber: 1, pageSize: 1000, paymentStatus: PaymentStatus.Pending })
-          .subscribe(result => {
-            const pendentes = result.items;
-            if (pendentes.length === 0) {
-              lines = ['Nenhuma despesa\npendente neste periodo.'];
-            } else {
-              lines = pendentes.map(e => {
-                const suffix = e.paymentStatus === PaymentStatus.Partial ? ' (parcial)' : '';
-                return `• ${e.description}${suffix}\n  ${this.fmt(e.amount)}`;
-              });
-              lines.push('', `TOTAL A PAGAR: ${this.fmt(s.totalOwed)}`);
-            }
-            this.marioTitle.set('DESPESAS A PAGAR');
-            this.marioContent.set(lines.join('\n'));
-            this.marioOpen.set(true);
-          });
+        if (this.expHasFilters()) {
+          const pendentes = this.allFilteredExpenses()
+            .filter(e => e.paymentStatus === PaymentStatus.Pending || e.paymentStatus === PaymentStatus.Partial);
+          lines = [...this.marioFilterInfo('expenses')];
+          if (pendentes.length === 0) {
+            lines.push('Nenhuma despesa\npendente com os filtros.');
+          } else {
+            lines.push(...pendentes.map(e => {
+              const suffix = e.paymentStatus === PaymentStatus.Partial ? ' (parcial)' : '';
+              return `• ${e.description}${suffix}\n  ${this.fmt(e.amount)}`;
+            }));
+            lines.push('', `TOTAL A PAGAR: ${this.fmt(this.kpiOwed())}`);
+          }
+          this.marioTitle.set('DESPESAS A PAGAR');
+          this.marioContent.set(lines.join('\n'));
+          this.marioOpen.set(true);
+        } else {
+          this.api.getExpensesByPeriod(this.id(), { pageNumber: 1, pageSize: 1000, paymentStatus: PaymentStatus.Pending })
+            .subscribe(result => {
+              const pendentes = result.items;
+              if (pendentes.length === 0) {
+                lines = ['Nenhuma despesa\npendente neste periodo.'];
+              } else {
+                lines = pendentes.map(e => {
+                  const suffix = e.paymentStatus === PaymentStatus.Partial ? ' (parcial)' : '';
+                  return `• ${e.description}${suffix}\n  ${this.fmt(e.amount)}`;
+                });
+                lines.push('', `TOTAL A PAGAR: ${this.fmt(s.totalOwed)}`);
+              }
+              this.marioTitle.set('DESPESAS A PAGAR');
+              this.marioContent.set(lines.join('\n'));
+              this.marioOpen.set(true);
+            });
+        }
         return;
       }
       case 'saldo': {
         title = 'CALCULO DO SALDO';
         lines = [
+          ...this.marioFilterInfo('balance'),
           `Receitas:`,
-          `  ${this.fmt(s.totalIncome)}`,
+          `  ${this.fmt(this.kpiIncomeTotal())}`,
           '',
           `(-) Despesas:`,
-          `  ${this.fmt(s.totalExpense)}`,
+          `  ${this.fmt(this.kpiExpenseTotal())}`,
           '',
           `(=) Saldo:`,
-          `  ${this.fmt(s.balance)}`,
+          `  ${this.fmt(this.kpiBalance())}`,
         ];
         break;
       }
       case 'saldoAposPagamento': {
-        const val = s.totalIncome - s.totalExpense;
         title = 'SALDO APOS PAGAMENTO';
         lines = [
+          ...this.marioFilterInfo('balance'),
           `Receitas:`,
-          `  ${this.fmt(s.totalIncome)}`,
+          `  ${this.fmt(this.kpiIncomeTotal())}`,
           '',
           `(-) Total de despesas:`,
-          `  ${this.fmt(s.totalExpense)}`,
+          `  ${this.fmt(this.kpiExpenseTotal())}`,
           '',
           `(=) Saldo apos pagamento:`,
-          `  ${this.fmt(val)}`,
+          `  ${this.fmt(this.kpiBalanceAfterPayment())}`,
         ];
         break;
       }

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.ts
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.ts
@@ -65,10 +65,12 @@ export class PeriodDetailComponent implements OnInit {
   readonly expPageSize     = signal(20);
   readonly expTotal        = signal(0);
   readonly expLoadingList  = signal(false);
-  readonly expDesc         = signal('');
+  // Filtros compartilhados entre despesas e receitas
+  readonly filterDesc      = signal('');
+  readonly filterFortnight = signal<FortnightType | null>(null);
+
   readonly expCategoryId   = signal('');
   readonly expStatus       = signal<PaymentStatus | null>(null);
-  readonly expFortnight    = signal<FortnightType | null>(null);
   readonly expSourceType   = signal<SourceType | null>(null);
   readonly expSortCol      = signal<ExpSortCol | null>(null);
   readonly expSortDir      = signal<'asc' | 'desc'>('asc');
@@ -78,19 +80,19 @@ export class PeriodDetailComponent implements OnInit {
   readonly allFilteredIncomes  = signal<IncomeResponse[]>([]);
 
   readonly expHasFilters = computed(() =>
-    !!this.expDesc() || !!this.expCategoryId() ||
-    this.expStatus() != null || this.expFortnight() != null ||
+    !!this.filterDesc() || !!this.expCategoryId() ||
+    this.expStatus() != null || this.filterFortnight() != null ||
     this.expSourceType() != null);
 
   readonly expFilterFields = computed<FilterFieldConfig[]>(() => [
-    { key: 'description',   label: 'Descrição', type: 'text',   value: this.expDesc() },
+    { key: 'description',   label: 'Descrição', type: 'text',   value: this.filterDesc() },
     { key: 'categoryId',    label: 'Categoria',  type: 'select', value: this.expCategoryId(),
       options: [{ value: '', label: 'Todas' }, ...this.categories().map(c => ({ value: c.id, label: c.name }))] },
     { key: 'paymentStatus', label: 'Status',     type: 'select', value: this.expStatus() ?? '',
       options: [{ value: '', label: 'Todos' }, { value: PaymentStatus.Pending, label: 'Pendente' },
         { value: PaymentStatus.Paid, label: 'Pago' }, { value: PaymentStatus.Partial, label: 'Parcial' },
         { value: PaymentStatus.Cancelled, label: 'Cancelado' }] },
-    { key: 'fortnightType', label: 'Quinzena',   type: 'select', value: this.expFortnight() ?? '',
+    { key: 'fortnightType', label: 'Quinzena',   type: 'select', value: this.filterFortnight() ?? '',
       options: [{ value: '', label: 'Ambas' }, { value: FortnightType.First, label: '1ª Quinzena' },
         { value: FortnightType.Second, label: '2ª Quinzena' }] },
     { key: 'sourceType',    label: 'Fonte',      type: 'select', value: this.expSourceType() ?? '',
@@ -128,18 +130,16 @@ export class PeriodDetailComponent implements OnInit {
   readonly incPageSize    = signal(20);
   readonly incTotal       = signal(0);
   readonly incLoadingList = signal(false);
-  readonly incDesc        = signal('');
-  readonly incFortnight   = signal<FortnightType | null>(null);
   readonly incSortCol     = signal<IncSortCol | null>(null);
   readonly incSortDir     = signal<'asc' | 'desc'>('asc');
   readonly incFilterOpen  = signal(false);
 
   readonly incHasFilters = computed(() =>
-    !!this.incDesc() || this.incFortnight() != null);
+    !!this.filterDesc() || this.filterFortnight() != null);
 
   readonly incFilterFields = computed<FilterFieldConfig[]>(() => [
-    { key: 'description',   label: 'Descrição', type: 'text',   value: this.incDesc() },
-    { key: 'fortnightType', label: 'Quinzena',   type: 'select', value: this.incFortnight() ?? '',
+    { key: 'description',   label: 'Descrição', type: 'text',   value: this.filterDesc() },
+    { key: 'fortnightType', label: 'Quinzena',   type: 'select', value: this.filterFortnight() ?? '',
       options: [{ value: '', label: 'Ambas' }, { value: FortnightType.First, label: '1ª Quinzena' },
         { value: FortnightType.Second, label: '2ª Quinzena' }] },
   ]);
@@ -239,11 +239,11 @@ export class PeriodDetailComponent implements OnInit {
     this.api.getExpensesByPeriod(this.id(), {
       pageNumber:    1,
       pageSize:      9999,
-      description:   this.expDesc()       || undefined,
-      categoryId:    this.expCategoryId() || undefined,
-      paymentStatus: this.expStatus()      ?? undefined,
-      fortnightType: this.expFortnight()   ?? undefined,
-      sourceType:    this.expSourceType()  ?? undefined,
+      description:   this.filterDesc()      || undefined,
+      categoryId:    this.expCategoryId()   || undefined,
+      paymentStatus: this.expStatus()        ?? undefined,
+      fortnightType: this.filterFortnight()  ?? undefined,
+      sourceType:    this.expSourceType()    ?? undefined,
     }).subscribe({ next: r => this.allFilteredExpenses.set(r.items) });
   }
 
@@ -252,8 +252,8 @@ export class PeriodDetailComponent implements OnInit {
     this.api.getIncomesByPeriod(this.id(), {
       pageNumber:    1,
       pageSize:      9999,
-      description:   this.incDesc()      || undefined,
-      fortnightType: this.incFortnight() ?? undefined,
+      description:   this.filterDesc()      || undefined,
+      fortnightType: this.filterFortnight()  ?? undefined,
     }).subscribe({ next: r => this.allFilteredIncomes.set(r.items) });
   }
 
@@ -262,11 +262,11 @@ export class PeriodDetailComponent implements OnInit {
     this.api.getExpensesByPeriod(this.id(), {
       pageNumber:    this.expPage(),
       pageSize:      this.expPageSize(),
-      description:   this.expDesc()       || undefined,
-      categoryId:    this.expCategoryId() || undefined,
-      paymentStatus: this.expStatus()      ?? undefined,
-      fortnightType: this.expFortnight()   ?? undefined,
-      sourceType:    this.expSourceType()  ?? undefined,
+      description:   this.filterDesc()      || undefined,
+      categoryId:    this.expCategoryId()   || undefined,
+      paymentStatus: this.expStatus()        ?? undefined,
+      fortnightType: this.filterFortnight()  ?? undefined,
+      sourceType:    this.expSourceType()    ?? undefined,
     }).subscribe({
       next: result => {
         this.expenses.set(result.items);
@@ -278,18 +278,21 @@ export class PeriodDetailComponent implements OnInit {
   }
 
   onExpFilterApply(values: Record<string, unknown>): void {
-    this.expDesc.set((values['description'] as string) ?? '');
+    this.filterDesc.set((values['description'] as string) ?? '');
     this.expCategoryId.set((values['categoryId'] as string) ?? '');
     const status = values['paymentStatus'] as string;
     this.expStatus.set(status ? Number(status) as PaymentStatus : null);
     const fortnight = values['fortnightType'] as string;
-    this.expFortnight.set(fortnight ? Number(fortnight) as FortnightType : null);
+    this.filterFortnight.set(fortnight ? Number(fortnight) as FortnightType : null);
     const source = values['sourceType'] as string;
     this.expSourceType.set(source ? Number(source) as SourceType : null);
     this.expFilterOpen.set(false);
     this.expPage.set(1);
+    this.incPage.set(1);
     this.loadExpenses();
     this.loadAllFilteredExpenses();
+    this.loadIncomes();
+    this.loadAllFilteredIncomes();
   }
 
   onExpFilterClear(): void {
@@ -298,14 +301,17 @@ export class PeriodDetailComponent implements OnInit {
   }
 
   clearExpFilters(): void {
-    this.expDesc.set('');
+    this.filterDesc.set('');
+    this.filterFortnight.set(null);
     this.expCategoryId.set('');
     this.expStatus.set(null);
-    this.expFortnight.set(null);
     this.expSourceType.set(null);
     this.expPage.set(1);
+    this.incPage.set(1);
     this.allFilteredExpenses.set([]);
+    this.allFilteredIncomes.set([]);
     this.loadExpenses();
+    this.loadIncomes();
   }
 
   onExpPageChange(page: number): void { this.expPage.set(page); this.loadExpenses(); }
@@ -328,8 +334,8 @@ export class PeriodDetailComponent implements OnInit {
     this.api.getIncomesByPeriod(this.id(), {
       pageNumber:    this.incPage(),
       pageSize:      this.incPageSize(),
-      description:   this.incDesc()      || undefined,
-      fortnightType: this.incFortnight() ?? undefined,
+      description:   this.filterDesc()      || undefined,
+      fortnightType: this.filterFortnight()  ?? undefined,
     }).subscribe({
       next: result => {
         this.incomes.set(result.items);
@@ -341,13 +347,16 @@ export class PeriodDetailComponent implements OnInit {
   }
 
   onIncFilterApply(values: Record<string, unknown>): void {
-    this.incDesc.set((values['description'] as string) ?? '');
+    this.filterDesc.set((values['description'] as string) ?? '');
     const fortnight = values['fortnightType'] as string;
-    this.incFortnight.set(fortnight ? Number(fortnight) as FortnightType : null);
+    this.filterFortnight.set(fortnight ? Number(fortnight) as FortnightType : null);
     this.incFilterOpen.set(false);
     this.incPage.set(1);
+    this.expPage.set(1);
     this.loadIncomes();
     this.loadAllFilteredIncomes();
+    this.loadExpenses();
+    this.loadAllFilteredExpenses();
   }
 
   onIncFilterClear(): void {
@@ -356,11 +365,14 @@ export class PeriodDetailComponent implements OnInit {
   }
 
   clearIncFilters(): void {
-    this.incDesc.set('');
-    this.incFortnight.set(null);
+    this.filterDesc.set('');
+    this.filterFortnight.set(null);
     this.incPage.set(1);
+    this.expPage.set(1);
     this.allFilteredIncomes.set([]);
+    this.allFilteredExpenses.set([]);
     this.loadIncomes();
+    this.loadExpenses();
   }
 
   onIncPageChange(page: number): void { this.incPage.set(page); this.loadIncomes(); }

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.ts
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.ts
@@ -74,6 +74,9 @@ export class PeriodDetailComponent implements OnInit {
   readonly expSortDir      = signal<'asc' | 'desc'>('asc');
   readonly expFilterOpen   = signal(false);
 
+  readonly allFilteredExpenses = signal<ExpenseResponse[]>([]);
+  readonly allFilteredIncomes  = signal<IncomeResponse[]>([]);
+
   readonly expHasFilters = computed(() =>
     !!this.expDesc() || !!this.expCategoryId() ||
     this.expStatus() != null || this.expFortnight() != null ||
@@ -176,10 +179,38 @@ export class PeriodDetailComponent implements OnInit {
 
   readonly year = computed(() => this.summary()?.year ?? null);
 
-  readonly balanceAfterPayment = computed(() => {
-    const s = this.summary();
-    return s ? s.totalIncome - s.totalExpense : 0;
+  readonly kpiIncomeTotal = computed(() =>
+    this.incHasFilters()
+      ? this.allFilteredIncomes().reduce((sum, i) => sum + i.amount, 0)
+      : (this.summary()?.totalIncome ?? 0));
+
+  readonly kpiExpenseTotal = computed(() =>
+    this.expHasFilters()
+      ? this.allFilteredExpenses().reduce((sum, e) => sum + e.amount, 0)
+      : (this.summary()?.totalExpense ?? 0));
+
+  readonly kpiPaid = computed(() =>
+    this.expHasFilters()
+      ? this.allFilteredExpenses()
+          .filter(e => e.paymentStatus === PaymentStatus.Paid)
+          .reduce((sum, e) => sum + e.amount, 0)
+      : (this.summary()?.totalPaid ?? 0));
+
+  readonly kpiOwed = computed(() =>
+    this.expHasFilters()
+      ? this.allFilteredExpenses()
+          .filter(e => e.paymentStatus === PaymentStatus.Pending || e.paymentStatus === PaymentStatus.Partial)
+          .reduce((sum, e) => sum + e.amount, 0)
+      : (this.summary()?.totalOwed ?? 0));
+
+  readonly kpiBalance = computed(() => {
+    if (this.expHasFilters() || this.incHasFilters())
+      return this.kpiIncomeTotal() - this.kpiExpenseTotal();
+    return this.summary()?.balance ?? 0;
   });
+
+  readonly kpiBalanceAfterPayment = computed(() =>
+    this.kpiIncomeTotal() - this.kpiExpenseTotal());
 
   // Exposição de enums para o template
   readonly PaymentStatus  = PaymentStatus;
@@ -202,6 +233,29 @@ export class PeriodDetailComponent implements OnInit {
   }
 
   // ── Despesas ─────────────────────────────────────────────────────────────
+
+  private loadAllFilteredExpenses(): void {
+    if (!this.expHasFilters()) { this.allFilteredExpenses.set([]); return; }
+    this.api.getExpensesByPeriod(this.id(), {
+      pageNumber:    1,
+      pageSize:      9999,
+      description:   this.expDesc()       || undefined,
+      categoryId:    this.expCategoryId() || undefined,
+      paymentStatus: this.expStatus()      ?? undefined,
+      fortnightType: this.expFortnight()   ?? undefined,
+      sourceType:    this.expSourceType()  ?? undefined,
+    }).subscribe({ next: r => this.allFilteredExpenses.set(r.items) });
+  }
+
+  private loadAllFilteredIncomes(): void {
+    if (!this.incHasFilters()) { this.allFilteredIncomes.set([]); return; }
+    this.api.getIncomesByPeriod(this.id(), {
+      pageNumber:    1,
+      pageSize:      9999,
+      description:   this.incDesc()      || undefined,
+      fortnightType: this.incFortnight() ?? undefined,
+    }).subscribe({ next: r => this.allFilteredIncomes.set(r.items) });
+  }
 
   private loadExpenses(): void {
     this.expLoadingList.set(true);
@@ -235,6 +289,7 @@ export class PeriodDetailComponent implements OnInit {
     this.expFilterOpen.set(false);
     this.expPage.set(1);
     this.loadExpenses();
+    this.loadAllFilteredExpenses();
   }
 
   onExpFilterClear(): void {
@@ -249,6 +304,7 @@ export class PeriodDetailComponent implements OnInit {
     this.expFortnight.set(null);
     this.expSourceType.set(null);
     this.expPage.set(1);
+    this.allFilteredExpenses.set([]);
     this.loadExpenses();
   }
 
@@ -291,6 +347,7 @@ export class PeriodDetailComponent implements OnInit {
     this.incFilterOpen.set(false);
     this.incPage.set(1);
     this.loadIncomes();
+    this.loadAllFilteredIncomes();
   }
 
   onIncFilterClear(): void {
@@ -302,6 +359,7 @@ export class PeriodDetailComponent implements OnInit {
     this.incDesc.set('');
     this.incFortnight.set(null);
     this.incPage.set(1);
+    this.allFilteredIncomes.set([]);
     this.loadIncomes();
   }
 


### PR DESCRIPTION
Closes #288

## Resumo
- Filtros de descrição e quinzena compartilhados entre as abas de despesas e receitas
- KPI cards (Receitas, Despesas, Pago, A pagar, Saldo, Saldo após pag.) refletem os dados filtrados quando filtros estão ativos
- `allFilteredExpenses` / `allFilteredIncomes` carregados com `pageSize: 9999` ao aplicar filtros
- Ao aplicar filtro em qualquer aba, ambas as listas e KPIs são atualizados
- Modal Mario exibe somente os itens filtrados com bloco `[FILTROS APLICADOS]` listando campos e valores
- Modais de saldo usam os KPI computeds (valores já filtrados)