### PR TITLE
feat(filters): converter filter-modal para overlay + filtros em Períodos e Dashboard

### DIFF
--- a/personal-finance/src/app/features/config/components/admin-users/admin-users.component.html
+++ b/personal-finance/src/app/features/config/components/admin-users/admin-users.component.html
@@ -14,6 +14,7 @@
       [open]="filterOpen()"
       (apply)="onFilterApply($event)"
       (clear)="onFilterClear()"
+      (closed)="filterOpen.set(false)"
     />
   </div>
 

--- a/personal-finance/src/app/features/dashboard/components/dashboard/dashboard.component.css
+++ b/personal-finance/src/app/features/dashboard/components/dashboard/dashboard.component.css
@@ -7,6 +7,19 @@
 }
 
 /* ── Seletor de período ── */
+.filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.period-selected-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
 .period-selector {
   display: flex;
   flex-direction: column;

--- a/personal-finance/src/app/features/dashboard/components/dashboard/dashboard.component.html
+++ b/personal-finance/src/app/features/dashboard/components/dashboard/dashboard.component.html
@@ -5,31 +5,25 @@
 <div class="page-content">
 
   <!-- Seletor de período -->
-  <div class="period-selector">
-    <div class="period-selector-top">
-      <span class="period-label">Período</span>
-      @if (availableYears().length > 1) {
-        <select class="year-select" [value]="selectedYear()" (change)="selectYear(+$any($event.target).value)">
-          @for (year of availableYears(); track year) {
-            <option [value]="year">{{ year }}</option>
-          }
-        </select>
-      }
-    </div>
-    <div class="month-chips">
-      @for (period of filteredPeriods(); track period.id) {
-        <button
-          class="month-chip"
-          [class.active]="selectedPeriodId() === period.id"
-          (click)="selectPeriod(period.id)"
-        >{{ monthName(period.month) }}/{{ period.year }}</button>
-      }
-      @if (filteredPeriods().length === 0 && !loadingPeriods()) {
-        <span class="text-muted" style="font-size:0.875rem">
-          Nenhum período. <a routerLink="/periods">Criar</a>
-        </span>
-      }
-    </div>
+  <div class="filter-bar">
+    <app-filter-button
+      [activeCount]="selectedPeriodId() ? 1 : 0"
+      (toggled)="filterOpen.update(v => !v)"
+    />
+    <app-filter-modal
+      [fields]="filterFields()"
+      [open]="filterOpen()"
+      (apply)="onApplyFilters($event)"
+      (clear)="onClearFilters()"
+      (closed)="filterOpen.set(false)"
+    />
+    @if (selectedPeriodId()) {
+      <span class="period-selected-label">{{ headerSubtitle() }}</span>
+    } @else if (!loadingPeriods()) {
+      <span class="text-muted" style="font-size:0.875rem">
+        Nenhum período selecionado. <a routerLink="/periods">Criar</a>
+      </span>
+    }
   </div>
 
   <!-- KPI Cards -->

--- a/personal-finance/src/app/features/dashboard/components/dashboard/dashboard.component.ts
+++ b/personal-finance/src/app/features/dashboard/components/dashboard/dashboard.component.ts
@@ -9,6 +9,9 @@ import { AuthService } from '../../../../core/auth/auth.service';
 import { ThemeService } from '../../../../core/services/theme.service';
 import { HeaderComponent } from '../../../../shared/components/header/header.component';
 import { CurrencyBrlPipe } from '../../../../shared/pipes/currency-brl.pipe';
+import { FilterModalComponent } from '../../../../shared/components/filter-modal/filter-modal.component';
+import { FilterButtonComponent } from '../../../../shared/components/filter-modal/filter-button.component';
+import { FilterFieldConfig } from '../../../../shared/components/filter-modal/filter-field-config';
 import { PeriodResponse, PeriodSummary, MONTH_NAMES, PaymentStatus, ExpensesReport } from '../../../../core/models/models';
 
 export interface DashWidget {
@@ -30,6 +33,7 @@ const DEFAULT_WIDGETS: DashWidget[] = [
   imports: [
     HeaderComponent, CurrencyBrlPipe, DecimalPipe, RouterLink,
     NgxEchartsDirective, CdkDropList, CdkDrag,
+    FilterModalComponent, FilterButtonComponent,
   ],
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.css'],
@@ -52,6 +56,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   readonly loadingPeriods   = signal(true);
   readonly loadingSummary   = signal(false);
 
+  readonly filterOpen     = signal(false);
   readonly selectedMonth  = signal<number>(new Date().getMonth() + 1);
   readonly loadingChart1  = signal(false);
   readonly loadingChart2  = signal(false);
@@ -89,6 +94,25 @@ export class DashboardComponent implements OnInit, OnDestroy {
     const today = new Date().getMonth() + 1; // 1–12
     return [today - 2, today - 1, today].filter(m => m >= 1);
   });
+
+  readonly filterFields = computed<FilterFieldConfig[]>(() => [
+    {
+      key: 'year', label: 'Ano', type: 'select',
+      value: this.selectedYear(),
+      options: this.availableYears().map(y => ({ value: y, label: String(y) }))
+    },
+    {
+      key: 'periodId', label: 'Período', type: 'select',
+      value: this.selectedPeriodId() ?? '',
+      options: [
+        { value: '', label: '-- Selecione --' },
+        ...this.filteredPeriods().map(p => ({
+          value: p.id,
+          label: `${MONTH_NAMES[p.month - 1]}/${p.year}`
+        }))
+      ]
+    }
+  ]);
 
   constructor() {
     effect(() => {
@@ -141,6 +165,18 @@ export class DashboardComponent implements OnInit, OnDestroy {
   selectMonth(month: number): void {
     this.selectedMonth.set(month);
     this.loadChart2(this.selectedYear(), month);
+  }
+
+  onApplyFilters(values: Record<string, unknown>): void {
+    const year     = values['year']     ? +values['year']          : this.selectedYear();
+    const periodId = values['periodId'] ? String(values['periodId']) : null;
+    if (year !== this.selectedYear()) this.selectYear(year);
+    if (periodId) this.selectPeriod(periodId);
+  }
+
+  onClearFilters(): void {
+    const years = this.availableYears();
+    if (years.length) this.selectYear(years[0]);
   }
 
   monthName(month: number): string {

--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.html
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.html
@@ -33,6 +33,7 @@
         [open]="filterOpen()"
         (apply)="onApplyFilters($event)"
         (clear)="onClearFilters()"
+        (closed)="filterOpen.set(false)"
       />
     </div>
   }

--- a/personal-finance/src/app/features/incomes/components/incomes/incomes.component.html
+++ b/personal-finance/src/app/features/incomes/components/incomes/incomes.component.html
@@ -33,6 +33,7 @@
         [open]="filterOpen()"
         (apply)="onApplyFilters($event)"
         (clear)="onClearFilters()"
+        (closed)="filterOpen.set(false)"
       />
     </div>
   }

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.html
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.html
@@ -132,6 +132,7 @@
         [open]="expFilterOpen()"
         (apply)="onExpFilterApply($event)"
         (clear)="onExpFilterClear()"
+        (closed)="expFilterOpen.set(false)"
       />
 
       @if (expLoadingList()) {
@@ -219,6 +220,7 @@
         [open]="incFilterOpen()"
         (apply)="onIncFilterApply($event)"
         (clear)="onIncFilterClear()"
+        (closed)="incFilterOpen.set(false)"
       />
 
       @if (incLoadingList()) {

--- a/personal-finance/src/app/features/periods/components/periods/periods.component.html
+++ b/personal-finance/src/app/features/periods/components/periods/periods.component.html
@@ -62,49 +62,17 @@
   <!-- Barra de filtros -->
   @if (!loadingList() && periods().length > 0) {
     <div class="filter-bar">
-      <div class="filter-controls">
-        <div class="filter-field">
-          <label class="filter-label">Ano</label>
-          <select class="input-sm" [value]="selectedYear() ?? ''" (change)="setYear($any($event.target).value)">
-            <option value="">Todos</option>
-            @for (y of availableYears(); track y) {
-              <option [value]="y">{{ y }}</option>
-            }
-          </select>
-        </div>
-
-        <div class="filter-field">
-          <label class="filter-label">De</label>
-          <select class="input-sm" [value]="monthFrom() ?? ''" (change)="setMonthFrom($any($event.target).value)">
-            <option value="">--</option>
-            @for (m of monthsShort; track m.value) {
-              <option [value]="m.value">{{ m.label }}</option>
-            }
-          </select>
-        </div>
-
-        <div class="filter-field">
-          <label class="filter-label">Até</label>
-          <select class="input-sm" [value]="monthTo() ?? ''" (change)="setMonthTo($any($event.target).value)">
-            <option value="">--</option>
-            @for (m of monthsShort; track m.value) {
-              <option [value]="m.value">{{ m.label }}</option>
-            }
-          </select>
-        </div>
-
-        <div class="filter-field">
-          <label class="filter-label">Status</label>
-          <select class="input-sm" [value]="filterStatus()" (change)="setStatus($any($event.target).value)">
-            <option value="all">Todos</option>
-            <option value="active">Ativo</option>
-            <option value="inactive">Inativo</option>
-          </select>
-        </div>
-
-        <button class="filter-clear" (click)="clearFilters()">Limpar</button>
-      </div>
-
+      <app-filter-button
+        [activeCount]="activeFilterCount()"
+        (toggled)="filterOpen.update(v => !v)"
+      />
+      <app-filter-modal
+        [fields]="filterFields()"
+        [open]="filterOpen()"
+        (apply)="onApplyFilters($event)"
+        (clear)="onClearFilters()"
+        (closed)="filterOpen.set(false)"
+      />
       <p class="filter-count">
         {{ filteredPeriods().length }} período(s) encontrado(s)
         @if (totalPages() > 1) {

--- a/personal-finance/src/app/features/periods/components/periods/periods.component.ts
+++ b/personal-finance/src/app/features/periods/components/periods/periods.component.ts
@@ -5,12 +5,15 @@ import { trigger, style, animate, transition } from '@angular/animations';
 import { ApiService } from '../../../../core/services/api.service';
 import { HeaderComponent } from '../../../../shared/components/header/header.component';
 import { RecurringExpensesModalComponent } from '../../../../shared/components/modal/recurring-expenses-modal/recurring-expenses-modal.component';
+import { FilterModalComponent } from '../../../../shared/components/filter-modal/filter-modal.component';
+import { FilterButtonComponent } from '../../../../shared/components/filter-modal/filter-button.component';
+import { FilterFieldConfig } from '../../../../shared/components/filter-modal/filter-field-config';
 import { PeriodResponse, RecurringExpenseResponse, MONTH_NAMES } from '../../../../core/models/models';
 
 @Component({
   selector: 'app-periods',
   standalone: true,
-  imports: [HeaderComponent, RouterLink, ReactiveFormsModule, RecurringExpensesModalComponent],
+  imports: [HeaderComponent, RouterLink, ReactiveFormsModule, RecurringExpensesModalComponent, FilterModalComponent, FilterButtonComponent],
   templateUrl: './periods.component.html',
   styleUrls: ['./periods.component.css'],
   animations: [
@@ -53,6 +56,7 @@ export class PeriodsComponent implements OnInit {
   readonly monthFrom    = signal<number | null>(null);
   readonly monthTo      = signal<number | null>(null);
   readonly filterStatus = signal<'all' | 'active' | 'inactive'>('all');
+  readonly filterOpen   = signal(false);
 
   // ── Paginação ─────────────────────────────────────────────────────────────
   readonly currentPage = signal(1);
@@ -93,6 +97,51 @@ export class PeriodsComponent implements OnInit {
     Array.from({ length: this.totalPages() }, (_, i) => i + 1)
   );
 
+  readonly activeFilterCount = computed(() => {
+    let count = 0;
+    if (this.selectedYear() !== new Date().getFullYear()) count++;
+    if (this.monthFrom() !== null) count++;
+    if (this.monthTo()   !== null) count++;
+    if (this.filterStatus() !== 'all') count++;
+    return count;
+  });
+
+  readonly filterFields = computed<FilterFieldConfig[]>(() => [
+    {
+      key: 'year', label: 'Ano', type: 'select',
+      value: this.selectedYear() ?? '',
+      options: [
+        { value: '', label: 'Todos' },
+        ...this.availableYears().map(y => ({ value: y, label: String(y) }))
+      ]
+    },
+    {
+      key: 'monthFrom', label: 'De', type: 'select',
+      value: this.monthFrom() ?? '',
+      options: [
+        { value: '', label: '--' },
+        ...this.monthsShort.map(m => ({ value: m.value, label: m.label }))
+      ]
+    },
+    {
+      key: 'monthTo', label: 'Até', type: 'select',
+      value: this.monthTo() ?? '',
+      options: [
+        { value: '', label: '--' },
+        ...this.monthsShort.map(m => ({ value: m.value, label: m.label }))
+      ]
+    },
+    {
+      key: 'status', label: 'Status', type: 'select',
+      value: this.filterStatus(),
+      options: [
+        { value: 'all',      label: 'Todos'   },
+        { value: 'active',   label: 'Ativo'   },
+        { value: 'inactive', label: 'Inativo' }
+      ]
+    }
+  ]);
+
   // ── Constantes ────────────────────────────────────────────────────────────
   readonly monthNames  = MONTH_NAMES;
   readonly monthsShort = MONTH_NAMES.map((label, i) => ({ value: i + 1, label }));
@@ -119,6 +168,17 @@ export class PeriodsComponent implements OnInit {
     this.monthTo.set(null);
     this.filterStatus.set('all');
     this.currentPage.set(1);
+  }
+
+  onApplyFilters(values: Record<string, unknown>): void {
+    this.setYear(String(values['year'] ?? ''));
+    this.setMonthFrom(String(values['monthFrom'] ?? ''));
+    this.setMonthTo(String(values['monthTo'] ?? ''));
+    this.setStatus(String(values['status'] ?? 'all'));
+  }
+
+  onClearFilters(): void {
+    this.clearFilters();
   }
 
   // ── Dados ─────────────────────────────────────────────────────────────────

--- a/personal-finance/src/app/shared/components/filter-modal/filter-modal.component.css
+++ b/personal-finance/src/app/shared/components/filter-modal/filter-modal.component.css
@@ -1,4 +1,18 @@
+.filter-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  background: rgba(0, 0, 0, 0.25);
+}
+
 .filter-panel {
+  position: fixed;
+  top: 80px;
+  right: 16px;
+  z-index: 201;
+  min-width: 280px;
+  max-width: 480px;
+  width: calc(100vw - 32px);
   background: var(--v2-surface);
   backdrop-filter: blur(24px);
   border-radius: var(--v2-radius);
@@ -46,6 +60,13 @@
 }
 
 @media (max-width: 640px) {
+  .filter-panel {
+    top: 70px;
+    right: 8px;
+    left: 8px;
+    width: auto;
+  }
+
   .filter-fields-grid {
     grid-template-columns: 1fr;
   }

--- a/personal-finance/src/app/shared/components/filter-modal/filter-modal.component.html
+++ b/personal-finance/src/app/shared/components/filter-modal/filter-modal.component.html
@@ -1,4 +1,5 @@
 @if (open()) {
+  <div class="filter-backdrop" @backdropAnim (click)="onClose()"></div>
   <div class="filter-panel" @panelAnim>
     <div class="filter-fields-grid">
       @for (field of fields(); track field.key) {

--- a/personal-finance/src/app/shared/components/filter-modal/filter-modal.component.ts
+++ b/personal-finance/src/app/shared/components/filter-modal/filter-modal.component.ts
@@ -8,13 +8,17 @@ import { FilterFieldConfig } from './filter-field-config';
   templateUrl: './filter-modal.component.html',
   styleUrls: ['./filter-modal.component.css'],
   animations: [
+    trigger('backdropAnim', [
+      transition(':enter', [style({ opacity: 0 }), animate('180ms ease', style({ opacity: 1 }))]),
+      transition(':leave', [animate('150ms ease', style({ opacity: 0 }))])
+    ]),
     trigger('panelAnim', [
       transition(':enter', [
-        style({ opacity: 0, transform: 'translateY(-8px)' }),
-        animate('200ms ease', style({ opacity: 1, transform: 'translateY(0)' }))
+        style({ opacity: 0, transform: 'translateY(-8px) scale(0.97)' }),
+        animate('200ms ease', style({ opacity: 1, transform: 'translateY(0) scale(1)' }))
       ]),
       transition(':leave', [
-        animate('150ms ease-in', style({ opacity: 0, transform: 'translateY(-8px)' }))
+        animate('150ms ease-in', style({ opacity: 0, transform: 'translateY(-8px) scale(0.97)' }))
       ])
     ])
   ]
@@ -23,8 +27,9 @@ export class FilterModalComponent {
   readonly fields = input<FilterFieldConfig[]>([]);
   readonly open   = input(false);
 
-  readonly apply = output<Record<string, unknown>>();
-  readonly clear = output<void>();
+  readonly apply  = output<Record<string, unknown>>();
+  readonly clear  = output<void>();
+  readonly closed = output<void>();
 
   readonly draftValues = signal<Record<string, unknown>>({});
 
@@ -58,6 +63,7 @@ export class FilterModalComponent {
 
   onApply(): void {
     this.apply.emit(this.draftValues());
+    this.closed.emit();
   }
 
   onClear(): void {
@@ -67,6 +73,11 @@ export class FilterModalComponent {
     }
     this.draftValues.set(cleared);
     this.clear.emit();
+    this.closed.emit();
+  }
+
+  onClose(): void {
+    this.closed.emit();
   }
 
   getStringValue(key: string): string {


### PR DESCRIPTION
## Summary
- `filter-modal` convertido de painel inline para overlay real (backdrop fixo, fecha ao clicar fora, ao aplicar e ao limpar)
- Tela de **Períodos**: filtros inline substituídos por `FilterButton` + `FilterModal` overlay
- Tela de **Dashboard**: seletor de período/ano substituído por `FilterButton` + `FilterModal` overlay
- Consumidores existentes (expenses, incomes, admin-users, period-detail) atualizados com binding `(closed)`

## Test plan
- [ ] Abrir filtros em Despesas → overlay aparece com backdrop; clicar fora fecha
- [ ] Aplicar/Limpar filtros fecha o overlay automaticamente
- [ ] Filtros em Receitas, Detalhe do Período e Admin Users funcionam igual
- [ ] Tela de Períodos: filtros por ano/mês/status via overlay
- [ ] Dashboard: selecionar ano + período via overlay

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)