### PR TITLE
fix(filters): overlay à esquerda e acima dos cards de períodos

### DIFF
--- a/personal-finance/src/app/features/periods/components/periods/periods.component.css
+++ b/personal-finance/src/app/features/periods/components/periods/periods.component.css
@@ -49,15 +49,10 @@
 
 /* ── Barra de filtros ── */
 .filter-bar {
-  background: var(--v2-surface);
-  backdrop-filter: blur(24px);
-  border-radius: var(--v2-radius);
-  border: 1px solid var(--v2-border);
-  box-shadow: var(--v2-shadow);
-  padding: 18px 20px;
   display: flex;
-  flex-direction: column;
-  gap: 14px;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
   animation: fadeUp 0.5s var(--ease) 0.05s both;
 }
 

--- a/personal-finance/src/app/shared/components/filter-modal/filter-modal.component.css
+++ b/personal-finance/src/app/shared/components/filter-modal/filter-modal.component.css
@@ -8,7 +8,7 @@
 .filter-panel {
   position: fixed;
   top: 80px;
-  right: 16px;
+  left: 16px;
   z-index: 201;
   min-width: 280px;
   max-width: 480px;
@@ -62,8 +62,8 @@
 @media (max-width: 640px) {
   .filter-panel {
     top: 70px;
-    right: 8px;
     left: 8px;
+    right: 8px;
     width: auto;
   }
 


### PR DESCRIPTION
## Summary
- Overlay do filtro aparece à **esquerda** em todas as telas (global)
- Periods: corrigido overlay ficando atrás dos cards — causa era `backdrop-filter` no `.filter-bar` que criava um _containing block_ para `position: fixed`, prendendo o overlay dentro do elemento

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)