### PR TITLE
fix(periods): corrige overlay de filtros atrás dos cards

### DIFF
--- a/personal-finance/src/app/features/periods/components/periods/periods.component.css
+++ b/personal-finance/src/app/features/periods/components/periods/periods.component.css
@@ -53,7 +53,7 @@
   align-items: center;
   gap: 10px;
   flex-wrap: wrap;
-  animation: fadeUp 0.5s var(--ease) 0.05s both;
+  animation: fadeUp 0.5s var(--ease) 0.05s backwards;
 }
 
 .filter-controls {


### PR DESCRIPTION
## Causa raiz
`animation-fill-mode: both` no `.filter-bar` deixava `transform: translateY(0)` permanentemente aplicado ao elemento após a animação `fadeUp`. Qualquer valor de `transform` (inclusive identidade) cria um *containing block* para descendentes `position: fixed` — o backdrop e o painel ficavam confinados dentro do `.filter-bar`, não do viewport.

## Fix
`animation-fill-mode: both` → `backwards` no `.filter-bar` de `periods.component.css`. Com `backwards`, o preenchimento de estado só ocorre durante o delay (antes da animação iniciar); após a conclusão, o elemento volta aos seus estilos CSS normais sem `transform`.

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)