### PR TITLE
fix(thought-bubble): bumps atrás da nuvem, conteúdo revisado, dots +5%

### DIFF
--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.html
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.html
@@ -117,8 +117,9 @@
                   {{ expense.description }}
                   <app-thought-bubble
                     class="desc-tooltip"
-                    [description]="expense.description"
+                    [notes]="expense.notes ?? ''"
                     [dueDate]="expense.dueDate"
+                    [amount]="expense.amount"
                   />
                 </div>
                 @if (expense.notes) {

--- a/personal-finance/src/app/shared/components/thought-bubble/thought-bubble.component.css
+++ b/personal-finance/src/app/shared/components/thought-bubble/thought-bubble.component.css
@@ -38,7 +38,7 @@
   z-index: 998;
 }
 
-/* ── Container: dots na base, nuvem no topo ── */
+/* ── Container: dots na base (column-reverse: 1º filho = base) ── */
 .tb-container {
   position: absolute;
   bottom: calc(100% + 8px);
@@ -47,16 +47,15 @@
   z-index: 999;
   pointer-events: none;
   display: flex;
-  flex-direction: column-reverse; /* primeiro filho = base, último = topo */
+  flex-direction: column-reverse;
   align-items: center;
-  gap: 0;
 }
 
-/* ── Dots em zigzag ── */
+/* ── Dots em zigzag (+5% do tamanho anterior) ── */
 .tb-dots {
   position: relative;
-  width: 54px;
-  height: 68px;
+  width: 56px;
+  height: 70px;
   flex-shrink: 0;
 }
 
@@ -78,28 +77,29 @@
 }
 
 /* Zigzag: dot1 (x:0,y:1) → dot2 (x:1,y:2) → dot3 (x:0,y:3) */
-.tb-dot--1 { width: 8px;  height: 8px;  bottom: 4px;  left: 10px; z-index: 1; }
-.tb-dot--2 { width: 12px; height: 12px; bottom: 24px; left: 32px; z-index: 2; }
-.tb-dot--3 { width: 16px; height: 16px; bottom: 48px; left: 8px;  z-index: 3; }
+.tb-dot--1 { width: 9px;  height: 9px;  bottom: 4px;  left: 10px; z-index: 1; }
+.tb-dot--2 { width: 13px; height: 13px; bottom: 24px; left: 32px; z-index: 2; }
+.tb-dot--3 { width: 17px; height: 17px; bottom: 50px; left: 8px;  z-index: 3; }
 
 /* ── Nuvem cartoon ── */
 .tb-cloud-wrap {
+  position: relative;
   pointer-events: all;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  animation: cloudPop 0.28s cubic-bezier(0.34, 1.56, 0.64, 1) both;
-  /* x:1 — levemente à direita, seguindo a trilha */
+  /* padding-top = altura visível dos bumps acima do corpo */
+  padding-top: 38px;
   margin-left: 12px;
+  animation: cloudPop 0.28s cubic-bezier(0.34, 1.56, 0.64, 1) both;
 }
 
-/* Protuberâncias das bolhas — aparecem ACIMA do corpo */
+/* Bumps absolutamente posicionados ATRÁS do corpo (z-index: 1) */
 .tb-bumps {
-  position: relative;
-  width: 200px;
-  height: 28px; /* altura visível das protuberâncias */
-  flex-shrink: 0;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 80px;
   z-index: 1;
+  pointer-events: none;
 }
 
 .tb-bump {
@@ -111,23 +111,21 @@
   border: 2px solid transparent;
 }
 
-/* 3 bolhas de tamanhos diferentes formando silhueta de nuvem */
-.tb-bump--a { width: 44px; height: 44px; bottom: 0; left: 12px;  }
-.tb-bump--b { width: 60px; height: 60px; bottom: 0; left: 62px;  }
-.tb-bump--c { width: 38px; height: 38px; bottom: 0; right: 18px; }
+/* Bumps aumentados — o corpo da nuvem (z-index:2) cobre sua base */
+.tb-bump--a { width: 60px; height: 60px; top: 0; left: 8px;  }
+.tb-bump--b { width: 80px; height: 80px; top: 0; left: 56px; }
+.tb-bump--c { width: 52px; height: 52px; top: 5px; right: 10px; }
 
-/* Corpo da nuvem — z-index maior para cobrir a base das protuberâncias */
+/* Corpo da nuvem — z-index maior cobre a base dos bumps */
 .tb-cloud-body {
   position: relative;
   z-index: 2;
-  background:
-    linear-gradient(#888, #888) padding-box,
-    linear-gradient(135deg, #fff 0%, #999 40%, #222 100%) border-box;
-  border: 2px solid transparent;
+  background: var(--v2-surface-raised, #2a2a3a);
+  border: 1.5px solid var(--v2-border, #555);
   border-radius: 18px;
   padding: 10px 14px 10px 12px;
-  min-width: 180px;
-  max-width: 260px;
+  min-width: 200px;
+  max-width: 270px;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
 }
 
@@ -154,7 +152,7 @@
 
 .tb-close:hover { color: var(--text-primary, #fff); }
 
-/* ── Texto typewriter ── */
+/* ── Texto typewriter (observação) ── */
 .tb-text {
   margin: 0 18px 0 0;
   font-size: 12px;
@@ -177,17 +175,31 @@
   50%       { opacity: 0; }
 }
 
-/* ── Linha de vencimento ── */
+/* ── Rodapé: vencimento + valor ── */
+.tb-footer {
+  margin-top: 6px;
+  border-top: 1px solid var(--v2-border, #444);
+  padding-top: 5px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  animation: fadeIn 0.2s ease both;
+}
+
 .tb-due {
-  margin: 6px 0 0;
+  margin: 0;
   font-size: 11px;
   color: var(--text-muted, #aaa);
   display: flex;
   align-items: center;
   gap: 4px;
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
-  padding-top: 5px;
-  animation: fadeIn 0.2s ease both;
+}
+
+.tb-amount {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary, #e0e0e0);
 }
 
 @keyframes fadeIn {

--- a/personal-finance/src/app/shared/components/thought-bubble/thought-bubble.component.html
+++ b/personal-finance/src/app/shared/components/thought-bubble/thought-bubble.component.html
@@ -1,5 +1,5 @@
 <div class="thought-bubble-wrap">
-  <button class="info-icon" (click)="toggle()" [class.active]="open()" aria-label="Ver descrição">
+  <button class="info-icon" (click)="toggle()" [class.active]="open()" aria-label="Ver detalhes">
     <span>i</span>
   </button>
 
@@ -17,23 +17,31 @@
       <!-- Nuvem (topo) -->
       @if (bubblesPhase() >= 4) {
         <div class="tb-cloud-wrap">
-          <!-- Protuberâncias cartoon -->
+          <!-- Protuberâncias atrás do corpo da nuvem -->
           <div class="tb-bumps">
             <div class="tb-bump tb-bump--a"></div>
             <div class="tb-bump tb-bump--b"></div>
             <div class="tb-bump tb-bump--c"></div>
           </div>
-          <!-- Corpo da nuvem -->
+
+          <!-- Corpo da nuvem (z-index maior → cobre a base dos bumps) -->
           <div class="tb-cloud-body">
             <button class="tb-close" (click)="close()" aria-label="Fechar">✕</button>
-            <p class="tb-text">{{ displayedText() }}<span class="tb-cursor" [class.hidden]="animDone()">|</span></p>
+
+            @if (notes()) {
+              <p class="tb-text">{{ displayedText() }}<span class="tb-cursor" [class.hidden]="animDone()">|</span></p>
+            }
+
             @if (showDueDate()) {
-              <p class="tb-due">
-                @if (isDueWarning()) {
-                  <span class="tb-warning">⚠</span>
-                }
-                Venc.: {{ formattedDueDate() }}
-              </p>
+              <div class="tb-footer">
+                <p class="tb-due">
+                  @if (isDueWarning()) {
+                    <span class="tb-warning">⚠</span>
+                  }
+                  Venc.: {{ formattedDueDate() }}
+                </p>
+                <p class="tb-amount">{{ formattedAmount() }}</p>
+              </div>
             }
           </div>
         </div>

--- a/personal-finance/src/app/shared/components/thought-bubble/thought-bubble.component.spec.ts
+++ b/personal-finance/src/app/shared/components/thought-bubble/thought-bubble.component.spec.ts
@@ -11,8 +11,9 @@ describe('ThoughtBubbleComponent', () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(ThoughtBubbleComponent);
-    fixture.componentRef.setInput('description', 'Aluguel mensal');
+    fixture.componentRef.setInput('notes', 'Observação de teste');
     fixture.componentRef.setInput('dueDate', '2099-12-31');
+    fixture.componentRef.setInput('amount', 250.00);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
@@ -26,7 +27,7 @@ describe('ThoughtBubbleComponent', () => {
     component.toggle();
     expect(component.open()).toBeTrue();
     expect(component.bubblesPhase()).toBe(1);
-    tick(1000);
+    tick(2000);
     fixture.detectChanges();
   }));
 
@@ -44,8 +45,17 @@ describe('ThoughtBubbleComponent', () => {
   it('deve executar o typewriter e marcar animDone', fakeAsync(() => {
     component.toggle();
     tick(950);
-    const len = 'Aluguel mensal'.length;
+    const len = 'Observação de teste'.length;
     tick(len * 70 + 600);
+    expect(component.animDone()).toBeTrue();
+    expect(component.showDueDate()).toBeTrue();
+  }));
+
+  it('deve pular typewriter e mostrar rodapé imediatamente quando notes vazio', fakeAsync(() => {
+    fixture.componentRef.setInput('notes', '');
+    fixture.detectChanges();
+    component.toggle();
+    tick(950);
     expect(component.animDone()).toBeTrue();
     expect(component.showDueDate()).toBeTrue();
   }));
@@ -68,8 +78,7 @@ describe('ThoughtBubbleComponent', () => {
   it('isDueWarning deve ser true para vencimento dentro de 3 dias', () => {
     const tomorrow = new Date();
     tomorrow.setDate(tomorrow.getDate() + 1);
-    const iso = tomorrow.toISOString().slice(0, 10);
-    fixture.componentRef.setInput('dueDate', iso);
+    fixture.componentRef.setInput('dueDate', tomorrow.toISOString().slice(0, 10));
     fixture.detectChanges();
     expect(component.isDueWarning()).toBeTrue();
   });
@@ -78,5 +87,11 @@ describe('ThoughtBubbleComponent', () => {
     fixture.componentRef.setInput('dueDate', '2025-03-05');
     fixture.detectChanges();
     expect(component.formattedDueDate()).toBe('05/03/25');
+  });
+
+  it('formattedAmount deve formatar em BRL', () => {
+    fixture.componentRef.setInput('amount', 1500.50);
+    fixture.detectChanges();
+    expect(component.formattedAmount()).toContain('1.500,50');
   });
 });

--- a/personal-finance/src/app/shared/components/thought-bubble/thought-bubble.component.ts
+++ b/personal-finance/src/app/shared/components/thought-bubble/thought-bubble.component.ts
@@ -8,16 +8,17 @@ import { Component, input, signal, computed, OnDestroy } from '@angular/core';
   styleUrls: ['./thought-bubble.component.css'],
 })
 export class ThoughtBubbleComponent implements OnDestroy {
-  readonly description = input.required<string>();
-  readonly dueDate     = input.required<string>();
+  readonly notes   = input.required<string>();
+  readonly dueDate = input.required<string>();
+  readonly amount  = input.required<number>();
 
   readonly open         = signal(false);
-  readonly bubblesPhase = signal(0); // 0=hidden, 1=dot1, 2=dot2, 3=dot3, 4=cloud
+  readonly bubblesPhase = signal(0);
   readonly charIndex    = signal(0);
   readonly animDone     = signal(false);
   readonly showDueDate  = signal(false);
 
-  readonly displayedText = computed(() => this.description().slice(0, this.charIndex()));
+  readonly displayedText = computed(() => this.notes().slice(0, this.charIndex()));
 
   readonly formattedDueDate = computed(() => {
     const raw = this.dueDate();
@@ -28,6 +29,10 @@ export class ThoughtBubbleComponent implements OnDestroy {
     const yy = String(d.getFullYear()).slice(2);
     return `${dd}/${mm}/${yy}`;
   });
+
+  readonly formattedAmount = computed(() =>
+    this.amount().toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })
+  );
 
   readonly isDueWarning = computed(() => {
     const raw = this.dueDate();
@@ -74,7 +79,7 @@ export class ThoughtBubbleComponent implements OnDestroy {
   }
 
   private startTypewriter(): void {
-    const full = this.description();
+    const full = this.notes();
     if (!full) {
       this.animDone.set(true);
       this.showDueDate.set(true);


### PR DESCRIPTION
## Summary
- Bumps (protuberâncias) reposicionados absolutamente com `z-index: 1` atrás do corpo da nuvem (`z-index: 2`), que cobre sua base — criando efeito cartoon correto
- Bumps aumentados: 60px / 80px / 52px
- Borda gradiente removida do corpo da nuvem — usa `border` sólido do tema
- Conteúdo do typewriter alterado para `notes` (observação do registro)
- Rodapé exibe `Venc.: dd/MM/yy` + `Valor: R$ X,XX` após typewriter finalizar
- Input `amount` adicionado ao componente
- Dots iniciais aumentados em 5%: 9px / 13px / 17px
- 353 testes — todos passando

🤖 Generated with [Claude Code](https://claude.com/claude-code)