### PR TITLE
fix(thought-bubble): cor da caixa igual aos bumps, dots mais próximos

### DIFF
--- a/personal-finance/src/app/shared/components/thought-bubble/thought-bubble.component.css
+++ b/personal-finance/src/app/shared/components/thought-bubble/thought-bubble.component.css
@@ -55,7 +55,7 @@
 .tb-dots {
   position: relative;
   width: 56px;
-  height: 70px;
+  height: 52px;
   flex-shrink: 0;
 }
 
@@ -78,8 +78,8 @@
 
 /* Zigzag: dot1 (x:0,y:1) → dot2 (x:1,y:2) → dot3 (x:0,y:3) */
 .tb-dot--1 { width: 9px;  height: 9px;  bottom: 4px;  left: 10px; z-index: 1; }
-.tb-dot--2 { width: 13px; height: 13px; bottom: 24px; left: 32px; z-index: 2; }
-.tb-dot--3 { width: 17px; height: 17px; bottom: 50px; left: 8px;  z-index: 3; }
+.tb-dot--2 { width: 13px; height: 13px; bottom: 16px; left: 32px; z-index: 2; }
+.tb-dot--3 { width: 17px; height: 17px; bottom: 32px; left: 8px;  z-index: 3; }
 
 /* ── Nuvem cartoon ── */
 .tb-cloud-wrap {
@@ -120,8 +120,8 @@
 .tb-cloud-body {
   position: relative;
   z-index: 2;
-  background: var(--v2-surface-raised, #2a2a3a);
-  border: 1.5px solid var(--v2-border, #555);
+  background: #888;
+  border: 1.5px solid rgba(255, 255, 255, 0.15);
   border-radius: 18px;
   padding: 10px 14px 10px 12px;
   min-width: 200px;
@@ -150,13 +150,14 @@
   pointer-events: all;
 }
 
-.tb-close:hover { color: var(--text-primary, #fff); }
+.tb-close { color: #333; }
+.tb-close:hover { color: #000; }
 
 /* ── Texto typewriter (observação) ── */
 .tb-text {
   margin: 0 18px 0 0;
   font-size: 12px;
-  color: var(--text-primary, #e0e0e0);
+  color: #111;
   line-height: 1.5;
   word-break: break-word;
   min-height: 1.5em;
@@ -178,7 +179,7 @@
 /* ── Rodapé: vencimento + valor ── */
 .tb-footer {
   margin-top: 6px;
-  border-top: 1px solid var(--v2-border, #444);
+  border-top: 1px solid rgba(0, 0, 0, 0.25);
   padding-top: 5px;
   display: flex;
   flex-direction: column;
@@ -189,7 +190,7 @@
 .tb-due {
   margin: 0;
   font-size: 11px;
-  color: var(--text-muted, #aaa);
+  color: #222;
   display: flex;
   align-items: center;
   gap: 4px;
@@ -199,7 +200,7 @@
   margin: 0;
   font-size: 12px;
   font-weight: 600;
-  color: var(--text-primary, #e0e0e0);
+  color: #111;
 }
 
 @keyframes fadeIn {


### PR DESCRIPTION
## Summary
- Corpo da nuvem usa `background: #888` igual aos bumps (círculos grandes)
- Texto, vencimento e valor com cores escuras (#111/#222) para contraste no fundo cinza
- Espaçamento entre os 3 dots reduzido: bottom 4px → 16px → 32px (era 4px → 24px → 50px)
- Container de dots com altura ajustada para 52px
- 353 testes — todos passando

🤖 Generated with [Claude Code](https://claude.com/claude-code)