### PR TITLE
fix(thought-bubble): restaura typewriter com fallback para description

### DIFF
--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.html
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.html
@@ -117,6 +117,7 @@
                   {{ expense.description }}
                   <app-thought-bubble
                     class="desc-tooltip"
+                    [description]="expense.description"
                     [notes]="expense.notes ?? ''"
                     [dueDate]="expense.dueDate"
                     [amount]="expense.amount"

--- a/personal-finance/src/app/shared/components/thought-bubble/thought-bubble.component.spec.ts
+++ b/personal-finance/src/app/shared/components/thought-bubble/thought-bubble.component.spec.ts
@@ -11,6 +11,7 @@ describe('ThoughtBubbleComponent', () => {
     }).compileComponents();
 
     fixture = TestBed.createComponent(ThoughtBubbleComponent);
+    fixture.componentRef.setInput('description', 'Aluguel mensal');
     fixture.componentRef.setInput('notes', 'Observação de teste');
     fixture.componentRef.setInput('dueDate', '2099-12-31');
     fixture.componentRef.setInput('amount', 250.00);
@@ -51,11 +52,13 @@ describe('ThoughtBubbleComponent', () => {
     expect(component.showDueDate()).toBeTrue();
   }));
 
-  it('deve pular typewriter e mostrar rodapé imediatamente quando notes vazio', fakeAsync(() => {
+  it('deve usar description como fallback quando notes vazio', fakeAsync(() => {
     fixture.componentRef.setInput('notes', '');
     fixture.detectChanges();
     component.toggle();
     tick(950);
+    const len = 'Aluguel mensal'.length;
+    tick(len * 70 + 600);
     expect(component.animDone()).toBeTrue();
     expect(component.showDueDate()).toBeTrue();
   }));

--- a/personal-finance/src/app/shared/components/thought-bubble/thought-bubble.component.ts
+++ b/personal-finance/src/app/shared/components/thought-bubble/thought-bubble.component.ts
@@ -8,9 +8,10 @@ import { Component, input, signal, computed, OnDestroy } from '@angular/core';
   styleUrls: ['./thought-bubble.component.css'],
 })
 export class ThoughtBubbleComponent implements OnDestroy {
-  readonly notes   = input.required<string>();
-  readonly dueDate = input.required<string>();
-  readonly amount  = input.required<number>();
+  readonly description = input.required<string>();
+  readonly notes       = input.required<string>();
+  readonly dueDate     = input.required<string>();
+  readonly amount      = input.required<number>();
 
   readonly open         = signal(false);
   readonly bubblesPhase = signal(0);
@@ -18,7 +19,9 @@ export class ThoughtBubbleComponent implements OnDestroy {
   readonly animDone     = signal(false);
   readonly showDueDate  = signal(false);
 
-  readonly displayedText = computed(() => this.notes().slice(0, this.charIndex()));
+  private readonly typewriterSource = computed(() => this.notes() || this.description());
+
+  readonly displayedText = computed(() => this.typewriterSource().slice(0, this.charIndex()));
 
   readonly formattedDueDate = computed(() => {
     const raw = this.dueDate();
@@ -79,7 +82,7 @@ export class ThoughtBubbleComponent implements OnDestroy {
   }
 
   private startTypewriter(): void {
-    const full = this.notes();
+    const full = this.typewriterSource();
     if (!full) {
       this.animDone.set(true);
       this.showDueDate.set(true);


### PR DESCRIPTION
## Summary
- Typewriter usa `notes` quando preenchido, e `description` como fallback quando notes está vazio
- Garante que a animação de digitação sempre execute, independente do registro ter observação
- 353 testes — todos passando

🤖 Generated with [Claude Code](https://claude.com/claude-code)