### PR TITLE
feat(thought-bubble): cloud.png como visual, dots pixel art, conteúdo em cada nuvem

### DIFF
--- a/personal-finance/src/app/shared/components/thought-bubble/thought-bubble.component.css
+++ b/personal-finance/src/app/shared/components/thought-bubble/thought-bubble.component.css
@@ -38,7 +38,7 @@
   z-index: 998;
 }
 
-/* ── Container: dots na base (column-reverse: 1º filho = base) ── */
+/* ── Container: column-reverse → dots na base, nuvem no topo ── */
 .tb-container {
   position: absolute;
   bottom: calc(100% + 8px);
@@ -51,7 +51,7 @@
   align-items: center;
 }
 
-/* ── Dots em zigzag (+5% do tamanho anterior) ── */
+/* ── Dots pixel art (branco + contorno preto) ── */
 .tb-dots {
   position: relative;
   width: 56px;
@@ -65,10 +65,10 @@
   opacity: 0;
   transform: scale(0);
   transition: opacity 0.2s ease, transform 0.28s cubic-bezier(0.34, 1.56, 0.64, 1);
-  background:
-    linear-gradient(#888, #888) padding-box,
-    linear-gradient(135deg, #fff 0%, #999 40%, #222 100%) border-box;
-  border: 2px solid transparent;
+  background: #fff;
+  border: 2px solid #111;
+  box-shadow: 1px 1px 0 #111, -1px -1px 0 rgba(0,0,0,0.08);
+  image-rendering: pixelated;
 }
 
 .tb-dot.visible {
@@ -81,92 +81,92 @@
 .tb-dot--2 { width: 13px; height: 13px; bottom: 16px; left: 32px; z-index: 2; }
 .tb-dot--3 { width: 17px; height: 17px; bottom: 32px; left: 8px;  z-index: 3; }
 
-/* ── Nuvem cartoon ── */
+/* ── Cloud wrap: imagem + conteúdo sobreposto ── */
 .tb-cloud-wrap {
   position: relative;
   pointer-events: all;
-  /* padding-top = altura visível dos bumps acima do corpo */
-  padding-top: 38px;
   margin-left: 12px;
   animation: cloudPop 0.28s cubic-bezier(0.34, 1.56, 0.64, 1) both;
 }
 
-/* Bumps absolutamente posicionados ATRÁS do corpo (z-index: 1) */
-.tb-bumps {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 80px;
-  z-index: 1;
-  pointer-events: none;
-}
-
-.tb-bump {
-  position: absolute;
-  border-radius: 50%;
-  background:
-    linear-gradient(#888, #888) padding-box,
-    linear-gradient(135deg, #fff 0%, #999 40%, #222 100%) border-box;
-  border: 2px solid transparent;
-}
-
-/* Bumps aumentados — o corpo da nuvem (z-index:2) cobre sua base */
-.tb-bump--a { width: 60px; height: 60px; top: 0; left: 8px;  }
-.tb-bump--b { width: 80px; height: 80px; top: 0; left: 56px; }
-.tb-bump--c { width: 52px; height: 52px; top: 5px; right: 10px; }
-
-/* Corpo da nuvem — z-index maior cobre a base dos bumps */
-.tb-cloud-body {
-  position: relative;
-  z-index: 2;
-  background: #888;
-  border: 1.5px solid rgba(255, 255, 255, 0.15);
-  border-radius: 18px;
-  padding: 10px 14px 10px 12px;
-  min-width: 200px;
-  max-width: 270px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+.tb-cloud-img {
+  display: block;
+  width: 320px;
+  height: auto;
+  image-rendering: pixelated;
 }
 
 @keyframes cloudPop {
-  from { opacity: 0; transform: scale(0.7) translateY(6px); }
+  from { opacity: 0; transform: scale(0.75) translateY(8px); }
   to   { opacity: 1; transform: scale(1) translateY(0); }
 }
 
 /* ── Botão fechar ── */
 .tb-close {
   position: absolute;
-  top: 6px;
-  right: 8px;
+  top: 18px;
+  right: 14px;
+  z-index: 10;
   background: none;
   border: none;
-  color: var(--text-subtle, #888);
+  color: #333;
   font-size: 11px;
+  font-weight: 700;
   cursor: pointer;
   padding: 2px 4px;
   line-height: 1;
-  border-radius: 4px;
-  pointer-events: all;
+  border-radius: 3px;
 }
 
-.tb-close { color: #333; }
 .tb-close:hover { color: #000; }
 
-/* ── Texto typewriter (observação) ── */
+/* ── Conteúdo na nuvem grande (cima) ── */
+/* Bounds estimados: top 20%–48%, left 10%–90% da imagem 920×530 */
+.tb-content-top {
+  position: absolute;
+  top: 20%;
+  left: 10%;
+  right: 10%;
+  bottom: 52%;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+}
+
+/* ── Conteúdo na nuvem pequena (baixo) ── */
+/* Bounds estimados: top 63%–94%, left 43%–92% da imagem 920×530 */
+.tb-content-bottom {
+  position: absolute;
+  top: 64%;
+  left: 43%;
+  right: 8%;
+  bottom: 5%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 2px;
+  overflow: hidden;
+  animation: fadeIn 0.2s ease both;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* ── Texto typewriter ── */
 .tb-text {
-  margin: 0 18px 0 0;
-  font-size: 12px;
+  margin: 0;
+  font-size: 11px;
   color: #111;
-  line-height: 1.5;
+  line-height: 1.4;
   word-break: break-word;
-  min-height: 1.5em;
 }
 
 .tb-cursor {
   display: inline-block;
   animation: blink 0.6s steps(1) infinite;
-  color: var(--accent, #7c6af7);
+  color: #555;
 }
 
 .tb-cursor.hidden { display: none; }
@@ -176,42 +176,29 @@
   50%       { opacity: 0; }
 }
 
-/* ── Rodapé: vencimento + valor ── */
-.tb-footer {
-  margin-top: 6px;
-  border-top: 1px solid rgba(0, 0, 0, 0.25);
-  padding-top: 5px;
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-  animation: fadeIn 0.2s ease both;
+/* ── Valor e vencimento ── */
+.tb-amount {
+  margin: 0;
+  font-size: 11px;
+  font-weight: 700;
+  color: #111;
+  white-space: nowrap;
 }
 
 .tb-due {
   margin: 0;
-  font-size: 11px;
-  color: #222;
+  font-size: 10px;
+  color: #333;
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 3px;
+  white-space: nowrap;
 }
 
-.tb-amount {
-  margin: 0;
-  font-size: 12px;
-  font-weight: 600;
-  color: #111;
-}
-
-@keyframes fadeIn {
-  from { opacity: 0; transform: translateY(4px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-
-/* ── Ícone de alerta piscante ── */
+/* ── Alerta piscante ── */
 .tb-warning {
   animation: warnBlink 0.6s steps(1) infinite;
-  font-size: 12px;
+  font-size: 10px;
 }
 
 @keyframes warnBlink {

--- a/personal-finance/src/app/shared/components/thought-bubble/thought-bubble.component.html
+++ b/personal-finance/src/app/shared/components/thought-bubble/thought-bubble.component.html
@@ -7,43 +7,37 @@
     <div class="tb-backdrop" (click)="close()"></div>
 
     <div class="tb-container">
-      <!-- Dots (base — entre o ícone e a nuvem) -->
+      <!-- Dots pixel art (base — entre ícone e nuvem) -->
       <div class="tb-dots">
         <div class="tb-dot tb-dot--1" [class.visible]="bubblesPhase() >= 1"></div>
         <div class="tb-dot tb-dot--2" [class.visible]="bubblesPhase() >= 2"></div>
         <div class="tb-dot tb-dot--3" [class.visible]="bubblesPhase() >= 3"></div>
       </div>
 
-      <!-- Nuvem (topo) -->
+      <!-- Cloud image + conteúdo posicionado -->
       @if (bubblesPhase() >= 4) {
         <div class="tb-cloud-wrap">
-          <!-- Protuberâncias atrás do corpo da nuvem -->
-          <div class="tb-bumps">
-            <div class="tb-bump tb-bump--a"></div>
-            <div class="tb-bump tb-bump--b"></div>
-            <div class="tb-bump tb-bump--c"></div>
+          <button class="tb-close" (click)="close()" aria-label="Fechar">✕</button>
+
+          <img class="tb-cloud-img" src="cloud.png" alt="nuvem" />
+
+          <!-- Conteúdo na nuvem grande: typewriter da descrição/observação -->
+          <div class="tb-content-top">
+            <p class="tb-text">{{ displayedText() }}<span class="tb-cursor" [class.hidden]="animDone()">|</span></p>
           </div>
 
-          <!-- Corpo da nuvem (z-index maior → cobre a base dos bumps) -->
-          <div class="tb-cloud-body">
-            <button class="tb-close" (click)="close()" aria-label="Fechar">✕</button>
-
-            @if (notes()) {
-              <p class="tb-text">{{ displayedText() }}<span class="tb-cursor" [class.hidden]="animDone()">|</span></p>
-            }
-
-            @if (showDueDate()) {
-              <div class="tb-footer">
-                <p class="tb-due">
-                  @if (isDueWarning()) {
-                    <span class="tb-warning">⚠</span>
-                  }
-                  Venc.: {{ formattedDueDate() }}
-                </p>
-                <p class="tb-amount">{{ formattedAmount() }}</p>
-              </div>
-            }
-          </div>
+          <!-- Conteúdo na nuvem pequena: valor e vencimento -->
+          @if (showDueDate()) {
+            <div class="tb-content-bottom">
+              <p class="tb-amount">{{ formattedAmount() }}</p>
+              <p class="tb-due">
+                @if (isDueWarning()) {
+                  <span class="tb-warning">⚠</span>
+                }
+                Venc.: {{ formattedDueDate() }}
+              </p>
+            </div>
+          }
         </div>
       }
     </div>


### PR DESCRIPTION
## Summary
- Substituídos os bumps CSS pela imagem `cloud.png` (920×530px, duas nuvens pixel art)
- Dois blocos de conteúdo sobrepostos absolutamente na imagem:
  - **Nuvem grande (topo):** typewriter da descrição/observação — bounds: top 20%, left 10%, right 10%, bottom 52%
  - **Nuvem pequena (baixo):** valor + vencimento — bounds: top 64%, left 43%, right 8%, bottom 5%
- `image-rendering: pixelated` para manter a estética pixel art
- Dots iniciais: branco com contorno preto (`border: 2px solid #111`) — estilo pixel art
- 353 testes — todos passando

🤖 Generated with [Claude Code](https://claude.com/claude-code)