### PR TITLE
fix(thought-bubble): aumenta imagem da nuvem para 960px (3x)

### DIFF
--- a/personal-finance/src/app/shared/components/thought-bubble/thought-bubble.component.css
+++ b/personal-finance/src/app/shared/components/thought-bubble/thought-bubble.component.css
@@ -91,7 +91,7 @@
 
 .tb-cloud-img {
   display: block;
-  width: 320px;
+  width: 960px;
   height: auto;
   image-rendering: pixelated;
 }


### PR DESCRIPTION
## Summary
- `cloud.png` exibida em 960px de largura (era 320px — aumento de 300%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)