### PR TITLE
fix(thought-bubble): corrige max-width bloqueado pelo Tailwind Preflight

### DIFF
--- a/personal-finance/src/app/shared/components/thought-bubble/thought-bubble.component.css
+++ b/personal-finance/src/app/shared/components/thought-bubble/thought-bubble.component.css
@@ -92,6 +92,7 @@
 .tb-cloud-img {
   display: block;
   width: 960px;
+  max-width: none; /* sobrescreve o max-width: 100% do Tailwind Preflight */
   height: auto;
   image-rendering: pixelated;
 }


### PR DESCRIPTION
## Summary
- O `@tailwind base` (Preflight) aplica `max-width: 100%` em todas as `<img>` — isso limitava a imagem ao tamanho do container
- Adicionado `max-width: none` em `.tb-cloud-img` para sobrescrever e permitir os 960px

🤖 Generated with [Claude Code](https://claude.com/claude-code)