### PR TITLE
fix(thought-bubble): imagem 211px, texto bold, dots quadrados pixelizados

### DIFF
--- a/personal-finance/src/app/shared/components/thought-bubble/thought-bubble.component.css
+++ b/personal-finance/src/app/shared/components/thought-bubble/thought-bubble.component.css
@@ -61,13 +61,12 @@
 
 .tb-dot {
   position: absolute;
-  border-radius: 50%;
+  border-radius: 0;
   opacity: 0;
   transform: scale(0);
   transition: opacity 0.2s ease, transform 0.28s cubic-bezier(0.34, 1.56, 0.64, 1);
   background: #fff;
   border: 2px solid #111;
-  box-shadow: 1px 1px 0 #111, -1px -1px 0 rgba(0,0,0,0.08);
   image-rendering: pixelated;
 }
 
@@ -91,8 +90,8 @@
 
 .tb-cloud-img {
   display: block;
-  width: 960px;
-  max-width: none; /* sobrescreve o max-width: 100% do Tailwind Preflight */
+  width: 211px;
+  max-width: none;
   height: auto;
   image-rendering: pixelated;
 }
@@ -159,6 +158,8 @@
 .tb-text {
   margin: 0;
   font-size: 11px;
+  font-family: inherit;
+  font-weight: 700;
   color: #111;
   line-height: 1.4;
   word-break: break-word;
@@ -181,6 +182,7 @@
 .tb-amount {
   margin: 0;
   font-size: 11px;
+  font-family: inherit;
   font-weight: 700;
   color: #111;
   white-space: nowrap;
@@ -189,6 +191,8 @@
 .tb-due {
   margin: 0;
   font-size: 10px;
+  font-family: inherit;
+  font-weight: 700;
   color: #333;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Imagem da nuvem: 960px → 211px
- Todo o texto (`tb-text`, `tb-amount`, `tb-due`): `font-family: inherit` + `font-weight: 700`
- Dots iniciais: `border-radius: 50%` → `border-radius: 0` (quadradinhos pixelizados)

🤖 Generated with [Claude Code](https://claude.com/claude-code)