### PR TITLE
feat(#296): responsividade mobile — grid reduzido com menu de 3 pontos

### DIFF
--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.css
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.css
@@ -305,6 +305,25 @@
 .desc-cell { display: flex; align-items: center; gap: 6px; }
 .desc-tooltip { display: none; }
 
+/* ── Ícone de categoria inline (mobile) ── */
+.cat-icon-mobile {
+  display: none;
+  position: relative;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.cat-circle-plain {
+  display: inline-block;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+/* Ações desktop / mobile */
+.col-show-mobile { display: none; }
+
 /* ── Responsividade mobile ── */
 @media (max-width: 767px) {
   .page-content { padding: 16px; gap: 16px; }
@@ -312,11 +331,18 @@
   .filter-row { flex-wrap: wrap; }
   .period-select { width: 100%; min-width: unset; }
 
-  .col-hide-mobile { display: none; }
+  .col-hide-mobile { display: none !important; }
+  .col-show-mobile { display: inline-block; }
 
   .category-dot-wrap    { display: inline-flex; }
   .category-name-desktop { display: none; }
-  td:has(.category-dot-wrap) { text-align: center; }
+
+  .cat-icon-mobile { display: inline-flex; }
+  .cat-icon-mobile:hover .category-kbd,
+  .cat-icon-mobile.touched .category-kbd {
+    visibility: visible;
+    opacity: 1;
+  }
 
   .desc-tooltip { display: inline-block; }
 

--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.html
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.html
@@ -69,14 +69,14 @@
       <table class="table">
         <thead>
           <tr>
-            <th class="check-col">
+            <th class="check-col col-hide-mobile">
               <input type="checkbox" [checked]="allSelected()" (change)="toggleSelectAll()" />
             </th>
-            <th class="drag-col"></th>
+            <th class="drag-col col-hide-mobile"></th>
             <th class="sortable" (click)="toggleSort('description')">
               Descrição {{ sortIcon('description') }}
             </th>
-            <th class="sortable" (click)="toggleSort('category')">
+            <th class="sortable col-hide-mobile" (click)="toggleSort('category')">
               Categoria {{ sortIcon('category') }}
             </th>
             <th class="sortable col-hide-mobile" (click)="toggleSort('sourceType')">
@@ -85,10 +85,10 @@
             <th class="sortable col-hide-mobile" (click)="toggleSort('fortnightType')">
               Quinzena {{ sortIcon('fortnightType') }}
             </th>
-            <th class="sortable" (click)="toggleSort('dueDate')">
+            <th class="sortable col-hide-mobile" (click)="toggleSort('dueDate')">
               Vencimento {{ sortIcon('dueDate') }}
             </th>
-            <th class="sortable" (click)="toggleSort('amount')">
+            <th class="sortable col-hide-mobile" (click)="toggleSort('amount')">
               Valor {{ sortIcon('amount') }}
             </th>
             <th class="sortable" (click)="toggleSort('paymentStatus')">
@@ -106,14 +106,29 @@
               (drop)="onDrop(i)"
               [class.row-selected]="isSelected(expense.id)"
             >
-              <td class="check-col">
+              <td class="check-col col-hide-mobile">
                 <input type="checkbox" [checked]="isSelected(expense.id)" (change)="toggleSelect(expense.id)" />
               </td>
-              <td class="drag-col">
+              <td class="drag-col col-hide-mobile">
                 <span class="drag-handle" title="Arrastar para reordenar">⠿</span>
               </td>
               <td>
                 <div class="cell-primary desc-cell">
+                  <span class="cat-icon-mobile"
+                    [style.--cat-color]="categoryColor(expense.categoryId)"
+                    [class.touched]="touchedCatId() === expense.categoryId"
+                    (touchstart)="touchedCatId.set(expense.categoryId)"
+                    (touchend)="touchedCatId.set(null)"
+                  >
+                    @if (categoryIcon(expense.categoryId)) {
+                      <span class="category-dot category-dot--icon">
+                        <img class="category-dot-img" [src]="categoryIcon(expense.categoryId)" [alt]="categoryName(expense.categoryId)" />
+                      </span>
+                    } @else {
+                      <span class="cat-circle-plain" [style.background]="categoryColor(expense.categoryId)"></span>
+                    }
+                    <kbd class="category-kbd">{{ categoryName(expense.categoryId) }}</kbd>
+                  </span>
                   {{ expense.description }}
                   <app-thought-bubble
                     class="desc-tooltip"
@@ -124,10 +139,10 @@
                   />
                 </div>
                 @if (expense.notes) {
-                  <div class="cell-secondary">{{ expense.notes }}</div>
+                  <div class="cell-secondary col-hide-mobile">{{ expense.notes }}</div>
                 }
               </td>
-              <td>
+              <td class="col-hide-mobile">
                 <span class="category-dot-wrap"
                   [style.--cat-color]="categoryColor(expense.categoryId)"
                   [class.touched]="touchedCatId() === expense.categoryId"
@@ -150,15 +165,15 @@
               </td>
               <td class="text-muted text-sm col-hide-mobile">{{ sourceLabel(expense.sourceType) }}</td>
               <td class="text-muted text-sm col-hide-mobile">{{ fortnightLabel(expense.fortnightType) }}</td>
-              <td class="text-muted text-sm">{{ formatDate(expense.dueDate) }}</td>
-              <td class="font-semibold">{{ expense.amount | currencyBrl }}</td>
+              <td class="text-muted text-sm col-hide-mobile">{{ formatDate(expense.dueDate) }}</td>
+              <td class="font-semibold col-hide-mobile">{{ expense.amount | currencyBrl }}</td>
               <td>
                 <span class="badge" [class]="statusBadgeClass(expense.paymentStatus)">
                   {{ statusLabel(expense.paymentStatus) }}
                 </span>
               </td>
               <td>
-                <div class="row-actions">
+                <div class="row-actions col-hide-mobile">
                   @if (expense.paymentStatus === PaymentStatus.Pending || expense.paymentStatus === PaymentStatus.Partial) {
                     <button class="action-btn action-success" (click)="markAsPaid($event, expense)" title="Marcar como pago">
                       ✓
@@ -179,6 +194,13 @@
                     </svg>
                   </button>
                 </div>
+                <app-action-menu
+                  class="col-show-mobile"
+                  [showPay]="expense.paymentStatus === PaymentStatus.Pending || expense.paymentStatus === PaymentStatus.Partial"
+                  (pay)="markAsPaid($event, expense)"
+                  (edit)="openEditModal(expense)"
+                  (delete)="deleteExpense(expense.id)"
+                />
               </td>
             </tr>
           }

--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.ts
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.ts
@@ -10,6 +10,7 @@ import { SonicRingBurstComponent } from '../../../../shared/components/sonic-rin
 import { FilterModalComponent } from '../../../../shared/components/filter-modal/filter-modal.component';
 import { FilterButtonComponent } from '../../../../shared/components/filter-modal/filter-button.component';
 import { ThoughtBubbleComponent } from '../../../../shared/components/thought-bubble/thought-bubble.component';
+import { ActionMenuComponent } from '../../../../shared/components/action-menu/action-menu.component';
 import { FilterFieldConfig } from '../../../../shared/components/filter-modal/filter-field-config';
 import {
   ExpenseResponse, PeriodResponse, CategoryResponse,
@@ -22,7 +23,7 @@ type SortCol = 'description' | 'category' | 'sourceType' | 'fortnightType' | 'du
 @Component({
   selector: 'app-expenses',
   standalone: true,
-  imports: [HeaderComponent, CurrencyBrlPipe, ReactiveFormsModule, SonicModalComponent, PaginationComponent, SonicRingBurstComponent, FilterModalComponent, FilterButtonComponent, ThoughtBubbleComponent],
+  imports: [HeaderComponent, CurrencyBrlPipe, ReactiveFormsModule, SonicModalComponent, PaginationComponent, SonicRingBurstComponent, FilterModalComponent, FilterButtonComponent, ThoughtBubbleComponent, ActionMenuComponent],
   templateUrl: './expenses.component.html',
   styleUrls: ['./expenses.component.css'],
   animations: [

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.css
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.css
@@ -263,6 +263,23 @@
 .table tbody tr:hover { background: rgba(255,255,255,0.03); }
 
 .cell-primary   { color: var(--text); font-weight: 500; }
+.desc-cell { display: flex; align-items: center; gap: 6px; }
+
+/* ── Ícone de categoria inline (mobile) ── */
+.cat-icon-mobile {
+  display: none;
+  position: relative;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.cat-circle-plain {
+  display: inline-block;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
 
 .category-dot {
   display: inline-block;
@@ -474,13 +491,19 @@
   .filters-grid { flex-direction: column; }
   .filter-field { min-width: unset; }
 
-  .col-hide-mobile { display: none; }
+  .col-hide-mobile { display: none !important; }
 
   .loading-state, .empty-state { padding: 32px; }
 
   .category-dot-wrap    { display: inline-flex; }
   .category-name-desktop { display: none; }
-  td:has(.category-dot-wrap) { text-align: center; }
+
+  .cat-icon-mobile { display: inline-flex; }
+  .cat-icon-mobile:hover .category-kbd,
+  .cat-icon-mobile.touched .category-kbd {
+    visibility: visible;
+    opacity: 1;
+  }
 }
 
 @media (max-width: 568px) {

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.html
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.html
@@ -148,19 +148,38 @@
             <thead>
               <tr>
                 <th class="sortable" (click)="toggleExpSort('description')">Descrição {{ expSortIcon('description') }}</th>
-                <th class="sortable" (click)="toggleExpSort('category')">Categoria {{ expSortIcon('category') }}</th>
+                <th class="sortable col-hide-mobile" (click)="toggleExpSort('category')">Categoria {{ expSortIcon('category') }}</th>
                 <th class="sortable col-hide-mobile" (click)="toggleExpSort('sourceType')">Fonte {{ expSortIcon('sourceType') }}</th>
                 <th class="sortable col-hide-mobile" (click)="toggleExpSort('fortnightType')">Quinzena {{ expSortIcon('fortnightType') }}</th>
-                <th class="sortable" (click)="toggleExpSort('dueDate')">Vencimento {{ expSortIcon('dueDate') }}</th>
-                <th class="sortable" (click)="toggleExpSort('amount')">Valor {{ expSortIcon('amount') }}</th>
+                <th class="sortable col-hide-mobile" (click)="toggleExpSort('dueDate')">Vencimento {{ expSortIcon('dueDate') }}</th>
+                <th class="sortable col-hide-mobile" (click)="toggleExpSort('amount')">Valor {{ expSortIcon('amount') }}</th>
                 <th class="sortable" (click)="toggleExpSort('paymentStatus')">Status {{ expSortIcon('paymentStatus') }}</th>
               </tr>
             </thead>
             <tbody>
               @for (expense of displayedExpenses(); track expense.id) {
                 <tr>
-                  <td class="cell-primary">{{ expense.description }}</td>
                   <td>
+                    <div class="cell-primary desc-cell">
+                      <span class="cat-icon-mobile"
+                        [style.--cat-color]="categoryColor(expense.categoryId)"
+                        [class.touched]="touchedCatId() === expense.categoryId"
+                        (touchstart)="touchedCatId.set(expense.categoryId)"
+                        (touchend)="touchedCatId.set(null)"
+                      >
+                        @if (categoryIcon(expense.categoryId)) {
+                          <span class="category-dot category-dot--icon">
+                            <img class="category-dot-img" [src]="categoryIcon(expense.categoryId)" [alt]="categoryName(expense.categoryId)" />
+                          </span>
+                        } @else {
+                          <span class="cat-circle-plain" [style.background]="categoryColor(expense.categoryId)"></span>
+                        }
+                        <kbd class="category-kbd">{{ categoryName(expense.categoryId) }}</kbd>
+                      </span>
+                      {{ expense.description }}
+                    </div>
+                  </td>
+                  <td class="col-hide-mobile">
                     <span class="category-dot-wrap"
                       [style.--cat-color]="categoryColor(expense.categoryId)"
                       [class.touched]="touchedCatId() === expense.categoryId"
@@ -183,8 +202,8 @@
                   </td>
                   <td class="text-muted text-sm col-hide-mobile">{{ sourceLabel(expense.sourceType) }}</td>
                   <td class="text-muted text-sm col-hide-mobile">{{ fortnightLabel(expense.fortnightType) }}</td>
-                  <td class="text-muted text-sm">{{ formatDate(expense.dueDate) }}</td>
-                  <td class="font-semibold">{{ expense.amount | currencyBrl }}</td>
+                  <td class="text-muted text-sm col-hide-mobile">{{ formatDate(expense.dueDate) }}</td>
+                  <td class="font-semibold col-hide-mobile">{{ expense.amount | currencyBrl }}</td>
                   <td>
                     <span class="badge" [class]="statusBadgeClass(expense.paymentStatus)">
                       {{ statusLabel(expense.paymentStatus) }}

--- a/personal-finance/src/app/shared/components/action-menu/action-menu.component.css
+++ b/personal-finance/src/app/shared/components/action-menu/action-menu.component.css
@@ -1,0 +1,59 @@
+.action-menu-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.action-menu-btn {
+  width: 30px;
+  height: 30px;
+  border: 1px solid var(--v2-border);
+  background: var(--v2-surface);
+  border-radius: var(--v2-radius-sm);
+  cursor: pointer;
+  font-size: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  transition: var(--t);
+  backdrop-filter: blur(24px);
+  line-height: 1;
+}
+
+.action-menu-btn:hover {
+  background: rgba(196, 103, 74, 0.1);
+  border-color: var(--terracotta);
+  color: var(--terracotta);
+}
+
+.action-menu-dropdown {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 6px);
+  background: var(--v2-surface);
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-radius-sm);
+  box-shadow: var(--v2-shadow);
+  backdrop-filter: blur(24px);
+  min-width: 110px;
+  z-index: 200;
+  overflow: hidden;
+}
+
+.action-menu-item {
+  display: block;
+  width: 100%;
+  padding: 9px 14px;
+  text-align: left;
+  background: none;
+  border: none;
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: var(--t);
+}
+
+.action-menu-item:hover         { background: var(--v2-border); }
+.action-menu-pay:hover          { color: var(--olive); }
+.action-menu-edit:hover         { color: var(--slate); }
+.action-menu-delete:hover       { color: var(--terracotta); }

--- a/personal-finance/src/app/shared/components/action-menu/action-menu.component.html
+++ b/personal-finance/src/app/shared/components/action-menu/action-menu.component.html
@@ -1,0 +1,12 @@
+<div class="action-menu-wrap">
+  <button class="action-menu-btn" (click)="toggle($event)" title="Ações">⋮</button>
+  @if (open()) {
+    <div class="action-menu-dropdown">
+      @if (showPay) {
+        <button class="action-menu-item action-menu-pay" (click)="onPay($event)">Pagar</button>
+      }
+      <button class="action-menu-item action-menu-edit" (click)="onEdit()">Editar</button>
+      <button class="action-menu-item action-menu-delete" (click)="onDelete()">Excluir</button>
+    </div>
+  }
+</div>

--- a/personal-finance/src/app/shared/components/action-menu/action-menu.component.ts
+++ b/personal-finance/src/app/shared/components/action-menu/action-menu.component.ts
@@ -1,0 +1,32 @@
+import { Component, Input, Output, EventEmitter, signal, HostListener } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-action-menu',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './action-menu.component.html',
+  styleUrls: ['./action-menu.component.css'],
+})
+export class ActionMenuComponent {
+  @Input() showPay = true;
+  @Output() pay    = new EventEmitter<MouseEvent>();
+  @Output() edit   = new EventEmitter<void>();
+  @Output() delete = new EventEmitter<void>();
+
+  readonly open = signal(false);
+
+  toggle(e: MouseEvent): void {
+    e.stopPropagation();
+    this.open.update(v => !v);
+  }
+
+  close(): void { this.open.set(false); }
+
+  onPay(e: MouseEvent): void  { this.pay.emit(e);  this.close(); }
+  onEdit(): void              { this.edit.emit();   this.close(); }
+  onDelete(): void            { this.delete.emit(); this.close(); }
+
+  @HostListener('document:click')
+  onDocumentClick(): void { this.close(); }
+}


### PR DESCRIPTION
Closes #296

## Resumo
- Cria `ActionMenuComponent` — botão ⋮ com overlay interativo (Pagar, Editar, Excluir)
- **Expenses**: mobile exibe 3 colunas: [ícone categoria + título + tooltip] | [status] | [menu ⋮]
- **Expenses**: oculta drag, checkbox, categoria, fonte, quinzena, vencimento e valor no mobile
- **Period-detail**: mesma reestruturação de colunas (sem botões de ação, somente-leitura)