### PR TITLE
fix(#296): corrige overlay, pagar sempre visível e restaura drag/checkbox

### DIFF
--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.html
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.html
@@ -69,10 +69,10 @@
       <table class="table">
         <thead>
           <tr>
-            <th class="check-col col-hide-mobile">
+            <th class="check-col">
               <input type="checkbox" [checked]="allSelected()" (change)="toggleSelectAll()" />
             </th>
-            <th class="drag-col col-hide-mobile"></th>
+            <th class="drag-col"></th>
             <th class="sortable" (click)="toggleSort('description')">
               Descrição {{ sortIcon('description') }}
             </th>
@@ -106,10 +106,10 @@
               (drop)="onDrop(i)"
               [class.row-selected]="isSelected(expense.id)"
             >
-              <td class="check-col col-hide-mobile">
+              <td class="check-col">
                 <input type="checkbox" [checked]="isSelected(expense.id)" (change)="toggleSelect(expense.id)" />
               </td>
-              <td class="drag-col col-hide-mobile">
+              <td class="drag-col">
                 <span class="drag-handle" title="Arrastar para reordenar">⠿</span>
               </td>
               <td>
@@ -196,7 +196,6 @@
                 </div>
                 <app-action-menu
                   class="col-show-mobile"
-                  [showPay]="expense.paymentStatus === PaymentStatus.Pending || expense.paymentStatus === PaymentStatus.Partial"
                   (pay)="markAsPaid($event, expense)"
                   (edit)="openEditModal(expense)"
                   (delete)="deleteExpense(expense.id)"

--- a/personal-finance/src/app/shared/components/action-menu/action-menu.component.css
+++ b/personal-finance/src/app/shared/components/action-menu/action-menu.component.css
@@ -30,11 +30,10 @@
   position: absolute;
   right: 0;
   top: calc(100% + 6px);
-  background: var(--v2-surface);
+  background: var(--surface-solid);
   border: 1px solid var(--v2-border);
   border-radius: var(--v2-radius-sm);
   box-shadow: var(--v2-shadow);
-  backdrop-filter: blur(24px);
   min-width: 110px;
   z-index: 200;
   overflow: hidden;

--- a/personal-finance/src/app/shared/components/action-menu/action-menu.component.html
+++ b/personal-finance/src/app/shared/components/action-menu/action-menu.component.html
@@ -2,9 +2,7 @@
   <button class="action-menu-btn" (click)="toggle($event)" title="Ações">⋮</button>
   @if (open()) {
     <div class="action-menu-dropdown">
-      @if (showPay) {
         <button class="action-menu-item action-menu-pay" (click)="onPay($event)">Pagar</button>
-      }
       <button class="action-menu-item action-menu-edit" (click)="onEdit()">Editar</button>
       <button class="action-menu-item action-menu-delete" (click)="onDelete()">Excluir</button>
     </div>

--- a/personal-finance/src/app/shared/components/action-menu/action-menu.component.ts
+++ b/personal-finance/src/app/shared/components/action-menu/action-menu.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, signal, HostListener } from '@angular/core';
+import { Component, Output, EventEmitter, signal, HostListener } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 @Component({
@@ -9,7 +9,6 @@ import { CommonModule } from '@angular/common';
   styleUrls: ['./action-menu.component.css'],
 })
 export class ActionMenuComponent {
-  @Input() showPay = true;
   @Output() pay    = new EventEmitter<MouseEvent>();
   @Output() edit   = new EventEmitter<void>();
   @Output() delete = new EventEmitter<void>();


### PR DESCRIPTION
Closes #296

## Resumo
- ActionMenuComponent: dropdown com `--surface-solid` (cor sólida)
- Remove condicional de Pagar — ação sempre visível no overlay
- Restaura drag-and-drop e checkbox no mobile