### PR TITLE
fix(mario-modal): reverte footer e exibe aviso de vencimento inline

### DIFF
--- a/personal-finance/src/app/shared/components/modal/mario-modal/mario-modal.component.css
+++ b/personal-finance/src/app/shared/components/modal/mario-modal/mario-modal.component.css
@@ -44,17 +44,14 @@
 .mario-footer {
   position: absolute;
   bottom: 16px;
-  left: 20px;
   right: 20px;
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 12px;
 }
 
 .mario-warning {
   animation: warnBlink 0.6s steps(1) infinite;
-  font-size: 1.1rem;
 }
 
 @keyframes warnBlink {

--- a/personal-finance/src/app/shared/components/modal/mario-modal/mario-modal.component.html
+++ b/personal-finance/src/app/shared/components/modal/mario-modal/mario-modal.component.html
@@ -2,11 +2,8 @@
   @if (title()) {
     <div class="mario-title">{{ title() }}</div>
   }
-  <div class="mario-content" #contentEl>{{ displayedText() }}</div>
+  <div class="mario-content" #contentEl>{{ displayedText() }}@if (showWarning() && animDone()) {<span class="mario-warning"> ⚠</span>}</div>
   <div class="mario-footer">
-    @if (showWarning() && animDone()) {
-      <span class="mario-warning">⚠</span>
-    }
     @if (!animDone()) {
       <button class="skip-btn" (click)="skipAnimation()" title="Pular animação">▼</button>
     }


### PR DESCRIPTION
## Summary

- Reverte `.mario-footer` para `right: 20px` original (sem `justify-content: space-between` desnecessário)
- Move o triângulo ⚠ piscante para dentro de `.mario-content`, colado após o `displayedText()`, de modo que aparece ao lado de "Venc.: DD/MM" ao fim da animação typewriter

## Test plan

- [ ] Skip/OK buttons permanecem alinhados à direita no rodapé do modal
- [ ] Despesa com vencimento ≤ 3 dias e pendente → ⚠ piscante aparece após "Venc.: DD/MM" ao fim do typewriter
- [ ] Despesa paga ou cancelada → ⚠ não aparece

🤖 Generated with [Claude Code](https://claude.com/claude-code)