### PR TITLE
docs(#318): regra de pré-ação e fluxo de sessão no CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,8 @@ Integration: `WebApplicationFactory<Program>` + banco InMemory. Unit: xUnit + Mo
 
 - **Nunca alterar fora do escopo** — apresentar como novo plano, Caique aprova caso a caso
 - **Verificar PR antes de push** — se fechado/mergeado, abrir novo PR para os ajustes
+- **Pré-ação obrigatória** — antes de post em issue, board update ou push: exibir ação e aguardar OK do Caique
+→ Fluxo completo: [`docs/session-flow.md`](docs/session-flow.md)
 
 ---
 
@@ -213,10 +215,8 @@ Integration: `WebApplicationFactory<Program>` + banco InMemory. Unit: xUnit + Mo
 ## Estilo de comunicação
 
 - Direto e técnico — sem rodeios, elogios ou introduções
-- Diagnóstico de erro: **causa + fix cirúrgico**
 - Nunca suposições silenciosas — alinhar antes de implementar
 - **Caique decide** a arquitetura — Claude propõe opções, Caique confirma
-- Explicações didáticas apenas quando solicitado
 
 ---
 
@@ -239,8 +239,6 @@ Regra geral: **worktree é espaço de implementação autônomo**. Volta ao modo
 - `str_replace` cirúrgico — nunca reescrever arquivo completo
 - Output de testes: filtrar com `grep -E "SUCCESS|FAILED|ERROR"`
 - Issues L/XL (>15 arquivos): propor divisão antes de implementar
-- Inputs grandes: usar apenas partes relevantes para a tarefa atual
-- Planning Mode: máximo 5 passos, 1 linha por passo
 
 ---
 
@@ -249,7 +247,4 @@ Regra geral: **worktree é espaço de implementação autônomo**. Volta ao modo
 - [`docs/claude-md-guide.md`](docs/claude-md-guide.md) — **consultar antes de qualquer alteração neste arquivo**
 - [`docs/test-factory.md`](docs/test-factory.md) — TestWebApplicationFactory setup
 - [`docs/patterns.md`](docs/patterns.md) — Padrão de modal Angular + Armadilhas conhecidas
-
----
-
-*CLAUDE.md — Personal Finance System — MonkeyBomb — Abril 2026*
+- [`docs/session-flow.md`](docs/session-flow.md) — Fluxo de sessão: regra de pré-ação e revisão de planning

--- a/docs/session-flow.md
+++ b/docs/session-flow.md
@@ -1,0 +1,33 @@
+# Fluxo de sessão — Planning vs Implementação
+
+## Regra de pré-ação obrigatória
+
+Antes de qualquer ação externa, exibir o que será feito e aguardar confirmação explícita do Caique:
+
+| Ação externa | Exige confirmação |
+|---|---|
+| Postar comentário em issue | Sim |
+| Atualizar campos do board (Status, Size, Priority) | Sim |
+| `git push` | Sim |
+| `gh pr create` | Sim |
+
+---
+
+## Fluxo de sessão de planning
+
+1. Levantamento autônomo (ler arquivos, board, issues)
+2. Montar o planning completo
+3. Apresentar ao Caique — **parar aqui**
+4. Aguardar OK explícito
+5. Somente após OK: executar ações externas (post na issue, update do board)
+
+---
+
+## Revisão de sessão
+
+Ao final de cada planning, verificar:
+- O fluxo acima foi seguido?
+- Houve ação externa sem confirmação prévia?
+- O planning foi postado antes da confirmação?
+
+Se sim a qualquer item: registrar como feedback e corrigir no próximo planning.


### PR DESCRIPTION
## Summary
- Adiciona regra de pré-ação obrigatória em "Regras absolutas de execução": confirmação do Caique antes de qualquer ação externa (post em issue, board update, push)
- Cria `docs/session-flow.md` com tabela de ações que exigem confirmação, fluxo completo de planning e checklist de revisão de sessão
- Compacta "Estilo de comunicação" e "Otimização de tokens" para manter CLAUDE.md em ≤ 250 linhas

## Test plan
- [x] `wc -l CLAUDE.md` = 250

Closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)