### PR TITLE
feat(#319): animação de moeda com sparkle e +10 no Mario Block

### DIFF
--- a/personal-finance/src/app/features/auth/components/login/login.component.css
+++ b/personal-finance/src/app/features/auth/components/login/login.component.css
@@ -302,11 +302,10 @@
   left: 0;
   width: 24px;
   text-align: center;
-  font-size: 11px;
-  font-weight: 700;
-  color: #f5c842;
-  text-shadow: 0 0 4px rgba(0,0,0,0.6);
-  font-family: var(--font-b);
+  font-size: 8px;
+  font-family: 'Press Start 2P', monospace;
+  color: #fff;
+  text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
   animation: points-rise 0.5s ease forwards;
   pointer-events: none;
 }

--- a/personal-finance/src/app/features/auth/components/login/login.component.ts
+++ b/personal-finance/src/app/features/auth/components/login/login.component.ts
@@ -124,7 +124,7 @@ export class LoginComponent implements OnDestroy {
 
     const id       = this.coinId++;
     const x        = Math.floor(Math.random() * 161) - 80;
-    const duration = Math.floor(Math.random() * 501) + 500;
+    const duration = Math.floor(Math.random() * 301) + 200;
 
     this.coins.update(c => [...c, { id, x, duration, phase: 'flying' }]);
 


### PR DESCRIPTION
Closes #319

## Resumo
- Duração do voo da moeda aleatória entre 200ms–500ms (`--flight-duration` CSS var)
- Substitui fases `slow/medium/fast` por `sparkle` → `points`
- Após o voo: brilho `✦` aparece na posição final (500ms, sem movimento XY)
- Após o brilho: texto `+10` sobe ~30px e desaparece (500ms) — fonte Press Start 2P, branca com contorno preto
- Ciclo completo destruído após `duration + 1000ms`

🤖 Generated with [Claude Code](https://claude.com/claude-code)