### PR TITLE
feat(#333): data de última atualização nas despesas

### DIFF
--- a/personal-finance/src/app/core/models/models.ts
+++ b/personal-finance/src/app/core/models/models.ts
@@ -108,6 +108,7 @@ export interface ExpenseResponse {
   notes:          string | null;
   isActive:       boolean;
   isRecurring:    boolean;
+  updatedAt:      string;
 }
 
 export interface RecurringExpenseResponse {
@@ -167,7 +168,8 @@ export enum ExpenseSortColumn {
   DueDate          = 5,
   Amount           = 6,
   Status           = 7,
-  DragAndDropOrder = 8,
+  DragAndDropOrder    = 8,
+  UpdatedAt           = 9,
 }
 
 export enum SortDirection {

--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.css
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.css
@@ -422,3 +422,11 @@
   accent-color: var(--accent, #6366f1);
   cursor: pointer;
 }
+
+.expense-updated-at {
+  text-align: right;
+  font-size: 0.72rem;
+  color: var(--text-muted, #9ca3af);
+  margin-bottom: 8px;
+  letter-spacing: 0.01em;
+}

--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.html
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.html
@@ -226,6 +226,11 @@
       (closed)="closeModal()"
     >
       <form [formGroup]="form" (ngSubmit)="onSubmit()">
+        @if (modalMode() === 'edit' && editingUpdatedAt()) {
+          <div class="expense-updated-at">
+            Última atualização: {{ editingUpdatedAt() | date:'dd/MM/yyyy HH:mm:ss' }}
+          </div>
+        }
         <div class="modal-form-grid">
 
           @if (modalMode() === 'create') {

--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.spec.ts
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.spec.ts
@@ -17,7 +17,7 @@ const EXPENSE: ExpenseResponse = {
   id: 'e-1', periodId: 'p-1', userId: 'u', categoryId: 'cat-1', description: 'Aluguel',
   amount: 1000, dueDate: '2024-04-05T00:00:00', paymentStatus: PaymentStatus.Pending,
   paymentDate: null, sourceType: SourceType.Personal, fortnightType: FortnightType.First,
-  notes: null, isActive: true, isRecurring: false,
+  notes: null, isActive: true, isRecurring: false, updatedAt: '2024-04-05T10:00:00',
 };
 
 describe('ExpensesComponent', () => {
@@ -394,10 +394,17 @@ describe('ExpensesComponent', () => {
       expect(sortDirIdx).toBeGreaterThan(sortColIdx);
     });
 
-    it('sortColumn tem todas as 8 colunas disponíveis como opções', () => {
+    it('sortColumn tem todas as 9 colunas disponíveis como opções', () => {
       const fields = component.filterFields();
       const sortColField = fields.find(f => f.key === 'sortColumn');
-      expect(sortColField?.options?.length).toBeGreaterThanOrEqual(8);
+      expect(sortColField?.options?.length).toBeGreaterThanOrEqual(9);
+    });
+
+    it('sortColumn inclui opção "Data Última Atualização"', () => {
+      const fields = component.filterFields();
+      const sortColField = fields.find(f => f.key === 'sortColumn');
+      const labels = sortColField?.options?.map(o => o.label) ?? [];
+      expect(labels).toContain('Data Última Atualização');
     });
 
     it('sortDirection tem opções Crescente e Decrescente', () => {
@@ -484,6 +491,48 @@ describe('ExpensesComponent', () => {
     it('formatDate retorna data formatada', () => {
       const result = component.formatDate('2024-04-05T00:00:00');
       expect(result).toContain('2024');
+    });
+  });
+
+  describe('updatedAt — modal de edição', () => {
+    it('editingUpdatedAt é definido ao abrir modal em modo edit', () => {
+      component.openEditModal(EXPENSE);
+      expect(component.editingUpdatedAt()).toBe('2024-04-05T10:00:00');
+    });
+
+    it('editingUpdatedAt é null ao abrir modal em modo create', () => {
+      component.openCreateModal();
+      expect(component.editingUpdatedAt()).toBeNull();
+    });
+
+    it('editingUpdatedAt é null após fechar modal', () => {
+      component.openEditModal(EXPENSE);
+      component.closeModal();
+      expect(component.editingUpdatedAt()).toBeNull();
+    });
+  });
+
+  describe('ordenação client-side por updatedAt', () => {
+    const EXPENSE_B: ExpenseResponse = { ...EXPENSE, id: 'e-2', updatedAt: '2024-04-06T10:00:00' };
+
+    beforeEach(() => {
+      component.expenses.set([EXPENSE_B, EXPENSE]);
+    });
+
+    it('displayedExpenses ordena por updatedAt asc quando sortCol = updatedAt', () => {
+      component.sortCol.set('updatedAt');
+      component.sortDir.set('asc');
+      const result = component.displayedExpenses();
+      expect(result[0].id).toBe('e-1');
+      expect(result[1].id).toBe('e-2');
+    });
+
+    it('displayedExpenses ordena por updatedAt desc quando sortCol = updatedAt', () => {
+      component.sortCol.set('updatedAt');
+      component.sortDir.set('desc');
+      const result = component.displayedExpenses();
+      expect(result[0].id).toBe('e-2');
+      expect(result[1].id).toBe('e-1');
     });
   });
 });

--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.ts
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.ts
@@ -1,4 +1,5 @@
 import { Component, inject, signal, computed, OnInit, input, ViewChild, ElementRef } from '@angular/core';
+import { DatePipe } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { trigger, style, animate, transition } from '@angular/animations';
 import { ApiService } from '../../../../core/services/api.service';
@@ -19,12 +20,12 @@ import {
   ExpenseSortColumn, SortDirection,
 } from '../../../../core/models/models';
 
-type SortCol = 'description' | 'category' | 'sourceType' | 'fortnightType' | 'dueDate' | 'amount' | 'paymentStatus';
+type SortCol = 'description' | 'category' | 'sourceType' | 'fortnightType' | 'dueDate' | 'amount' | 'paymentStatus' | 'updatedAt';
 
 @Component({
   selector: 'app-expenses',
   standalone: true,
-  imports: [HeaderComponent, CurrencyBrlPipe, ReactiveFormsModule, SonicModalComponent, PaginationComponent, SonicRingBurstComponent, FilterModalComponent, FilterButtonComponent, MarioModalComponent, ActionMenuComponent],
+  imports: [HeaderComponent, CurrencyBrlPipe, ReactiveFormsModule, SonicModalComponent, PaginationComponent, SonicRingBurstComponent, FilterModalComponent, FilterButtonComponent, MarioModalComponent, ActionMenuComponent, DatePipe],
   templateUrl: './expenses.component.html',
   styleUrls: ['./expenses.component.css'],
   animations: [
@@ -84,8 +85,9 @@ export class ExpensesComponent implements OnInit {
   readonly loadingList = signal(false);
   readonly saving      = signal(false);
   readonly apiError    = signal<string | null>(null);
-  readonly modalOpen   = signal(false);
-  readonly modalMode   = signal<'create' | 'edit'>('create');
+  readonly modalOpen        = signal(false);
+  readonly modalMode        = signal<'create' | 'edit'>('create');
+  readonly editingUpdatedAt = signal<string | null>(null);
 
   private editingId: string | null = null;
   selectedPeriodId: string | null = null;
@@ -184,6 +186,7 @@ export class ExpensesComponent implements OnInit {
         { value: ExpenseSortColumn.Amount,        label: 'Valor'      },
         { value: ExpenseSortColumn.Status,        label: 'Status'     },
         { value: ExpenseSortColumn.DragAndDropOrder, label: 'Arrastar e soltar' },
+        { value: ExpenseSortColumn.UpdatedAt,        label: 'Data Última Atualização' },
       ],
       value: this.filterSortColumn() ?? '' },
     { key: 'sortDirection', label: 'Ordem',      type: 'select',
@@ -215,6 +218,7 @@ export class ExpensesComponent implements OnInit {
         case 'dueDate':       va = a.dueDate;                     vb = b.dueDate;                     break;
         case 'amount':        va = a.amount;                      vb = b.amount;                      break;
         case 'paymentStatus': va = a.paymentStatus;               vb = b.paymentStatus;               break;
+        case 'updatedAt':     va = a.updatedAt;                   vb = b.updatedAt;                   break;
         default:              return 0;
       }
 
@@ -278,6 +282,7 @@ export class ExpensesComponent implements OnInit {
 
   openCreateModal(): void {
     this.editingId = null;
+    this.editingUpdatedAt.set(null);
     this.modalMode.set('create');
     this.apiError.set(null);
     this.form.reset({
@@ -290,6 +295,7 @@ export class ExpensesComponent implements OnInit {
 
   openEditModal(expense: ExpenseResponse): void {
     this.editingId = expense.id;
+    this.editingUpdatedAt.set(expense.updatedAt);
     this.modalMode.set('edit');
     this.apiError.set(null);
     this.form.patchValue({
@@ -310,6 +316,7 @@ export class ExpensesComponent implements OnInit {
   closeModal(): void {
     this.modalOpen.set(false);
     this.editingId = null;
+    this.editingUpdatedAt.set(null);
     this.apiError.set(null);
   }
 

--- a/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.spec.ts
+++ b/personal-finance/src/app/features/periods/components/period-detail/period-detail.component.spec.ts
@@ -39,6 +39,7 @@ const EXPENSE: ExpenseResponse = {
   notes:          null,
   isActive:       true,
   isRecurring:    false,
+  updatedAt:      '2024-04-05T10:00:00',
 };
 
 const INCOME: IncomeResponse = {

--- a/src/PersonalFinance.Application/DTOs/Financial/FinancialDtos.cs
+++ b/src/PersonalFinance.Application/DTOs/Financial/FinancialDtos.cs
@@ -61,7 +61,8 @@ public sealed record ExpenseResponseDto(
     DateOnly?     PaymentDate,
     string?       Notes,
     bool          IsActive,
-    bool          IsRecurring
+    bool          IsRecurring,
+    DateTime      UpdatedAt
 );
 
 public sealed record RecurringExpenseDto(

--- a/src/PersonalFinance.Application/UseCases/Financial/Expenses/ExpenseUseCases.cs
+++ b/src/PersonalFinance.Application/UseCases/Financial/Expenses/ExpenseUseCases.cs
@@ -78,7 +78,7 @@ public sealed class CreateExpenseUseCase
         new(e.Id, e.PeriodId, e.UserId, e.CategoryId,
             e.SourceType, e.FortnightType, e.PaymentStatus,
             e.Description, e.Amount, e.DueDate, e.PaymentDate,
-            e.Notes, e.IsActive, e.IsRecurring);
+            e.Notes, e.IsActive, e.IsRecurring, e.UpdatedAt);
 }
 
 // ══════════════════════════════════════════════════════════════════════════════

--- a/src/PersonalFinance.Application/UseCases/Financial/Expenses/GetExpenseByIdUseCase.cs
+++ b/src/PersonalFinance.Application/UseCases/Financial/Expenses/GetExpenseByIdUseCase.cs
@@ -23,7 +23,7 @@ namespace PersonalFinance.Application.UseCases.Financial.Expenses
                 expense.Id, expense.PeriodId, expense.UserId, expense.CategoryId,
                 expense.SourceType, expense.FortnightType, expense.PaymentStatus,
                 expense.Description, expense.Amount, expense.DueDate, expense.PaymentDate,
-                expense.Notes, expense.IsActive, expense.IsRecurring);
+                expense.Notes, expense.IsActive, expense.IsRecurring, expense.UpdatedAt);
         }
     }
 }

--- a/src/PersonalFinance.Application/UseCases/Financial/Expenses/GetExpensesByPeriodUseCase.cs
+++ b/src/PersonalFinance.Application/UseCases/Financial/Expenses/GetExpensesByPeriodUseCase.cs
@@ -50,6 +50,6 @@ namespace PersonalFinance.Application.UseCases.Financial.Expenses
             new(e.Id, e.PeriodId, e.UserId, e.CategoryId,
                 e.SourceType, e.FortnightType, e.PaymentStatus,
                 e.Description, e.Amount, e.DueDate, e.PaymentDate,
-                e.Notes, e.IsActive, e.IsRecurring);
+                e.Notes, e.IsActive, e.IsRecurring, e.UpdatedAt);
     }
 }

--- a/src/PersonalFinance.Domain/Enums/DomainEnums.cs
+++ b/src/PersonalFinance.Domain/Enums/DomainEnums.cs
@@ -43,7 +43,8 @@ public enum ExpenseSortColumn
     DueDate          = 5,
     Amount           = 6,
     Status           = 7,
-    DragAndDropOrder = 8
+    DragAndDropOrder = 8,
+    UpdatedAt        = 9
 }
 
 public enum SortDirection

--- a/src/PersonalFinance.Infrastructure/Persistence/Repositories/Financial/ExpenseRepository.cs
+++ b/src/PersonalFinance.Infrastructure/Persistence/Repositories/Financial/ExpenseRepository.cs
@@ -146,6 +146,10 @@ public sealed class ExpenseRepository : IExpenseRepository
                     ? baseQuery.OrderByDescending(e => e.PaymentStatus)
                     : baseQuery.OrderBy(e => e.PaymentStatus),
 
+                ExpenseSortColumn.UpdatedAt => desc
+                    ? baseQuery.OrderByDescending(e => e.UpdatedAt)
+                    : baseQuery.OrderBy(e => e.UpdatedAt),
+
                 _ => baseQuery.OrderBy(e => e.FortnightType).ThenBy(e => e.DueDate)
             };
 

--- a/tests/PersonalFinance.Api.Tests/Integration/ExpensesSortingControllerTests.cs
+++ b/tests/PersonalFinance.Api.Tests/Integration/ExpensesSortingControllerTests.cs
@@ -250,6 +250,45 @@ namespace PersonalFinance.Api.Tests.Integration
             items[2].GetProperty("id").GetString().Should().Be(id1);
         }
 
+        // ── UpdatedAt ─────────────────────────────────────────────────────────────
+
+        [Fact(DisplayName = "Sort por UpdatedAt ASC deve retornar da mais antiga para a mais recente")]
+        public async Task Sort_ByUpdatedAt_Ascending_ShouldReturnOldestFirst()
+        {
+            var (client, pid, cid) = await SetupAsync();
+            var id1 = await CreateExpenseAsync(client, pid, cid, "Primeira", 100m, "2026-09-10");
+            await Task.Delay(50);
+            var id2 = await CreateExpenseAsync(client, pid, cid, "Segunda", 200m, "2026-09-11");
+            await Task.Delay(50);
+            await CreateExpenseAsync(client, pid, cid, "Terceira", 300m, "2026-09-12");
+
+            // sortColumn=9 (UpdatedAt), sortDirection=1 (Ascending)
+            var r = await client.GetAsync($"/api/v1/expenses?periodId={pid}&sortColumn=9&sortDirection=1&pageSize=10");
+            r.StatusCode.Should().Be(HttpStatusCode.OK);
+            var items = (await r.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("items");
+
+            items[0].GetProperty("id").GetString().Should().Be(id1);
+        }
+
+        [Fact(DisplayName = "Sort por UpdatedAt DESC deve retornar da mais recente para a mais antiga")]
+        public async Task Sort_ByUpdatedAt_Descending_ShouldReturnNewestFirst()
+        {
+            var (client, pid, cid) = await SetupAsync();
+            var id1 = await CreateExpenseAsync(client, pid, cid, "Primeira", 100m, "2026-09-10");
+            await Task.Delay(50);
+            await CreateExpenseAsync(client, pid, cid, "Segunda", 200m, "2026-09-11");
+            await Task.Delay(50);
+            var id3 = await CreateExpenseAsync(client, pid, cid, "Terceira", 300m, "2026-09-12");
+
+            // sortColumn=9 (UpdatedAt), sortDirection=2 (Descending)
+            var r = await client.GetAsync($"/api/v1/expenses?periodId={pid}&sortColumn=9&sortDirection=2&pageSize=10");
+            r.StatusCode.Should().Be(HttpStatusCode.OK);
+            var items = (await r.Content.ReadFromJsonAsync<JsonElement>()).GetProperty("items");
+
+            items[0].GetProperty("id").GetString().Should().Be(id3);
+            items[2].GetProperty("id").GetString().Should().Be(id1);
+        }
+
         // ── Default (sem sort) ────────────────────────────────────────────────────
 
         [Fact(DisplayName = "Sem sortColumn deve manter comportamento padrão (DragAndDropOrder → FortnightType → DueDate)")]

--- a/tests/PersonalFinance.Application.Tests/Unit/Financial/GetExpensesByPeriodUseCaseTests.cs
+++ b/tests/PersonalFinance.Application.Tests/Unit/Financial/GetExpensesByPeriodUseCaseTests.cs
@@ -77,6 +77,32 @@ public class GetExpensesByPeriodUseCaseTests
             ExpenseSortColumn.Description, SortDirection.Descending, default), Times.Once);
     }
 
+    [Fact(DisplayName = "Deve incluir UpdatedAt no DTO de resposta")]
+    public async Task Execute_ShouldMapUpdatedAtToResponseDto()
+    {
+        var periodId   = Guid.NewGuid();
+        var userId     = Guid.NewGuid();
+        var categoryId = Guid.NewGuid();
+        var filter     = new ExpenseFilterDto();
+        var expense    = Expense.Create(
+            periodId, userId, categoryId,
+            SourceType.Personal, FortnightType.First, PaymentStatus.Pending,
+            "Aluguel", 1000m, DateOnly.FromDateTime(DateTime.UtcNow), null, null);
+
+        _periodRepo.Setup(r => r.ExistsByIdAndUserAsync(periodId, userId, default)).ReturnsAsync(true);
+        _expenseRepo.Setup(r => r.GetPagedByPeriodAsync(
+            periodId, userId, filter.PageNumber, filter.PageSize,
+            filter.Description, filter.CategoryId,
+            filter.PaymentStatus, filter.FortnightType, filter.SourceType,
+            filter.SortColumn, filter.SortDirection, default))
+            .ReturnsAsync((new List<Expense> { expense }, 1));
+
+        var result = await _sut.ExecuteAsync(periodId, userId, filter);
+
+        result.Items.Should().HaveCount(1);
+        result.Items.First().UpdatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
     [Fact(DisplayName = "Deve lançar exceção se período não pertence ao usuário")]
     public async Task Execute_WithUnauthorizedPeriod_ShouldThrow()
     {


### PR DESCRIPTION
Closes #333

## Summary
- `ExpenseResponseDto` agora expõe `UpdatedAt: DateTime`
- `ExpenseSortColumn` enum — novo valor `UpdatedAt = 9`
- `ExpenseRepository` — novo case de ordenação por `UpdatedAt`
- `ExpenseResponse` (TS) — campo `updatedAt: string`
- Modal de edição exibe label **"Última atualização: dd/MM/yyyy HH:mm:ss"** no topo direito (somente no modo `edit`)
- Filtro de ordenação — nova opção **"Data Última Atualização"**

## Test plan
- [x] Unit: `GetExpensesByPeriodUseCaseTests` — 4 testes passando
- [x] Integration: `ExpensesSortingControllerTests` — 13 testes passando (2 novos: `UpdatedAt` ASC/DESC)
- [x] Frontend: 360 specs passando

🤖 Generated with [Claude Code](https://claude.com/claude-code)