### PR TITLE
chore(ci): retry no push do sync-branches

### DIFF
--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -29,11 +29,11 @@ jobs:
         run: |
           git checkout develop
           git merge --ff-only origin/master || git merge -m "chore(ci): sync develop ← master [skip ci]" origin/master
-          git push origin develop
+          for i in 1 2 3; do git push origin develop && break || (echo "Tentativa $i falhou, aguardando..." && sleep 10); done
 
       - name: Sync release ← master
         run: |
           git checkout release
           git merge --ff-only origin/master || git merge -m "chore(ci): sync release ← master [skip ci]" origin/master
-          git push origin release
+          for i in 1 2 3; do git push origin release && break || (echo "Tentativa $i falhou, aguardando..." && sleep 10); done
 


### PR DESCRIPTION
## Summary
- Adiciona retry (3 tentativas com 10s de intervalo) nos steps de push para `develop` e `release`
- Corrige falha transiente `remote: fatal error in commit_refs` do GitHub que causa falso erro no workflow

## Test plan
- [ ] Verificar próxima execução do workflow `sync-branches` após merge em master

🤖 Generated with [Claude Code](https://claude.com/claude-code)