### PR TITLE
feat(#337): criação de despesas em lote

### DIFF
--- a/personal-finance/src/app/core/models/models.ts
+++ b/personal-finance/src/app/core/models/models.ts
@@ -146,6 +146,22 @@ export interface MarkAsPaidRequest {
   paymentDate: string;
 }
 
+export interface BatchExpenseItemRequest {
+  categoryId:    string;
+  sourceType:    SourceType;
+  fortnightType: FortnightType;
+  description:   string;
+  amount:        number;
+  dueDate:       string;
+  notes?:        string;
+  isRecurring?:  boolean;
+}
+
+export interface CreateExpensesBatchRequest {
+  periodId: string;
+  items:    BatchExpenseItemRequest[];
+}
+
 export interface ExpenseOrderItem {
   expenseId: string;
   order: number;

--- a/personal-finance/src/app/core/services/api.service.ts
+++ b/personal-finance/src/app/core/services/api.service.ts
@@ -6,6 +6,7 @@ import {
   CategoryResponse, CreateCategoryRequest, UpdateCategoryRequest,
   PeriodResponse, CreatePeriodRequest, PeriodSummary, RecurringExpenseResponse,
   ExpenseResponse, CreateExpenseRequest, UpdateExpenseRequest, MarkAsPaidRequest, ExpenseOrderItem,
+  BatchExpenseItemRequest, CreateExpensesBatchRequest,
   PagedResult, ExpenseFilterParams, IncomeFilterParams,
   IncomeResponse, CreateIncomeRequest,
   LookupItem,
@@ -135,6 +136,10 @@ export class ApiService {
 
   batchDeleteExpenses(ids: string[]): Observable<void> {
     return this.http.delete<void>(`${this.base}/expenses/batch`, { body: { expenseIds: ids } });
+  }
+
+  createExpensesBatch(data: CreateExpensesBatchRequest): Observable<ExpenseResponse[]> {
+    return this.http.post<ExpenseResponse[]>(`${this.base}/expenses/batch/create`, data);
   }
 
   // ── Incomes ───────────────────────────────────────────────────────────────

--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.html
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.html
@@ -6,6 +6,9 @@
   <button class="btn btn-primary btn-sm" (click)="openCreateModal()">
     + Nova despesa
   </button>
+  <button class="btn btn-secondary btn-sm" (click)="openBatchModal()">
+    + Adicionar em Lote
+  </button>
 </app-header>
 
 <div class="page-content">
@@ -380,4 +383,13 @@
       (closed)="marioOpen.set(false)"
     />
   </div>
+}
+
+@if (batchModalOpen()) {
+  <app-batch-expenses-modal
+    [periodId]="selectedPeriodId!"
+    [categories]="categories()"
+    (closed)="batchModalOpen.set(false)"
+    (saved)="onBatchSaved($event)"
+  />
 }

--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.spec.ts
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.spec.ts
@@ -535,4 +535,18 @@ describe('ExpensesComponent', () => {
       expect(result[1].id).toBe('e-1');
     });
   });
+
+  describe('openBatchModal()', () => {
+    it('exibe MarioModal quando não há período selecionado', () => {
+      component.selectedPeriodId = null;
+      component.openBatchModal();
+      expect(component.marioOpen()).toBeTrue();
+    });
+
+    it('abre modal de lote quando há período selecionado', () => {
+      component.selectedPeriodId = 'p-1';
+      component.openBatchModal();
+      expect(component.batchModalOpen()).toBeTrue();
+    });
+  });
 });

--- a/personal-finance/src/app/features/expenses/components/expenses/expenses.component.ts
+++ b/personal-finance/src/app/features/expenses/components/expenses/expenses.component.ts
@@ -11,6 +11,7 @@ import { SonicRingBurstComponent } from '../../../../shared/components/sonic-rin
 import { FilterModalComponent } from '../../../../shared/components/filter-modal/filter-modal.component';
 import { FilterButtonComponent } from '../../../../shared/components/filter-modal/filter-button.component';
 import { MarioModalComponent } from '../../../../shared/components/modal/mario-modal/mario-modal.component';
+import { BatchExpensesModalComponent } from '../../../../shared/components/modal/batch-expenses-modal/batch-expenses-modal.component';
 import { ActionMenuComponent } from '../../../../shared/components/action-menu/action-menu.component';
 import { FilterFieldConfig } from '../../../../shared/components/filter-modal/filter-field-config';
 import {
@@ -25,7 +26,7 @@ type SortCol = 'description' | 'category' | 'sourceType' | 'fortnightType' | 'du
 @Component({
   selector: 'app-expenses',
   standalone: true,
-  imports: [HeaderComponent, CurrencyBrlPipe, ReactiveFormsModule, SonicModalComponent, PaginationComponent, SonicRingBurstComponent, FilterModalComponent, FilterButtonComponent, MarioModalComponent, ActionMenuComponent, DatePipe],
+  imports: [HeaderComponent, CurrencyBrlPipe, ReactiveFormsModule, SonicModalComponent, PaginationComponent, SonicRingBurstComponent, FilterModalComponent, FilterButtonComponent, MarioModalComponent, BatchExpensesModalComponent, ActionMenuComponent, DatePipe],
   templateUrl: './expenses.component.html',
   styleUrls: ['./expenses.component.css'],
   animations: [
@@ -113,6 +114,9 @@ export class ExpensesComponent implements OnInit {
   readonly marioTitle       = signal('');
   readonly marioContent     = signal('');
   readonly marioShowWarning = signal(false);
+
+  // Modal de despesas em lote
+  readonly batchModalOpen = signal(false);
 
   incrementAmount(): void {
     const cur = this.form.get('amount')?.value ?? 0;
@@ -278,6 +282,21 @@ export class ExpensesComponent implements OnInit {
       },
       error: () => this.loadingList.set(false)
     });
+  }
+
+  openBatchModal(): void {
+    if (!this.selectedPeriodId) {
+      this.marioTitle.set('Atenção');
+      this.marioContent.set('Selecione um período para adicionar despesas em lote.');
+      this.marioOpen.set(true);
+      return;
+    }
+    this.batchModalOpen.set(true);
+  }
+
+  onBatchSaved(newExpenses: ExpenseResponse[]): void {
+    this.batchModalOpen.set(false);
+    this.loadPage();
   }
 
   openCreateModal(): void {

--- a/personal-finance/src/app/shared/components/modal/batch-expenses-modal/batch-expenses-modal.component.css
+++ b/personal-finance/src/app/shared/components/modal/batch-expenses-modal/batch-expenses-modal.component.css
@@ -1,0 +1,220 @@
+.batch-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  z-index: 1000;
+}
+
+.batch-modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1001;
+  width: min(92vw, 900px);
+  max-height: 85vh;
+  background: var(--color-surface, #1e1e2e);
+  border: 2px solid var(--color-border, #3a3a5c);
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.5);
+}
+
+.batch-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--color-border, #3a3a5c);
+  flex-shrink: 0;
+}
+
+.batch-title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--color-text, #e0e0f0);
+  margin: 0;
+}
+
+.batch-close {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-muted, #888);
+  padding: 4px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.15s;
+}
+
+.batch-close:hover { color: var(--color-text, #e0e0f0); }
+
+.batch-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+/* Lista de itens adicionados */
+.batch-items-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.batch-item-summary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  background: var(--color-surface-alt, #2a2a3e);
+  border-radius: 8px;
+  border: 1px solid var(--color-border, #3a3a5c);
+}
+
+.item-desc {
+  flex: 1;
+  font-size: 0.875rem;
+  color: var(--color-text, #e0e0f0);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.item-amount {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-primary, #7c6af7);
+  white-space: nowrap;
+}
+
+.icon-btn {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-muted, #888);
+  padding: 4px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.15s;
+  flex-shrink: 0;
+}
+
+.icon-btn:hover { color: var(--color-text, #e0e0f0); }
+.icon-btn--danger:hover { color: #ef4444; }
+
+/* Formulário (novo item ou edição) */
+.batch-new-form,
+.batch-item-edit {
+  display: grid;
+  grid-template-columns: 1fr 1.5fr 100px 130px 110px 120px 1fr;
+  gap: 8px;
+  align-items: start;
+  padding: 10px 12px;
+  background: var(--color-surface-alt, #2a2a3e);
+  border-radius: 8px;
+  border: 1px solid var(--color-border, #3a3a5c);
+}
+
+.batch-item-edit {
+  border-color: var(--color-primary, #7c6af7);
+}
+
+.edit-actions {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+
+.input-sm {
+  font-size: 0.8rem;
+  padding: 6px 8px;
+  height: 34px;
+}
+
+/* Botão + 3D */
+.add-btn-row {
+  display: flex;
+  justify-content: center;
+}
+
+.btn-add-3d {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: none;
+  background: linear-gradient(145deg, #7c6af7, #5a4ed4);
+  box-shadow:
+    4px 4px 8px rgba(0, 0, 0, 0.4),
+    -2px -2px 6px rgba(255, 255, 255, 0.08),
+    inset 0 1px 2px rgba(255, 255, 255, 0.15);
+  color: #fff;
+  font-size: 1.5rem;
+  font-weight: 700;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.1s, box-shadow 0.1s;
+  line-height: 1;
+}
+
+.btn-add-3d:hover {
+  transform: translateY(-1px);
+  box-shadow:
+    5px 5px 10px rgba(0, 0, 0, 0.4),
+    -2px -2px 6px rgba(255, 255, 255, 0.1),
+    inset 0 1px 2px rgba(255, 255, 255, 0.15);
+}
+
+.btn-add-3d:active {
+  transform: translateY(1px);
+  box-shadow:
+    2px 2px 4px rgba(0, 0, 0, 0.4),
+    inset 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+/* Footer */
+.batch-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 20px;
+  border-top: 1px solid var(--color-border, #3a3a5c);
+  flex-shrink: 0;
+}
+
+.item-count {
+  font-size: 0.8rem;
+  color: var(--color-text-muted, #888);
+}
+
+.btn-xs {
+  padding: 3px 8px;
+  font-size: 0.75rem;
+}
+
+.btn-ghost {
+  background: transparent;
+  border: 1px solid var(--color-border, #3a3a5c);
+  color: var(--color-text-muted, #888);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.btn-ghost:hover { color: var(--color-text, #e0e0f0); }
+
+@media (max-width: 768px) {
+  .batch-new-form,
+  .batch-item-edit {
+    grid-template-columns: 1fr 1fr;
+  }
+}

--- a/personal-finance/src/app/shared/components/modal/batch-expenses-modal/batch-expenses-modal.component.html
+++ b/personal-finance/src/app/shared/components/modal/batch-expenses-modal/batch-expenses-modal.component.html
@@ -1,0 +1,125 @@
+<!-- Backdrop -->
+<div class="batch-backdrop" (click)="close()"></div>
+
+<!-- Modal container -->
+<div class="batch-modal">
+
+  <!-- Header -->
+  <div class="batch-header">
+    <h2 class="batch-title">Adicionar Despesas em Lote</h2>
+    <button class="batch-close" (click)="close()" aria-label="Fechar">
+      <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+        <line x1="2" y1="2" x2="12" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+        <line x1="12" y1="2" x2="2" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+      </svg>
+    </button>
+  </div>
+
+  <!-- Body -->
+  <div class="batch-body">
+
+    <!-- Lista de itens adicionados -->
+    @if (items().length > 0) {
+      <div class="batch-items-list">
+        @for (item of items(); track $index) {
+          @if (editingIndex() === $index) {
+            <!-- Modo edição -->
+            <div class="batch-item-edit" [formGroup]="editForm">
+              <select class="input input-sm" formControlName="categoryId">
+                <option value="">Categoria</option>
+                @for (cat of categories(); track cat.id) {
+                  <option [value]="cat.id">{{ cat.name }}</option>
+                }
+              </select>
+              <input class="input input-sm" type="text" placeholder="Descrição" formControlName="description" />
+              <input class="input input-sm" type="number" placeholder="Valor" formControlName="amount" step="0.01" />
+              <input class="input input-sm" type="date" formControlName="dueDate" />
+              <select class="input input-sm" formControlName="sourceType">
+                <option [value]="SourceType.Personal">Própria</option>
+                <option [value]="SourceType.Parental">Parental</option>
+              </select>
+              <select class="input input-sm" formControlName="fortnightType">
+                <option [value]="FortnightType.First">1ª Quinzena</option>
+                <option [value]="FortnightType.Second">2ª Quinzena</option>
+              </select>
+              <input class="input input-sm" type="text" placeholder="Observação" formControlName="notes" />
+              <div class="edit-actions">
+                <button class="btn btn-xs btn-primary" type="button" (click)="confirmEditItem()">✓</button>
+                <button class="btn btn-xs btn-ghost" type="button" (click)="cancelEdit()">✕</button>
+              </div>
+            </div>
+          } @else {
+            <!-- Modo summary -->
+            <div class="batch-item-summary">
+              <span class="item-desc">{{ item.description }}</span>
+              <span class="item-amount">R$ {{ item.amount | number:'1.2-2' }}</span>
+              <button class="icon-btn" type="button" title="Editar" (click)="startEditItem($index)">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
+                  <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
+                </svg>
+              </button>
+              <button class="icon-btn icon-btn--danger" type="button" title="Remover" (click)="removeItem($index)">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <line x1="18" y1="6" x2="6" y2="18"/>
+                  <line x1="6" y1="6" x2="18" y2="18"/>
+                </svg>
+              </button>
+            </div>
+          }
+        }
+      </div>
+    }
+
+    <!-- Formulário do novo item -->
+    <div class="batch-new-form" [formGroup]="newForm">
+      <select class="input input-sm" formControlName="categoryId">
+        <option value="">Categoria *</option>
+        @for (cat of categories(); track cat.id) {
+          <option [value]="cat.id">{{ cat.name }}</option>
+        }
+      </select>
+      <input class="input input-sm" type="text" placeholder="Descrição *" formControlName="description" />
+      <input class="input input-sm" type="number" placeholder="Valor *" formControlName="amount" step="0.01" />
+      <input class="input input-sm" type="date" formControlName="dueDate" />
+      <select class="input input-sm" formControlName="sourceType">
+        <option [value]="SourceType.Personal">Própria</option>
+        <option [value]="SourceType.Parental">Parental</option>
+      </select>
+      <select class="input input-sm" formControlName="fortnightType">
+        <option [value]="FortnightType.First">1ª Quinzena</option>
+        <option [value]="FortnightType.Second">2ª Quinzena</option>
+      </select>
+      <input class="input input-sm" type="text" placeholder="Observação" formControlName="notes" />
+    </div>
+
+    <!-- Botão + -->
+    <div class="add-btn-row">
+      <button class="btn-add-3d" type="button" (click)="addItem()" title="Adicionar item">+</button>
+    </div>
+
+  </div>
+
+  <!-- Footer -->
+  <div class="batch-footer">
+    <span class="item-count">{{ items().length }} item{{ items().length !== 1 ? 's' : '' }}</span>
+    <button
+      class="btn btn-primary"
+      type="button"
+      [disabled]="!canSave() || saving()"
+      (click)="save()"
+    >
+      @if (saving()) { Salvando... } @else { Salvar }
+    </button>
+  </div>
+
+</div>
+
+<!-- Mario Modal — erro -->
+@if (marioOpen()) {
+  <app-mario-modal
+    title="Ops!"
+    [content]="marioContent()"
+    (closed)="marioOpen.set(false)"
+  />
+}

--- a/personal-finance/src/app/shared/components/modal/batch-expenses-modal/batch-expenses-modal.component.spec.ts
+++ b/personal-finance/src/app/shared/components/modal/batch-expenses-modal/batch-expenses-modal.component.spec.ts
@@ -1,0 +1,136 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { of, throwError } from 'rxjs';
+import { BatchExpensesModalComponent } from './batch-expenses-modal.component';
+import { ApiService } from '../../../../core/services/api.service';
+import { CategoryResponse, FortnightType, SourceType } from '../../../../core/models/models';
+
+const CATEGORY: CategoryResponse = {
+  id: 'cat-1', userId: 'u', name: 'Moradia', color: '#abc', icon: null, isGlobal: false, isActive: true
+};
+
+const ITEM = {
+  categoryId: 'cat-1', description: 'Aluguel', amount: 1000,
+  dueDate: '2026-10-05', sourceType: SourceType.Personal,
+  fortnightType: FortnightType.First, isRecurring: false
+};
+
+describe('BatchExpensesModalComponent', () => {
+  let fixture: ComponentFixture<BatchExpensesModalComponent>;
+  let component: BatchExpensesModalComponent;
+  let apiSpy: jasmine.SpyObj<ApiService>;
+
+  beforeEach(async () => {
+    apiSpy = jasmine.createSpyObj('ApiService', ['createExpensesBatch']);
+
+    await TestBed.configureTestingModule({
+      imports: [BatchExpensesModalComponent],
+      providers: [{ provide: ApiService, useValue: apiSpy }],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BatchExpensesModalComponent);
+    component = fixture.componentInstance;
+
+    fixture.componentRef.setInput('periodId', 'p-1');
+    fixture.componentRef.setInput('categories', [CATEGORY]);
+
+    fixture.detectChanges();
+  });
+
+  it('cria o componente com lista vazia e form definido', () => {
+    expect(component).toBeTruthy();
+    expect(component.items()).toEqual([]);
+    expect(component.newForm).toBeDefined();
+  });
+
+  describe('addItem()', () => {
+    it('adiciona item válido ao signal e limpa o form', () => {
+      component.newForm.patchValue({
+        categoryId: 'cat-1', description: 'Aluguel', amount: 1000,
+        dueDate: '2026-10-05', sourceType: SourceType.Personal, fortnightType: FortnightType.First
+      });
+      component.addItem();
+      expect(component.items().length).toBe(1);
+      expect(component.items()[0].description).toBe('Aluguel');
+      expect(component.newForm.get('description')?.value).toBe('');
+    });
+
+    it('não adiciona quando form inválido', () => {
+      component.addItem();
+      expect(component.items().length).toBe(0);
+    });
+  });
+
+  describe('startEditItem()', () => {
+    it('define editingIndex e popula editForm com valores do item', () => {
+      component.items.set([{ ...ITEM }]);
+      component.startEditItem(0);
+      expect(component.editingIndex()).toBe(0);
+      expect(component.editForm.get('description')?.value).toBe('Aluguel');
+      expect(component.editForm.get('amount')?.value).toBe(1000);
+    });
+  });
+
+  describe('removeItem()', () => {
+    it('remove item do signal e rearranja lista', () => {
+      component.items.set([
+        { ...ITEM, description: 'A', amount: 100 },
+        { ...ITEM, description: 'B', amount: 200 },
+      ]);
+      component.removeItem(0);
+      expect(component.items().length).toBe(1);
+      expect(component.items()[0].description).toBe('B');
+    });
+
+    it('ajusta editingIndex ao remover item antes do editado', () => {
+      component.items.set([
+        { ...ITEM, description: 'A' },
+        { ...ITEM, description: 'B' },
+      ]);
+      component.startEditItem(1);
+      component.removeItem(0);
+      expect(component.editingIndex()).toBe(0);
+    });
+  });
+
+  describe('canSave()', () => {
+    it('retorna false sem itens', () => expect(component.canSave()).toBeFalse());
+    it('retorna true com itens', () => {
+      component.items.set([{ ...ITEM }]);
+      expect(component.canSave()).toBeTrue();
+    });
+  });
+
+  describe('save()', () => {
+    it('chama createExpensesBatch com periodId e itens e emite saved', fakeAsync(() => {
+      const savedSpy = jasmine.createSpy('saved');
+      component.saved.subscribe(savedSpy);
+      component.items.set([{ ...ITEM }]);
+      apiSpy.createExpensesBatch.and.returnValue(of([]));
+
+      component.save();
+      tick();
+
+      expect(apiSpy.createExpensesBatch).toHaveBeenCalledWith({
+        periodId: 'p-1',
+        items: [{ ...ITEM }]
+      });
+      expect(savedSpy).toHaveBeenCalled();
+    }));
+
+    it('abre MarioModal com mensagem de erro quando API falha', fakeAsync(() => {
+      component.items.set([{ ...ITEM }]);
+      apiSpy.createExpensesBatch.and.returnValue(
+        throwError(() => ({ error: { message: 'Erro ao salvar lote.' } }))
+      );
+
+      component.save();
+      tick();
+
+      expect(component.marioOpen()).toBeTrue();
+      expect(component.marioContent()).toBe('Erro ao salvar lote.');
+    }));
+  });
+});

--- a/personal-finance/src/app/shared/components/modal/batch-expenses-modal/batch-expenses-modal.component.ts
+++ b/personal-finance/src/app/shared/components/modal/batch-expenses-modal/batch-expenses-modal.component.ts
@@ -1,0 +1,175 @@
+import { Component, inject, signal, computed, input, output } from '@angular/core';
+import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+import { DecimalPipe } from '@angular/common';
+import { ApiService } from '../../../../core/services/api.service';
+import { MarioModalComponent } from '../mario-modal/mario-modal.component';
+import {
+  CategoryResponse, ExpenseResponse,
+  SourceType, FortnightType,
+} from '../../../../core/models/models';
+
+export interface BatchFormItem {
+  categoryId:    string;
+  sourceType:    SourceType;
+  fortnightType: FortnightType;
+  description:   string;
+  amount:        number;
+  dueDate:       string;
+  notes?:        string;
+  isRecurring:   boolean;
+}
+
+@Component({
+  selector: 'app-batch-expenses-modal',
+  standalone: true,
+  imports: [ReactiveFormsModule, DecimalPipe, MarioModalComponent],
+  templateUrl: './batch-expenses-modal.component.html',
+  styleUrls: ['./batch-expenses-modal.component.css'],
+})
+export class BatchExpensesModalComponent {
+  private readonly api = inject(ApiService);
+  private readonly fb  = inject(FormBuilder);
+
+  readonly periodId  = input.required<string>();
+  readonly categories = input<CategoryResponse[]>([]);
+
+  readonly closed = output<void>();
+  readonly saved  = output<ExpenseResponse[]>();
+
+  readonly SourceType    = SourceType;
+  readonly FortnightType = FortnightType;
+
+  readonly items        = signal<BatchFormItem[]>([]);
+  readonly editingIndex = signal<number | null>(null);
+  readonly saving       = signal(false);
+
+  readonly marioOpen    = signal(false);
+  readonly marioContent = signal('');
+
+  readonly newForm = this.fb.group({
+    categoryId:    ['', Validators.required],
+    sourceType:    [SourceType.Personal, Validators.required],
+    fortnightType: [FortnightType.First, Validators.required],
+    description:   ['', Validators.required],
+    amount:        [null as number | null, [Validators.required, Validators.min(0.01)]],
+    dueDate:       ['', Validators.required],
+    notes:         [''],
+    isRecurring:   [false],
+  });
+
+  readonly editForm = this.fb.group({
+    categoryId:    ['', Validators.required],
+    sourceType:    [SourceType.Personal, Validators.required],
+    fortnightType: [FortnightType.First, Validators.required],
+    description:   ['', Validators.required],
+    amount:        [null as number | null, [Validators.required, Validators.min(0.01)]],
+    dueDate:       ['', Validators.required],
+    notes:         [''],
+    isRecurring:   [false],
+  });
+
+  canSave(): boolean {
+    return this.items().length > 0;
+  }
+
+  addItem(): void {
+    if (this.newForm.invalid) {
+      this.newForm.markAllAsTouched();
+      return;
+    }
+    const v = this.newForm.getRawValue();
+    this.items.update(list => [...list, {
+      categoryId:    v.categoryId!,
+      sourceType:    v.sourceType!,
+      fortnightType: v.fortnightType!,
+      description:   v.description!,
+      amount:        v.amount!,
+      dueDate:       v.dueDate!,
+      notes:         v.notes || undefined,
+      isRecurring:   v.isRecurring ?? false,
+    }]);
+    this.newForm.reset({
+      categoryId: '', sourceType: SourceType.Personal,
+      fortnightType: FortnightType.First, description: '',
+      amount: null, dueDate: '', notes: '', isRecurring: false,
+    });
+  }
+
+  startEditItem(index: number): void {
+    const item = this.items()[index];
+    this.editForm.patchValue({
+      categoryId:    item.categoryId,
+      sourceType:    item.sourceType,
+      fortnightType: item.fortnightType,
+      description:   item.description,
+      amount:        item.amount,
+      dueDate:       item.dueDate,
+      notes:         item.notes ?? '',
+      isRecurring:   item.isRecurring,
+    });
+    this.editingIndex.set(index);
+  }
+
+  confirmEditItem(): void {
+    const idx = this.editingIndex();
+    if (idx === null || this.editForm.invalid) {
+      this.editForm.markAllAsTouched();
+      return;
+    }
+    const v = this.editForm.getRawValue();
+    this.items.update(list => {
+      const updated = [...list];
+      updated[idx] = {
+        categoryId:    v.categoryId!,
+        sourceType:    v.sourceType!,
+        fortnightType: v.fortnightType!,
+        description:   v.description!,
+        amount:        v.amount!,
+        dueDate:       v.dueDate!,
+        notes:         v.notes || undefined,
+        isRecurring:   v.isRecurring ?? false,
+      };
+      return updated;
+    });
+    this.editingIndex.set(null);
+  }
+
+  cancelEdit(): void {
+    this.editingIndex.set(null);
+  }
+
+  removeItem(index: number): void {
+    const editIdx = this.editingIndex();
+    this.items.update(list => list.filter((_, i) => i !== index));
+    if (editIdx !== null) {
+      if (editIdx === index) {
+        this.editingIndex.set(null);
+      } else if (editIdx > index) {
+        this.editingIndex.set(editIdx - 1);
+      }
+    }
+  }
+
+  save(): void {
+    if (!this.canSave() || this.saving()) return;
+    this.saving.set(true);
+    this.api.createExpensesBatch({
+      periodId: this.periodId(),
+      items: this.items(),
+    }).subscribe({
+      next: (result) => {
+        this.saving.set(false);
+        this.saved.emit(result);
+      },
+      error: (err) => {
+        this.saving.set(false);
+        this.marioContent.set(err?.error?.message ?? 'Erro ao salvar as despesas em lote.');
+        this.marioOpen.set(true);
+      },
+    });
+  }
+
+  close(): void {
+    this.closed.emit();
+  }
+}

--- a/src/PersonalFinance.Api/Controllers/V1/Financial/ExpensesController.cs
+++ b/src/PersonalFinance.Api/Controllers/V1/Financial/ExpensesController.cs
@@ -14,6 +14,7 @@ public sealed class ExpensesController(
     GetExpensesByPeriodUseCase getByPeriodUseCase,
     GetExpenseByIdUseCase getByIdUseCase,
     CreateExpenseUseCase createUseCase,
+    CreateExpensesBatchUseCase createBatchUseCase,
     UpdateExpenseUseCase updateUseCase,
     DeleteExpenseUseCase deleteUseCase,
     DeleteExpensesBatchUseCase deleteBatchUseCase,
@@ -26,6 +27,7 @@ public sealed class ExpensesController(
     private readonly GetExpensesByPeriodUseCase _getByPeriodUseCase = getByPeriodUseCase;
     private readonly GetExpenseByIdUseCase _getByIdUseCase = getByIdUseCase;
     private readonly CreateExpenseUseCase _createUseCase = createUseCase;
+    private readonly CreateExpensesBatchUseCase _createBatchUseCase = createBatchUseCase;
     private readonly UpdateExpenseUseCase _updateUseCase = updateUseCase;
     private readonly DeleteExpenseUseCase _deleteUseCase = deleteUseCase;
     private readonly DeleteExpensesBatchUseCase _deleteBatchUseCase = deleteBatchUseCase;
@@ -127,6 +129,18 @@ public sealed class ExpensesController(
         await _expenseRepository.UpdateAsync(expense, ct);
         await _unitOfWork.CommitAsync(ct);
         return NoContent();
+    }
+
+    /// <summary>Cria múltiplas despesas em lote. Em caso de erro, nenhuma despesa é persistida.</summary>
+    [HttpPost("batch/create")]
+    [ProducesResponseType(typeof(IReadOnlyList<ExpenseResponseDto>), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> CreateBatch(
+        [FromBody] CreateExpensesBatchDto dto, CancellationToken ct)
+    {
+        var result = await _createBatchUseCase.ExecuteAsync(
+            dto with { UserId = CurrentUserId }, ct);
+        return StatusCode(StatusCodes.Status201Created, result);
     }
 
     /// <summary>Exclui logicamente múltiplas despesas em lote.</summary>

--- a/src/PersonalFinance.Api/Extensions/ApplicationExtensions.cs
+++ b/src/PersonalFinance.Api/Extensions/ApplicationExtensions.cs
@@ -60,6 +60,7 @@ public static class ApplicationExtensions
         services.AddScoped<GetExpensesByPeriodUseCase>();
         services.AddScoped<GetExpenseByIdUseCase>();
         services.AddScoped<CreateExpenseUseCase>();
+        services.AddScoped<CreateExpensesBatchUseCase>();
         services.AddScoped<UpdateExpenseUseCase>();
         services.AddScoped<DeleteExpenseUseCase>();
         services.AddScoped<DeleteExpensesBatchUseCase>();

--- a/src/PersonalFinance.Application/DTOs/Financial/BatchExpenseItemDto.cs
+++ b/src/PersonalFinance.Application/DTOs/Financial/BatchExpenseItemDto.cs
@@ -1,0 +1,14 @@
+using PersonalFinance.Domain.Enums;
+
+namespace PersonalFinance.Application.DTOs.Financial;
+
+public sealed record BatchExpenseItemDto(
+    Guid          CategoryId,
+    SourceType    SourceType,
+    FortnightType FortnightType,
+    string        Description,
+    decimal       Amount,
+    DateOnly      DueDate,
+    string?       Notes       = null,
+    bool          IsRecurring = false
+);

--- a/src/PersonalFinance.Application/DTOs/Financial/CreateExpensesBatchDto.cs
+++ b/src/PersonalFinance.Application/DTOs/Financial/CreateExpensesBatchDto.cs
@@ -1,0 +1,7 @@
+namespace PersonalFinance.Application.DTOs.Financial;
+
+public sealed record CreateExpensesBatchDto(
+    Guid                               PeriodId,
+    Guid                               UserId,
+    IReadOnlyList<BatchExpenseItemDto> Items
+);

--- a/src/PersonalFinance.Application/UseCases/Financial/Expenses/ExpenseUseCases.cs
+++ b/src/PersonalFinance.Application/UseCases/Financial/Expenses/ExpenseUseCases.cs
@@ -202,6 +202,80 @@ public sealed class DeleteExpenseUseCase
 }
 
 // ══════════════════════════════════════════════════════════════════════════════
+// CREATE EXPENSES BATCH
+// ══════════════════════════════════════════════════════════════════════════════
+
+public sealed class CreateExpensesBatchUseCase
+{
+    private readonly IExpenseRepository  _expenseRepository;
+    private readonly IPeriodRepository   _periodRepository;
+    private readonly ICategoryRepository _categoryRepository;
+    private readonly IUnitOfWork         _unitOfWork;
+
+    public CreateExpensesBatchUseCase(
+        IExpenseRepository  expenseRepository,
+        IPeriodRepository   periodRepository,
+        ICategoryRepository categoryRepository,
+        IUnitOfWork         unitOfWork)
+    {
+        _expenseRepository  = expenseRepository;
+        _periodRepository   = periodRepository;
+        _categoryRepository = categoryRepository;
+        _unitOfWork         = unitOfWork;
+    }
+
+    public async Task<IReadOnlyList<ExpenseResponseDto>> ExecuteAsync(
+        CreateExpensesBatchDto dto,
+        CancellationToken ct = default)
+    {
+        if (dto.Items.Count == 0)
+            throw new DomainException("A lista de despesas não pode ser vazia.");
+
+        var periodExists = await _periodRepository
+            .ExistsByIdAndUserAsync(dto.PeriodId, dto.UserId, ct);
+
+        if (!periodExists)
+            throw new DomainException("Período não encontrado ou sem permissão de acesso.");
+
+        // Valida todas as categorias antes de criar qualquer despesa (rollback semântico)
+        foreach (var item in dto.Items)
+        {
+            var categoryAccessible = await _categoryRepository
+                .IsAccessibleByUserAsync(item.CategoryId, dto.UserId, ct);
+
+            if (!categoryAccessible)
+                throw new DomainException("Categoria não encontrada ou sem permissão de acesso.");
+        }
+
+        var expenses = dto.Items.Select(item => Expense.Create(
+            periodId:      dto.PeriodId,
+            userId:        dto.UserId,
+            categoryId:    item.CategoryId,
+            sourceType:    item.SourceType,
+            fortnightType: item.FortnightType,
+            paymentStatus: PaymentStatus.Pending,
+            description:   item.Description,
+            amount:        item.Amount,
+            dueDate:       item.DueDate,
+            paymentDate:   null,
+            notes:         item.Notes,
+            isRecurring:   item.IsRecurring
+        )).ToList();
+
+        await _expenseRepository.AddRangeAsync(expenses, ct);
+        await _unitOfWork.CommitAsync(ct);
+
+        return expenses.Select(ToDto).ToList();
+    }
+
+    private static ExpenseResponseDto ToDto(Expense e) =>
+        new(e.Id, e.PeriodId, e.UserId, e.CategoryId,
+            e.SourceType, e.FortnightType, e.PaymentStatus,
+            e.Description, e.Amount, e.DueDate, e.PaymentDate,
+            e.Notes, e.IsActive, e.IsRecurring, e.UpdatedAt);
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
 // DELETE EXPENSES BATCH
 // ══════════════════════════════════════════════════════════════════════════════
 

--- a/tests/PersonalFinance.Api.Tests/Integration/ExpensesCreateBatchControllerTests.cs
+++ b/tests/PersonalFinance.Api.Tests/Integration/ExpensesCreateBatchControllerTests.cs
@@ -1,0 +1,97 @@
+using FluentAssertions;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Xunit;
+
+namespace PersonalFinance.Api.Tests.Integration
+{
+    public class ExpensesCreateBatchControllerTests : ApiIntegrationTestBase
+    {
+        public ExpensesCreateBatchControllerTests(TestWebApplicationFactory f) : base(f) { }
+
+        private async Task<(HttpClient client, string periodId, string categoryId)> SetupAsync()
+        {
+            var (client, _) = await GetAuthenticatedClientAsync();
+
+            var period = await client.PostAsJsonAsync("/api/v1/periods", new { year = 2026, month = 10 });
+            var pBody  = await period.Content.ReadFromJsonAsync<JsonElement>();
+            var pid    = pBody.GetProperty("id").GetString()!;
+
+            var cat   = await client.PostAsJsonAsync("/api/v1/categories", new
+            { name = $"CatCreateBatch_{Guid.NewGuid():N}", color = "#3A7BD5" });
+            var cBody = await cat.Content.ReadFromJsonAsync<JsonElement>();
+            var cid   = cBody.GetProperty("id").GetString()!;
+
+            return (client, pid, cid);
+        }
+
+        [Fact(DisplayName = "POST /expenses/batch/create deve criar N despesas e retornar 201")]
+        public async Task CreateBatch_ShouldReturn201WithAllExpenses()
+        {
+            var (client, pid, cid) = await SetupAsync();
+
+            var payload = new
+            {
+                periodId = pid,
+                items = new[]
+                {
+                    new { categoryId = cid, sourceType = 2, fortnightType = 1, description = "Lote 1", amount = 100.00, dueDate = "2026-10-05" },
+                    new { categoryId = cid, sourceType = 2, fortnightType = 1, description = "Lote 2", amount = 200.00, dueDate = "2026-10-10" },
+                    new { categoryId = cid, sourceType = 2, fortnightType = 1, description = "Lote 3", amount = 300.00, dueDate = "2026-10-15" }
+                }
+            };
+
+            var r = await client.PostAsJsonAsync("/api/v1/expenses/batch/create", payload);
+
+            r.StatusCode.Should().Be(HttpStatusCode.Created);
+
+            var body = await r.Content.ReadFromJsonAsync<JsonElement>();
+            body.GetArrayLength().Should().Be(3);
+
+            var list = await client.GetAsync($"/api/v1/expenses?periodId={pid}");
+            var listBody = await list.Content.ReadFromJsonAsync<JsonElement>();
+            listBody.GetProperty("items").GetArrayLength().Should().Be(3);
+        }
+
+        [Fact(DisplayName = "POST /expenses/batch/create com lista vazia deve retornar 400")]
+        public async Task CreateBatch_EmptyList_ShouldReturn400()
+        {
+            var (client, pid, _) = await SetupAsync();
+
+            var r = await client.PostAsJsonAsync("/api/v1/expenses/batch/create", new
+            {
+                periodId = pid,
+                items = new object[] { }
+            });
+
+            r.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        }
+
+        [Fact(DisplayName = "POST /expenses/batch/create com categoria inválida deve retornar 400 sem persistir")]
+        public async Task CreateBatch_InvalidCategory_ShouldReturn400WithRollback()
+        {
+            var (client, pid, cid) = await SetupAsync();
+            var invalidCatId = Guid.NewGuid().ToString();
+
+            var payload = new
+            {
+                periodId = pid,
+                items = new[]
+                {
+                    new { categoryId = cid,           sourceType = 2, fortnightType = 1, description = "Válida",   amount = 100.00, dueDate = "2026-10-05" },
+                    new { categoryId = invalidCatId,  sourceType = 2, fortnightType = 1, description = "Inválida", amount = 200.00, dueDate = "2026-10-10" }
+                }
+            };
+
+            var r = await client.PostAsJsonAsync("/api/v1/expenses/batch/create", payload);
+
+            r.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+            // Nenhuma despesa deve ter sido persistida (rollback)
+            var list = await client.GetAsync($"/api/v1/expenses?periodId={pid}");
+            var listBody = await list.Content.ReadFromJsonAsync<JsonElement>();
+            listBody.GetProperty("items").GetArrayLength().Should().Be(0);
+        }
+    }
+}

--- a/tests/PersonalFinance.Application.Tests/Unit/Financial/CreateExpensesBatchUseCaseTests.cs
+++ b/tests/PersonalFinance.Application.Tests/Unit/Financial/CreateExpensesBatchUseCaseTests.cs
@@ -1,0 +1,98 @@
+using FluentAssertions;
+using Moq;
+using PersonalFinance.Application.DTOs.Financial;
+using PersonalFinance.Application.UseCases.Financial.Expenses;
+using PersonalFinance.Domain.Enums;
+using PersonalFinance.Domain.Exceptions;
+using PersonalFinance.Domain.Interfaces.Repositories;
+using Xunit;
+
+namespace PersonalFinance.Application.Tests.Unit.Financial;
+
+public class CreateExpensesBatchUseCaseTests
+{
+    private readonly Mock<IExpenseRepository>  _expenseRepo  = new();
+    private readonly Mock<IPeriodRepository>   _periodRepo   = new();
+    private readonly Mock<ICategoryRepository> _categoryRepo = new();
+    private readonly Mock<IUnitOfWork>         _uow          = new();
+
+    private static BatchExpenseItemDto MakeItem(Guid categoryId) =>
+        new(categoryId, SourceType.Personal, FortnightType.First,
+            "Despesa Teste", 100m, DateOnly.FromDateTime(DateTime.UtcNow));
+
+    [Fact(DisplayName = "CreateBatch: deve criar N despesas e retornar lista com mesmo tamanho")]
+    public async Task CreateBatch_ShouldCreateAllExpensesAndReturnList()
+    {
+        var userId   = Guid.NewGuid();
+        var periodId = Guid.NewGuid();
+        var catId1   = Guid.NewGuid();
+        var catId2   = Guid.NewGuid();
+
+        _periodRepo.Setup(r => r.ExistsByIdAndUserAsync(periodId, userId, default))
+                   .ReturnsAsync(true);
+        _categoryRepo.Setup(r => r.IsAccessibleByUserAsync(catId1, userId, default))
+                     .ReturnsAsync(true);
+        _categoryRepo.Setup(r => r.IsAccessibleByUserAsync(catId2, userId, default))
+                     .ReturnsAsync(true);
+
+        var dto = new CreateExpensesBatchDto(periodId, userId, [MakeItem(catId1), MakeItem(catId2)]);
+        var sut = new CreateExpensesBatchUseCase(
+            _expenseRepo.Object, _periodRepo.Object, _categoryRepo.Object, _uow.Object);
+
+        var result = await sut.ExecuteAsync(dto);
+
+        result.Should().HaveCount(2);
+        _uow.Verify(u => u.CommitAsync(default), Times.Once);
+    }
+
+    [Fact(DisplayName = "CreateBatch: lista vazia deve lançar DomainException sem commit")]
+    public async Task CreateBatch_EmptyList_ShouldThrowWithoutCommit()
+    {
+        var dto = new CreateExpensesBatchDto(Guid.NewGuid(), Guid.NewGuid(), []);
+        var sut = new CreateExpensesBatchUseCase(
+            _expenseRepo.Object, _periodRepo.Object, _categoryRepo.Object, _uow.Object);
+
+        var act = () => sut.ExecuteAsync(dto);
+        await act.Should().ThrowAsync<DomainException>();
+        _uow.Verify(u => u.CommitAsync(default), Times.Never);
+    }
+
+    [Fact(DisplayName = "CreateBatch: período inválido deve lançar DomainException sem commit")]
+    public async Task CreateBatch_InvalidPeriod_ShouldThrowWithoutCommit()
+    {
+        var userId   = Guid.NewGuid();
+        var periodId = Guid.NewGuid();
+
+        _periodRepo.Setup(r => r.ExistsByIdAndUserAsync(periodId, userId, default))
+                   .ReturnsAsync(false);
+
+        var dto = new CreateExpensesBatchDto(periodId, userId, [MakeItem(Guid.NewGuid())]);
+        var sut = new CreateExpensesBatchUseCase(
+            _expenseRepo.Object, _periodRepo.Object, _categoryRepo.Object, _uow.Object);
+
+        var act = () => sut.ExecuteAsync(dto);
+        await act.Should().ThrowAsync<DomainException>();
+        _uow.Verify(u => u.CommitAsync(default), Times.Never);
+    }
+
+    [Fact(DisplayName = "CreateBatch: categoria inválida deve lançar DomainException sem commit")]
+    public async Task CreateBatch_InvalidCategory_ShouldThrowWithoutCommit()
+    {
+        var userId   = Guid.NewGuid();
+        var periodId = Guid.NewGuid();
+        var catId    = Guid.NewGuid();
+
+        _periodRepo.Setup(r => r.ExistsByIdAndUserAsync(periodId, userId, default))
+                   .ReturnsAsync(true);
+        _categoryRepo.Setup(r => r.IsAccessibleByUserAsync(catId, userId, default))
+                     .ReturnsAsync(false);
+
+        var dto = new CreateExpensesBatchDto(periodId, userId, [MakeItem(catId)]);
+        var sut = new CreateExpensesBatchUseCase(
+            _expenseRepo.Object, _periodRepo.Object, _categoryRepo.Object, _uow.Object);
+
+        var act = () => sut.ExecuteAsync(dto);
+        await act.Should().ThrowAsync<DomainException>();
+        _uow.Verify(u => u.CommitAsync(default), Times.Never);
+    }
+}


### PR DESCRIPTION
Closes #337

## Backend
- `CreateExpensesBatchUseCase`: valida período e todas as categorias antes de persistir (rollback semântico em caso de erro)
- Endpoint `POST /api/v1/expenses/batch/create` → 201 com lista criada
- DTOs: `BatchExpenseItemDto`, `CreateExpensesBatchDto`
- Testes: 4 unit + 3 integration

## Frontend
- `BatchExpensesModalComponent`: lista de itens em memória com modo summary (desc + valor + lápis + X) e modo edição por item, botão 3D "+", rodapé com "Salvar" desabilitado sem itens, erro via MarioModal
- Botão "Adicionar em Lote" na tela de despesas (entre "+ Nova despesa" e "Personalizar"), exibe MarioModal se não há período selecionado
- `models.ts`: `BatchExpenseItemRequest`, `CreateExpensesBatchRequest`
- `api.service.ts`: `createExpensesBatch`
- Testes: 372 specs (2 novos no expenses.component.spec + 12 no batch-expenses-modal.component.spec)