### PR TITLE
[BE] Expurgo: Domain + Application

### DIFF
--- a/src/PersonalFinance.Application/Interfaces/ICsvExportService.cs
+++ b/src/PersonalFinance.Application/Interfaces/ICsvExportService.cs
@@ -1,0 +1,6 @@
+namespace PersonalFinance.Application.Interfaces;
+
+public interface ICsvExportService
+{
+    Task<string> ExportPeriodAsync(Guid periodId, Guid userId, CancellationToken ct = default);
+}

--- a/src/PersonalFinance.Application/UseCases/Financial/Purge/DeletePurgeRecordUseCase.cs
+++ b/src/PersonalFinance.Application/UseCases/Financial/Purge/DeletePurgeRecordUseCase.cs
@@ -1,0 +1,34 @@
+using PersonalFinance.Domain.Exceptions;
+using PersonalFinance.Domain.Interfaces.Repositories;
+
+namespace PersonalFinance.Application.UseCases.Financial.Purge;
+
+/// <summary>
+/// Remove um registro de expurgo pelo Id, validando o ownership do usuário.
+/// </summary>
+public sealed class DeletePurgeRecordUseCase
+{
+    private readonly IPurgeRepository _purgeRepository;
+    private readonly IUnitOfWork      _unitOfWork;
+
+    public DeletePurgeRecordUseCase(
+        IPurgeRepository purgeRepository,
+        IUnitOfWork      unitOfWork)
+    {
+        _purgeRepository = purgeRepository;
+        _unitOfWork      = unitOfWork;
+    }
+
+    public async Task ExecuteAsync(
+        Guid id,
+        Guid userId,
+        CancellationToken ct = default)
+    {
+        var record = await _purgeRepository.GetByIdAndUserAsync(id, userId, ct)
+            ?? throw new DomainException(
+                "Registro de expurgo não encontrado ou sem permissão de acesso.");
+
+        await _purgeRepository.DeleteAsync(record, ct);
+        await _unitOfWork.CommitAsync(ct);
+    }
+}

--- a/src/PersonalFinance.Application/UseCases/Financial/Purge/ExportPeriodUseCase.cs
+++ b/src/PersonalFinance.Application/UseCases/Financial/Purge/ExportPeriodUseCase.cs
@@ -1,0 +1,34 @@
+using PersonalFinance.Application.Interfaces;
+using PersonalFinance.Domain.Exceptions;
+using PersonalFinance.Domain.Interfaces.Repositories;
+
+namespace PersonalFinance.Application.UseCases.Financial.Purge;
+
+/// <summary>
+/// Exporta os dados de um período para CSV, validando o ownership antes de delegar ao serviço.
+/// </summary>
+public sealed class ExportPeriodUseCase
+{
+    private readonly IPeriodRepository  _periodRepository;
+    private readonly ICsvExportService  _csvExportService;
+
+    public ExportPeriodUseCase(
+        IPeriodRepository periodRepository,
+        ICsvExportService csvExportService)
+    {
+        _periodRepository = periodRepository;
+        _csvExportService = csvExportService;
+    }
+
+    public async Task<string> ExecuteAsync(
+        Guid periodId,
+        Guid userId,
+        CancellationToken ct = default)
+    {
+        _ = await _periodRepository.GetByIdAndUserAsync(periodId, userId, ct)
+            ?? throw new DomainException(
+                "Período não encontrado ou sem permissão de acesso.");
+
+        return await _csvExportService.ExportPeriodAsync(periodId, userId, ct);
+    }
+}

--- a/src/PersonalFinance.Application/UseCases/Financial/Purge/GetPurgeRecordsUseCase.cs
+++ b/src/PersonalFinance.Application/UseCases/Financial/Purge/GetPurgeRecordsUseCase.cs
@@ -1,0 +1,25 @@
+using PersonalFinance.Domain.Entities.Financial;
+using PersonalFinance.Domain.Interfaces.Repositories;
+
+namespace PersonalFinance.Application.UseCases.Financial.Purge;
+
+/// <summary>
+/// Retorna todos os registros de expurgo do usuário, ordenados por PurgedAt decrescente.
+/// </summary>
+public sealed class GetPurgeRecordsUseCase
+{
+    private readonly IPurgeRepository _purgeRepository;
+
+    public GetPurgeRecordsUseCase(IPurgeRepository purgeRepository)
+    {
+        _purgeRepository = purgeRepository;
+    }
+
+    public async Task<IEnumerable<PurgeRecord>> ExecuteAsync(
+        Guid userId,
+        CancellationToken ct = default)
+    {
+        var records = await _purgeRepository.GetByUserAsync(userId, ct);
+        return records.OrderByDescending(r => r.PurgedAt);
+    }
+}

--- a/src/PersonalFinance.Application/UseCases/Financial/Purge/PurgePeriodUseCase.cs
+++ b/src/PersonalFinance.Application/UseCases/Financial/Purge/PurgePeriodUseCase.cs
@@ -1,0 +1,94 @@
+using System.Text.Json;
+using PersonalFinance.Domain.Entities.Financial;
+using PersonalFinance.Domain.Exceptions;
+using PersonalFinance.Domain.Interfaces.Repositories;
+
+namespace PersonalFinance.Application.UseCases.Financial.Purge;
+
+/// <summary>
+/// Expurga um período: insere PurgeRecord com snapshot dos totais,
+/// deleta fisicamente todas as despesas, receitas e o próprio período.
+/// Tudo executado em uma única transação.
+/// </summary>
+public sealed class PurgePeriodUseCase
+{
+    private readonly IPeriodRepository  _periodRepository;
+    private readonly IExpenseRepository _expenseRepository;
+    private readonly IIncomeRepository  _incomeRepository;
+    private readonly IPurgeRepository   _purgeRepository;
+    private readonly IUnitOfWork        _unitOfWork;
+
+    public PurgePeriodUseCase(
+        IPeriodRepository  periodRepository,
+        IExpenseRepository expenseRepository,
+        IIncomeRepository  incomeRepository,
+        IPurgeRepository   purgeRepository,
+        IUnitOfWork        unitOfWork)
+    {
+        _periodRepository  = periodRepository;
+        _expenseRepository = expenseRepository;
+        _incomeRepository  = incomeRepository;
+        _purgeRepository   = purgeRepository;
+        _unitOfWork        = unitOfWork;
+    }
+
+    public async Task ExecuteAsync(
+        Guid periodId,
+        Guid userId,
+        CancellationToken ct = default)
+    {
+        var period = await _periodRepository.GetByIdAndUserAsync(periodId, userId, ct)
+            ?? throw new DomainException(
+                "Período não encontrado ou sem permissão de acesso.");
+
+        var expenses = (await _expenseRepository.GetByPeriodAsync(periodId, userId, ct)).ToList();
+        var incomes  = (await _incomeRepository.GetByPeriodAsync(periodId, userId, ct)).ToList();
+
+        var totalExpense  = expenses.Sum(e => e.Amount);
+        var totalIncome   = incomes.Sum(i => i.Amount);
+        var expenseCount  = expenses.Count;
+        var incomeCount   = incomes.Count;
+
+        // Agrupa despesas por categoria e serializa como JSON
+        string categorySummaryJson;
+        if (expenses.Count > 0)
+        {
+            var dict = expenses
+                .GroupBy(e => e.CategoryId)
+                .ToDictionary(g => g.Key, g => g.Sum(e => e.Amount));
+            categorySummaryJson = JsonSerializer.Serialize(dict);
+        }
+        else
+        {
+            categorySummaryJson = "{}";
+        }
+
+        var csvFileName = $"expurgo_{period.Year}_{period.Month:D2}.csv";
+
+        var purgeRecord = PurgeRecord.Create(
+            userId:              userId,
+            periodYear:          period.Year,
+            periodMonth:         period.Month,
+            totalIncome:         totalIncome,
+            totalExpense:        totalExpense,
+            incomeCount:         incomeCount,
+            expenseCount:        expenseCount,
+            categorySummaryJson: categorySummaryJson,
+            csvFileName:         csvFileName);
+
+        await _purgeRepository.AddAsync(purgeRecord, ct);
+
+        // Exclusão física das despesas
+        foreach (var expense in expenses)
+            await _expenseRepository.DeleteAsync(expense, ct);
+
+        // Exclusão física das receitas
+        foreach (var income in incomes)
+            await _incomeRepository.DeleteAsync(income, ct);
+
+        // Exclusão física do período
+        await _periodRepository.DeleteAsync(period, ct);
+
+        await _unitOfWork.CommitAsync(ct);
+    }
+}

--- a/src/PersonalFinance.Application/UseCases/Financial/Purge/PurgePeriodUseCase.cs
+++ b/src/PersonalFinance.Application/UseCases/Financial/Purge/PurgePeriodUseCase.cs
@@ -35,6 +35,7 @@ public sealed class PurgePeriodUseCase
     public async Task ExecuteAsync(
         Guid periodId,
         Guid userId,
+        string csvFileName,
         CancellationToken ct = default)
     {
         var period = await _periodRepository.GetByIdAndUserAsync(periodId, userId, ct)
@@ -62,8 +63,6 @@ public sealed class PurgePeriodUseCase
         {
             categorySummaryJson = "{}";
         }
-
-        var csvFileName = $"expurgo_{period.Year}_{period.Month:D2}.csv";
 
         var purgeRecord = PurgeRecord.Create(
             userId:              userId,

--- a/src/PersonalFinance.Domain/Entities/Financial/PurgeRecord.cs
+++ b/src/PersonalFinance.Domain/Entities/Financial/PurgeRecord.cs
@@ -1,0 +1,104 @@
+using PersonalFinance.Domain.Entities.Shared;
+using PersonalFinance.Domain.Exceptions;
+
+namespace PersonalFinance.Domain.Entities.Financial;
+
+/// <summary>
+/// Registro de expurgo de um período mensal.
+/// Armazena snapshot dos totais e referência ao CSV gerado antes da exclusão física.
+/// </summary>
+public sealed class PurgeRecord : EntityBase
+{
+    // ── Propriedades ──────────────────────────────────────────────────────────
+
+    /// <summary>Usuário dono do expurgo.</summary>
+    public Guid UserId { get; private set; }
+
+    /// <summary>Ano do período expurgado.</summary>
+    public short PeriodYear { get; private set; }
+
+    /// <summary>Mês do período expurgado.</summary>
+    public byte PeriodMonth { get; private set; }
+
+    /// <summary>Data/hora UTC do expurgo.</summary>
+    public DateTime PurgedAt { get; private set; }
+
+    /// <summary>Total de receitas do período expurgado.</summary>
+    public decimal TotalIncome { get; private set; }
+
+    /// <summary>Total de despesas do período expurgado.</summary>
+    public decimal TotalExpense { get; private set; }
+
+    /// <summary>Quantidade de despesas do período expurgado.</summary>
+    public int ExpenseCount { get; private set; }
+
+    /// <summary>Quantidade de receitas do período expurgado.</summary>
+    public int IncomeCount { get; private set; }
+
+    /// <summary>JSON com resumo de despesas por categoria (CategoryId → total).</summary>
+    public string CategorySummaryJson { get; private set; } = default!;
+
+    /// <summary>Nome do arquivo CSV gerado no expurgo.</summary>
+    public string CsvFileName { get; private set; } = default!;
+
+    // ── EF Core ───────────────────────────────────────────────────────────────
+    private PurgeRecord() { }
+
+    // ── Factory ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Cria um novo registro de expurgo com snapshot dos dados do período.
+    /// </summary>
+    public static PurgeRecord Create(
+        Guid userId,
+        int periodYear,
+        int periodMonth,
+        decimal totalIncome,
+        decimal totalExpense,
+        int incomeCount,
+        int expenseCount,
+        string categorySummaryJson,
+        string csvFileName)
+    {
+        if (userId == Guid.Empty)
+            throw new DomainException("O UserId do expurgo é obrigatório.");
+
+        if (periodMonth < 1 || periodMonth > 12)
+            throw new DomainException($"O mês do período é inválido: {periodMonth}. Use valores entre 1 e 12.");
+
+        if (periodYear < 2000)
+            throw new DomainException($"O ano do período é inválido: {periodYear}. Mínimo permitido: 2000.");
+
+        if (totalIncome < 0)
+            throw new DomainException("O total de receitas não pode ser negativo.");
+
+        if (totalExpense < 0)
+            throw new DomainException("O total de despesas não pode ser negativo.");
+
+        if (expenseCount < 0)
+            throw new DomainException("A quantidade de despesas não pode ser negativa.");
+
+        if (incomeCount < 0)
+            throw new DomainException("A quantidade de receitas não pode ser negativa.");
+
+        if (string.IsNullOrWhiteSpace(csvFileName))
+            throw new DomainException("O nome do arquivo CSV é obrigatório.");
+
+        if (string.IsNullOrWhiteSpace(categorySummaryJson))
+            throw new DomainException("O resumo de categorias é obrigatório.");
+
+        return new PurgeRecord
+        {
+            UserId              = userId,
+            PeriodYear          = (short)periodYear,
+            PeriodMonth         = (byte)periodMonth,
+            PurgedAt            = DateTime.UtcNow,
+            TotalIncome         = totalIncome,
+            TotalExpense        = totalExpense,
+            ExpenseCount        = expenseCount,
+            IncomeCount         = incomeCount,
+            CategorySummaryJson = categorySummaryJson,
+            CsvFileName         = csvFileName
+        };
+    }
+}

--- a/src/PersonalFinance.Domain/Interfaces/Repositories/IExpenseRepository.cs
+++ b/src/PersonalFinance.Domain/Interfaces/Repositories/IExpenseRepository.cs
@@ -37,6 +37,7 @@ public interface IExpenseRepository
 
     Task AddAsync(Expense expense, CancellationToken ct = default);
     Task UpdateAsync(Expense expense, CancellationToken ct = default);
+    Task DeleteAsync(Expense expense, CancellationToken ct = default);
     Task UpdateRangeAsync(IEnumerable<Expense> expenses, CancellationToken ct = default);
 
     Task<IEnumerable<Expense>> GetByIdsAndUserAsync(

--- a/src/PersonalFinance.Domain/Interfaces/Repositories/IIncomeRepository.cs
+++ b/src/PersonalFinance.Domain/Interfaces/Repositories/IIncomeRepository.cs
@@ -27,6 +27,6 @@ public interface IIncomeRepository
         CancellationToken ct = default);
 
     Task AddAsync(Income income, CancellationToken ct = default);
-
     Task UpdateAsync(Income income, CancellationToken ct = default);
+    Task DeleteAsync(Income income, CancellationToken ct = default);
 }

--- a/src/PersonalFinance.Domain/Interfaces/Repositories/IPeriodRepository.cs
+++ b/src/PersonalFinance.Domain/Interfaces/Repositories/IPeriodRepository.cs
@@ -22,6 +22,7 @@ public interface IPeriodRepository
 
     Task AddAsync(Period period, CancellationToken ct = default);
     Task UpdateAsync(Period period, CancellationToken ct = default);
+    Task DeleteAsync(Period period, CancellationToken ct = default);
 
     /// <summary>
     /// Retorna true se o período existir e pertencer ao usuário informado.

--- a/src/PersonalFinance.Domain/Interfaces/Repositories/IPurgeRepository.cs
+++ b/src/PersonalFinance.Domain/Interfaces/Repositories/IPurgeRepository.cs
@@ -1,0 +1,11 @@
+using PersonalFinance.Domain.Entities.Financial;
+
+namespace PersonalFinance.Domain.Interfaces.Repositories;
+
+public interface IPurgeRepository
+{
+    Task AddAsync(PurgeRecord record, CancellationToken ct = default);
+    Task<IEnumerable<PurgeRecord>> GetByUserAsync(Guid userId, CancellationToken ct = default);
+    Task<PurgeRecord?> GetByIdAndUserAsync(Guid id, Guid userId, CancellationToken ct = default);
+    Task DeleteAsync(PurgeRecord record, CancellationToken ct = default);
+}

--- a/src/PersonalFinance.Infrastructure/Persistence/Repositories/Financial/ExpenseRepository.cs
+++ b/src/PersonalFinance.Infrastructure/Persistence/Repositories/Financial/ExpenseRepository.cs
@@ -208,4 +208,10 @@ public sealed class ExpenseRepository : IExpenseRepository
 
     public async Task AddRangeAsync(IEnumerable<Expense> expenses, CancellationToken ct = default)
         => await _context.Expenses.AddRangeAsync(expenses, ct);
+
+    public Task DeleteAsync(Expense expense, CancellationToken ct = default)
+    {
+        _context.Expenses.Remove(expense);
+        return Task.CompletedTask;
+    }
 }

--- a/src/PersonalFinance.Infrastructure/Persistence/Repositories/Financial/IncomeRepository.cs
+++ b/src/PersonalFinance.Infrastructure/Persistence/Repositories/Financial/IncomeRepository.cs
@@ -80,4 +80,10 @@ public sealed class IncomeRepository : IIncomeRepository
         _context.Incomes.Update(income);
         return Task.CompletedTask;
     }
+
+    public Task DeleteAsync(Income income, CancellationToken ct = default)
+    {
+        _context.Incomes.Remove(income);
+        return Task.CompletedTask;
+    }
 }

--- a/src/PersonalFinance.Infrastructure/Persistence/Repositories/Financial/PeriodRepository.cs
+++ b/src/PersonalFinance.Infrastructure/Persistence/Repositories/Financial/PeriodRepository.cs
@@ -62,4 +62,10 @@ public sealed class PeriodRepository : IPeriodRepository
     Guid id, Guid userId, CancellationToken ct = default)
     => await _context.Periods
            .AnyAsync(p => p.Id == id && p.UserId == userId, ct);
+
+    public Task DeleteAsync(Period period, CancellationToken ct = default)
+    {
+        _context.Periods.Remove(period);
+        return Task.CompletedTask;
+    }
 }

--- a/tests/PersonalFinance.Application.Tests/Unit/Financial/DeletePurgeRecordUseCaseTests.cs
+++ b/tests/PersonalFinance.Application.Tests/Unit/Financial/DeletePurgeRecordUseCaseTests.cs
@@ -1,0 +1,90 @@
+using FluentAssertions;
+using Moq;
+using PersonalFinance.Application.UseCases.Financial.Purge;
+using PersonalFinance.Domain.Entities.Financial;
+using PersonalFinance.Domain.Exceptions;
+using PersonalFinance.Domain.Interfaces.Repositories;
+using Xunit;
+
+namespace PersonalFinance.Application.Tests.Unit.Financial;
+
+/// <summary>
+/// Testes do DeletePurgeRecordUseCase.
+/// Regras: valida ownership via GetByIdAndUserAsync; chama DeleteAsync e CommitAsync no caminho feliz;
+/// lança DomainException se registro não encontrado ou de outro usuário.
+/// </summary>
+public class DeletePurgeRecordUseCaseTests
+{
+    private readonly Mock<IPurgeRepository>   _purgeRepo = new();
+    private readonly Mock<IUnitOfWork>        _uow       = new();
+    private readonly DeletePurgeRecordUseCase _sut;
+
+    private static readonly Guid UserId   = Guid.NewGuid();
+    private static readonly Guid RecordId = Guid.NewGuid();
+
+    public DeletePurgeRecordUseCaseTests()
+    {
+        _sut = new DeletePurgeRecordUseCase(_purgeRepo.Object, _uow.Object);
+    }
+
+    private static PurgeRecord BuildRecord() =>
+        PurgeRecord.Create(
+            userId:              UserId,
+            periodYear:          2026,
+            periodMonth:         6,
+            totalIncome:         5000m,
+            totalExpense:        3000m,
+            incomeCount:         2,
+            expenseCount:        10,
+            categorySummaryJson: "{}",
+            csvFileName:         "expurgo_2026_06.csv");
+
+    // ── Caminho feliz ─────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Deve deletar o registro e commitar quando encontrado")]
+    public async Task Execute_RecordFound_ShouldDeleteAndCommit()
+    {
+        var record = BuildRecord();
+
+        _purgeRepo.Setup(r => r.GetByIdAndUserAsync(RecordId, UserId, default))
+                  .ReturnsAsync(record);
+
+        await _sut.ExecuteAsync(RecordId, UserId);
+
+        _purgeRepo.Verify(r => r.DeleteAsync(record, default), Times.Once);
+        _uow.Verify(u => u.CommitAsync(default), Times.Once);
+    }
+
+    // ── Registro não encontrado ───────────────────────────────────────────────
+
+    [Fact(DisplayName = "Deve lançar DomainException quando registro não encontrado")]
+    public async Task Execute_RecordNotFound_ShouldThrow()
+    {
+        _purgeRepo.Setup(r => r.GetByIdAndUserAsync(RecordId, UserId, default))
+                  .ReturnsAsync((PurgeRecord?)null);
+
+        var act = () => _sut.ExecuteAsync(RecordId, UserId);
+
+        await act.Should().ThrowAsync<DomainException>();
+        _purgeRepo.Verify(r => r.DeleteAsync(It.IsAny<PurgeRecord>(), default), Times.Never);
+        _uow.Verify(u => u.CommitAsync(default), Times.Never);
+    }
+
+    // ── Ownership — registro de outro usuário ─────────────────────────────────
+
+    [Fact(DisplayName = "Deve lançar DomainException quando registro pertence a outro usuário")]
+    public async Task Execute_RecordBelongsToOtherUser_ShouldThrow()
+    {
+        var otherUserId = Guid.NewGuid();
+
+        // GetByIdAndUserAsync retorna null quando userId não bate — ownership validado no repositório
+        _purgeRepo.Setup(r => r.GetByIdAndUserAsync(RecordId, otherUserId, default))
+                  .ReturnsAsync((PurgeRecord?)null);
+
+        var act = () => _sut.ExecuteAsync(RecordId, otherUserId);
+
+        await act.Should().ThrowAsync<DomainException>();
+        _purgeRepo.Verify(r => r.DeleteAsync(It.IsAny<PurgeRecord>(), default), Times.Never);
+        _uow.Verify(u => u.CommitAsync(default), Times.Never);
+    }
+}

--- a/tests/PersonalFinance.Application.Tests/Unit/Financial/ExportPeriodUseCaseTests.cs
+++ b/tests/PersonalFinance.Application.Tests/Unit/Financial/ExportPeriodUseCaseTests.cs
@@ -1,0 +1,97 @@
+using FluentAssertions;
+using Moq;
+using PersonalFinance.Application.Interfaces;
+using PersonalFinance.Application.UseCases.Financial.Purge;
+using PersonalFinance.Domain.Entities.Financial;
+using PersonalFinance.Domain.Exceptions;
+using PersonalFinance.Domain.Interfaces.Repositories;
+using Xunit;
+
+namespace PersonalFinance.Application.Tests.Unit.Financial;
+
+/// <summary>
+/// Testes do ExportPeriodUseCase.
+/// Regras: validar ownership do período; delegar exportação ao ICsvExportService; retornar resultado do serviço.
+/// </summary>
+public class ExportPeriodUseCaseTests
+{
+    private readonly Mock<IPeriodRepository> _periodRepo  = new();
+    private readonly Mock<ICsvExportService> _csvService  = new();
+    private readonly ExportPeriodUseCase     _sut;
+
+    private static readonly Guid UserId   = Guid.NewGuid();
+    private static readonly Guid PeriodId = Guid.NewGuid();
+
+    public ExportPeriodUseCaseTests()
+    {
+        _sut = new ExportPeriodUseCase(_periodRepo.Object, _csvService.Object);
+    }
+
+    // ── Caminho feliz ─────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Deve exportar período e retornar o resultado do serviço CSV")]
+    public async Task Execute_ValidPeriod_ShouldDelegateAndReturnCsvResult()
+    {
+        var period    = Period.Create(UserId, 2026, 4);
+        var csvResult = "expurgo_2026_04.csv";
+
+        _periodRepo.Setup(r => r.GetByIdAndUserAsync(PeriodId, UserId, default))
+                   .ReturnsAsync(period);
+        _csvService.Setup(s => s.ExportPeriodAsync(PeriodId, UserId, default))
+                   .ReturnsAsync(csvResult);
+
+        var result = await _sut.ExecuteAsync(PeriodId, UserId);
+
+        result.Should().Be(csvResult);
+        _csvService.Verify(s => s.ExportPeriodAsync(PeriodId, UserId, default), Times.Once);
+    }
+
+    // ── Período não encontrado ────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Deve lançar exceção quando período não encontrado")]
+    public async Task Execute_PeriodNotFound_ShouldThrow()
+    {
+        _periodRepo.Setup(r => r.GetByIdAndUserAsync(PeriodId, UserId, default))
+                   .ReturnsAsync((Period?)null);
+
+        var act = () => _sut.ExecuteAsync(PeriodId, UserId);
+
+        await act.Should().ThrowAsync<DomainException>();
+        _csvService.Verify(s => s.ExportPeriodAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), default), Times.Never);
+    }
+
+    // ── Validação de ownership ────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Não deve chamar CsvExportService se período não pertencer ao usuário")]
+    public async Task Execute_PeriodBelongsToOtherUser_ShouldThrow()
+    {
+        var otherUserId = Guid.NewGuid();
+
+        _periodRepo.Setup(r => r.GetByIdAndUserAsync(PeriodId, otherUserId, default))
+                   .ReturnsAsync((Period?)null);
+
+        var act = () => _sut.ExecuteAsync(PeriodId, otherUserId);
+
+        await act.Should().ThrowAsync<DomainException>();
+        _csvService.Verify(s => s.ExportPeriodAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), default), Times.Never);
+    }
+
+    // ── CancellationToken propagado ───────────────────────────────────────────
+
+    [Fact(DisplayName = "Deve propagar o CancellationToken ao serviço CSV")]
+    public async Task Execute_ShouldPropagateCancellationToken()
+    {
+        var cts    = new CancellationTokenSource();
+        var ct     = cts.Token;
+        var period = Period.Create(UserId, 2026, 4);
+
+        _periodRepo.Setup(r => r.GetByIdAndUserAsync(PeriodId, UserId, ct))
+                   .ReturnsAsync(period);
+        _csvService.Setup(s => s.ExportPeriodAsync(PeriodId, UserId, ct))
+                   .ReturnsAsync("file.csv");
+
+        await _sut.ExecuteAsync(PeriodId, UserId, ct);
+
+        _csvService.Verify(s => s.ExportPeriodAsync(PeriodId, UserId, ct), Times.Once);
+    }
+}

--- a/tests/PersonalFinance.Application.Tests/Unit/Financial/GetPurgeRecordsUseCaseTests.cs
+++ b/tests/PersonalFinance.Application.Tests/Unit/Financial/GetPurgeRecordsUseCaseTests.cs
@@ -1,0 +1,121 @@
+using FluentAssertions;
+using Moq;
+using PersonalFinance.Application.UseCases.Financial.Purge;
+using PersonalFinance.Domain.Entities.Financial;
+using PersonalFinance.Domain.Interfaces.Repositories;
+using Xunit;
+
+namespace PersonalFinance.Application.Tests.Unit.Financial;
+
+/// <summary>
+/// Testes do GetPurgeRecordsUseCase.
+/// Regras: filtro obrigatório por userId; ordenação decrescente por PurgedAt.
+/// </summary>
+public class GetPurgeRecordsUseCaseTests
+{
+    private readonly Mock<IPurgeRepository>  _purgeRepo = new();
+    private readonly GetPurgeRecordsUseCase  _sut;
+
+    private static readonly Guid UserId = Guid.NewGuid();
+
+    public GetPurgeRecordsUseCaseTests()
+    {
+        _sut = new GetPurgeRecordsUseCase(_purgeRepo.Object);
+    }
+
+    private static PurgeRecord BuildRecord(short year, byte month) =>
+        PurgeRecord.Create(
+            userId:              UserId,
+            periodYear:          year,
+            periodMonth:         month,
+            totalIncome:         5000m,
+            totalExpense:        3000m,
+            incomeCount:         2,
+            expenseCount:        10,
+            categorySummaryJson: "{}",
+            csvFileName:         $"expurgo_{year}_{month:D2}.csv"
+        );
+
+    // ── Caminho feliz ─────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Deve retornar registros do usuário")]
+    public async Task Execute_WithRecords_ShouldReturnAll()
+    {
+        var records = new[]
+        {
+            BuildRecord(2026, 4),
+            BuildRecord(2026, 3)
+        };
+        _purgeRepo.Setup(r => r.GetByUserAsync(UserId, default))
+                  .ReturnsAsync(records);
+
+        var result = await _sut.ExecuteAsync(UserId);
+
+        result.Should().HaveCount(2);
+    }
+
+    [Fact(DisplayName = "Deve retornar lista vazia se não houver registros")]
+    public async Task Execute_WithNoRecords_ShouldReturnEmpty()
+    {
+        _purgeRepo.Setup(r => r.GetByUserAsync(UserId, default))
+                  .ReturnsAsync(Enumerable.Empty<PurgeRecord>());
+
+        var result = await _sut.ExecuteAsync(UserId);
+
+        result.Should().BeEmpty();
+    }
+
+    // ── Filtro por userId ─────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Deve filtrar por userId — nunca retornar registros de outro usuário")]
+    public async Task Execute_ShouldFilterByUserId()
+    {
+        var userId = Guid.NewGuid();
+        _purgeRepo.Setup(r => r.GetByUserAsync(userId, default))
+                  .ReturnsAsync(Enumerable.Empty<PurgeRecord>());
+
+        await _sut.ExecuteAsync(userId);
+
+        // Deve chamar GetByUserAsync com o userId correto
+        _purgeRepo.Verify(r => r.GetByUserAsync(userId, default), Times.Once);
+        _purgeRepo.Verify(r => r.GetByUserAsync(It.IsNotIn(userId), default), Times.Never);
+    }
+
+    // ── Ordenação decrescente por PurgedAt ────────────────────────────────────
+
+    [Fact(DisplayName = "Deve retornar registros ordenados de forma decrescente por PurgedAt")]
+    public async Task Execute_WithMultipleRecords_ShouldReturnOrderedByPurgedAtDescending()
+    {
+        // O repositório mock retorna na ordem que o use case deve garantir
+        var records = new[]
+        {
+            BuildRecord(2026, 4),
+            BuildRecord(2026, 3),
+            BuildRecord(2026, 1)
+        };
+
+        _purgeRepo.Setup(r => r.GetByUserAsync(UserId, default))
+                  .ReturnsAsync(records);
+
+        var result = (await _sut.ExecuteAsync(UserId)).ToList();
+
+        // O use case deve garantir ordenação decrescente por PurgedAt
+        result.Should().BeInDescendingOrder(r => r.PurgedAt);
+    }
+
+    // ── CancellationToken propagado ───────────────────────────────────────────
+
+    [Fact(DisplayName = "Deve propagar o CancellationToken ao repositório")]
+    public async Task Execute_ShouldPropagateCancellationToken()
+    {
+        var cts = new CancellationTokenSource();
+        var ct  = cts.Token;
+
+        _purgeRepo.Setup(r => r.GetByUserAsync(UserId, ct))
+                  .ReturnsAsync(Enumerable.Empty<PurgeRecord>());
+
+        await _sut.ExecuteAsync(UserId, ct);
+
+        _purgeRepo.Verify(r => r.GetByUserAsync(UserId, ct), Times.Once);
+    }
+}

--- a/tests/PersonalFinance.Application.Tests/Unit/Financial/PurgePeriodUseCaseTests.cs
+++ b/tests/PersonalFinance.Application.Tests/Unit/Financial/PurgePeriodUseCaseTests.cs
@@ -1,0 +1,182 @@
+using FluentAssertions;
+using Moq;
+using PersonalFinance.Application.UseCases.Financial.Purge;
+using PersonalFinance.Domain.Entities.Financial;
+using PersonalFinance.Domain.Enums;
+using PersonalFinance.Domain.Exceptions;
+using PersonalFinance.Domain.Interfaces.Repositories;
+using Xunit;
+
+namespace PersonalFinance.Application.Tests.Unit.Financial;
+
+/// <summary>
+/// Testes do PurgePeriodUseCase.
+/// Regras: valida ownership; insere PurgeRecord; deleta fisicamente Incomes, Expenses e Period;
+/// tudo em transação única; rollback em falha.
+/// </summary>
+public class PurgePeriodUseCaseTests
+{
+    private readonly Mock<IPeriodRepository>  _periodRepo  = new();
+    private readonly Mock<IExpenseRepository> _expenseRepo = new();
+    private readonly Mock<IIncomeRepository>  _incomeRepo  = new();
+    private readonly Mock<IPurgeRepository>   _purgeRepo   = new();
+    private readonly Mock<IUnitOfWork>        _uow         = new();
+    private readonly PurgePeriodUseCase       _sut;
+
+    private static readonly Guid UserId     = Guid.NewGuid();
+    private static readonly Guid PeriodId   = Guid.NewGuid();
+    private static readonly Guid CategoryId = Guid.NewGuid();
+
+    public PurgePeriodUseCaseTests()
+    {
+        _sut = new PurgePeriodUseCase(
+            _periodRepo.Object,
+            _expenseRepo.Object,
+            _incomeRepo.Object,
+            _purgeRepo.Object,
+            _uow.Object);
+    }
+
+    private static Expense BuildExpense(decimal amount = 500m) =>
+        Expense.Create(PeriodId, UserId, CategoryId,
+            SourceType.Personal, FortnightType.First, PaymentStatus.Pending,
+            "Aluguel", amount, new DateOnly(2026, 4, 10), null, null);
+
+    private static Income BuildIncome(decimal amount = 3000m) =>
+        Income.Create(PeriodId, UserId, FortnightType.First,
+            "Salário", amount, new DateOnly(2026, 4, 5), null);
+
+    // ── Caminho feliz ─────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Deve criar PurgeRecord com totais corretos e deletar tudo")]
+    public async Task Execute_ValidPeriod_ShouldPurgeAndCommit()
+    {
+        var period   = Period.Create(UserId, 2026, 4);
+        var expenses = new[] { BuildExpense(500m), BuildExpense(200m) };
+        var incomes  = new[] { BuildIncome(3000m), BuildIncome(1500m) };
+
+        _periodRepo.Setup(r => r.GetByIdAndUserAsync(PeriodId, UserId, default))
+                   .ReturnsAsync(period);
+        _expenseRepo.Setup(r => r.GetByPeriodAsync(PeriodId, UserId, default))
+                    .ReturnsAsync(expenses);
+        _incomeRepo.Setup(r => r.GetByPeriodAsync(PeriodId, UserId, default))
+                   .ReturnsAsync(incomes);
+
+        await _sut.ExecuteAsync(PeriodId, UserId);
+
+        // Deve inserir 1 PurgeRecord
+        _purgeRepo.Verify(r => r.AddAsync(
+            It.Is<PurgeRecord>(pr =>
+                pr.TotalExpense   == 700m  &&
+                pr.TotalIncome    == 4500m &&
+                pr.ExpenseCount   == 2     &&
+                pr.IncomeCount    == 2     &&
+                pr.UserId         == UserId),
+            default), Times.Once);
+
+        // Deve commitar a transação
+        _uow.Verify(u => u.CommitAsync(default), Times.Once);
+    }
+
+    [Fact(DisplayName = "Deve calcular CategorySummaryJson com totais por categoria")]
+    public async Task Execute_MultipleExpenseCategories_ShouldCalculateSummaryJson()
+    {
+        var period  = Period.Create(UserId, 2026, 4);
+        var expense = BuildExpense(500m);
+
+        _periodRepo.Setup(r => r.GetByIdAndUserAsync(PeriodId, UserId, default))
+                   .ReturnsAsync(period);
+        _expenseRepo.Setup(r => r.GetByPeriodAsync(PeriodId, UserId, default))
+                    .ReturnsAsync(new[] { expense });
+        _incomeRepo.Setup(r => r.GetByPeriodAsync(PeriodId, UserId, default))
+                   .ReturnsAsync(Enumerable.Empty<Income>());
+
+        await _sut.ExecuteAsync(PeriodId, UserId);
+
+        _purgeRepo.Verify(r => r.AddAsync(
+            It.Is<PurgeRecord>(pr =>
+                !string.IsNullOrEmpty(pr.CategorySummaryJson)),
+            default), Times.Once);
+    }
+
+    [Fact(DisplayName = "Deve gerar CsvFileName com ano e mês do período")]
+    public async Task Execute_ValidPeriod_ShouldGenerateCsvFileName()
+    {
+        var period = Period.Create(UserId, 2026, 4);
+
+        _periodRepo.Setup(r => r.GetByIdAndUserAsync(PeriodId, UserId, default))
+                   .ReturnsAsync(period);
+        _expenseRepo.Setup(r => r.GetByPeriodAsync(PeriodId, UserId, default))
+                    .ReturnsAsync(Enumerable.Empty<Expense>());
+        _incomeRepo.Setup(r => r.GetByPeriodAsync(PeriodId, UserId, default))
+                   .ReturnsAsync(Enumerable.Empty<Income>());
+
+        await _sut.ExecuteAsync(PeriodId, UserId);
+
+        _purgeRepo.Verify(r => r.AddAsync(
+            It.Is<PurgeRecord>(pr =>
+                pr.CsvFileName.Contains("2026") &&
+                pr.CsvFileName.Contains("04")),
+            default), Times.Once);
+    }
+
+    // ── Período não encontrado ────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Deve lançar exceção quando período não encontrado")]
+    public async Task Execute_PeriodNotFound_ShouldThrow()
+    {
+        _periodRepo.Setup(r => r.GetByIdAndUserAsync(PeriodId, UserId, default))
+                   .ReturnsAsync((Period?)null);
+
+        var act = () => _sut.ExecuteAsync(PeriodId, UserId);
+
+        await act.Should().ThrowAsync<DomainException>();
+        _purgeRepo.Verify(r => r.AddAsync(It.IsAny<PurgeRecord>(), default), Times.Never);
+        _uow.Verify(u => u.CommitAsync(default), Times.Never);
+    }
+
+    // ── Rollback em falha ─────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Não deve commitar se AddAsync do PurgeRecord lançar exceção")]
+    public async Task Execute_PurgeRepoThrows_ShouldNotCommit()
+    {
+        var period = Period.Create(UserId, 2026, 4);
+
+        _periodRepo.Setup(r => r.GetByIdAndUserAsync(PeriodId, UserId, default))
+                   .ReturnsAsync(period);
+        _expenseRepo.Setup(r => r.GetByPeriodAsync(PeriodId, UserId, default))
+                    .ReturnsAsync(Enumerable.Empty<Expense>());
+        _incomeRepo.Setup(r => r.GetByPeriodAsync(PeriodId, UserId, default))
+                   .ReturnsAsync(Enumerable.Empty<Income>());
+        _purgeRepo.Setup(r => r.AddAsync(It.IsAny<PurgeRecord>(), default))
+                  .ThrowsAsync(new InvalidOperationException("Erro no banco"));
+
+        var act = () => _sut.ExecuteAsync(PeriodId, UserId);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        _uow.Verify(u => u.CommitAsync(default), Times.Never);
+    }
+
+    // ── Período sem lançamentos ───────────────────────────────────────────────
+
+    [Fact(DisplayName = "Deve expurgar período vazio (sem despesas e receitas)")]
+    public async Task Execute_EmptyPeriod_ShouldSucceed()
+    {
+        var period = Period.Create(UserId, 2026, 4);
+
+        _periodRepo.Setup(r => r.GetByIdAndUserAsync(PeriodId, UserId, default))
+                   .ReturnsAsync(period);
+        _expenseRepo.Setup(r => r.GetByPeriodAsync(PeriodId, UserId, default))
+                    .ReturnsAsync(Enumerable.Empty<Expense>());
+        _incomeRepo.Setup(r => r.GetByPeriodAsync(PeriodId, UserId, default))
+                   .ReturnsAsync(Enumerable.Empty<Income>());
+
+        var act = () => _sut.ExecuteAsync(PeriodId, UserId);
+
+        await act.Should().NotThrowAsync();
+        _purgeRepo.Verify(r => r.AddAsync(
+            It.Is<PurgeRecord>(pr => pr.ExpenseCount == 0 && pr.IncomeCount == 0),
+            default), Times.Once);
+        _uow.Verify(u => u.CommitAsync(default), Times.Once);
+    }
+}

--- a/tests/PersonalFinance.Application.Tests/Unit/Financial/PurgePeriodUseCaseTests.cs
+++ b/tests/PersonalFinance.Application.Tests/Unit/Financial/PurgePeriodUseCaseTests.cs
@@ -62,7 +62,7 @@ public class PurgePeriodUseCaseTests
         _incomeRepo.Setup(r => r.GetByPeriodAsync(PeriodId, UserId, default))
                    .ReturnsAsync(incomes);
 
-        await _sut.ExecuteAsync(PeriodId, UserId);
+        await _sut.ExecuteAsync(PeriodId, UserId, "expurgo_2026_04.csv");
 
         // Deve inserir 1 PurgeRecord
         _purgeRepo.Verify(r => r.AddAsync(
@@ -91,7 +91,7 @@ public class PurgePeriodUseCaseTests
         _incomeRepo.Setup(r => r.GetByPeriodAsync(PeriodId, UserId, default))
                    .ReturnsAsync(Enumerable.Empty<Income>());
 
-        await _sut.ExecuteAsync(PeriodId, UserId);
+        await _sut.ExecuteAsync(PeriodId, UserId, "expurgo_2026_04.csv");
 
         _purgeRepo.Verify(r => r.AddAsync(
             It.Is<PurgeRecord>(pr =>
@@ -99,10 +99,11 @@ public class PurgePeriodUseCaseTests
             default), Times.Once);
     }
 
-    [Fact(DisplayName = "Deve gerar CsvFileName com ano e mês do período")]
-    public async Task Execute_ValidPeriod_ShouldGenerateCsvFileName()
+    [Fact(DisplayName = "Deve armazenar CsvFileName recebido como parâmetro")]
+    public async Task Execute_ValidPeriod_ShouldStoreCsvFileName()
     {
         var period = Period.Create(UserId, 2026, 4);
+        const string csvFileName = "expurgo_2026_04.csv";
 
         _periodRepo.Setup(r => r.GetByIdAndUserAsync(PeriodId, UserId, default))
                    .ReturnsAsync(period);
@@ -111,12 +112,10 @@ public class PurgePeriodUseCaseTests
         _incomeRepo.Setup(r => r.GetByPeriodAsync(PeriodId, UserId, default))
                    .ReturnsAsync(Enumerable.Empty<Income>());
 
-        await _sut.ExecuteAsync(PeriodId, UserId);
+        await _sut.ExecuteAsync(PeriodId, UserId, csvFileName);
 
         _purgeRepo.Verify(r => r.AddAsync(
-            It.Is<PurgeRecord>(pr =>
-                pr.CsvFileName.Contains("2026") &&
-                pr.CsvFileName.Contains("04")),
+            It.Is<PurgeRecord>(pr => pr.CsvFileName == csvFileName),
             default), Times.Once);
     }
 
@@ -128,7 +127,7 @@ public class PurgePeriodUseCaseTests
         _periodRepo.Setup(r => r.GetByIdAndUserAsync(PeriodId, UserId, default))
                    .ReturnsAsync((Period?)null);
 
-        var act = () => _sut.ExecuteAsync(PeriodId, UserId);
+        var act = () => _sut.ExecuteAsync(PeriodId, UserId, "expurgo_2026_04.csv");
 
         await act.Should().ThrowAsync<DomainException>();
         _purgeRepo.Verify(r => r.AddAsync(It.IsAny<PurgeRecord>(), default), Times.Never);
@@ -151,7 +150,7 @@ public class PurgePeriodUseCaseTests
         _purgeRepo.Setup(r => r.AddAsync(It.IsAny<PurgeRecord>(), default))
                   .ThrowsAsync(new InvalidOperationException("Erro no banco"));
 
-        var act = () => _sut.ExecuteAsync(PeriodId, UserId);
+        var act = () => _sut.ExecuteAsync(PeriodId, UserId, "expurgo_2026_04.csv");
 
         await act.Should().ThrowAsync<InvalidOperationException>();
         _uow.Verify(u => u.CommitAsync(default), Times.Never);
@@ -171,7 +170,7 @@ public class PurgePeriodUseCaseTests
         _incomeRepo.Setup(r => r.GetByPeriodAsync(PeriodId, UserId, default))
                    .ReturnsAsync(Enumerable.Empty<Income>());
 
-        var act = () => _sut.ExecuteAsync(PeriodId, UserId);
+        var act = () => _sut.ExecuteAsync(PeriodId, UserId, "expurgo_2026_04.csv");
 
         await act.Should().NotThrowAsync();
         _purgeRepo.Verify(r => r.AddAsync(

--- a/tests/PersonalFinance.Domain.Tests/Unit/Financial/PurgeRecordTests.cs
+++ b/tests/PersonalFinance.Domain.Tests/Unit/Financial/PurgeRecordTests.cs
@@ -1,0 +1,301 @@
+using FluentAssertions;
+using PersonalFinance.Domain.Entities.Financial;
+using PersonalFinance.Domain.Exceptions;
+using Xunit;
+
+namespace PersonalFinance.Domain.Tests.Unit.Financial;
+
+/// <summary>
+/// Testes da entidade PurgeRecord (registro de expurgo de período).
+/// Regras: todos os campos obrigatórios; PurgedAt deve ser UTC; UserId não pode ser vazio.
+/// </summary>
+public class PurgeRecordTests
+{
+    private static readonly Guid UserId = Guid.NewGuid();
+
+    private static PurgeRecord CreateValid() => PurgeRecord.Create(
+        userId:              UserId,
+        periodYear:          (short)2026,
+        periodMonth:         (byte)4,
+        totalIncome:         5000m,
+        totalExpense:        3000m,
+        incomeCount:         2,
+        expenseCount:        10,
+        categorySummaryJson: "{\"Alimentação\":500}",
+        csvFileName:         "expurgo_2026_04.csv"
+    );
+
+    // ── Criação válida ────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Deve criar PurgeRecord com dados válidos")]
+    public void Create_WithValidData_ShouldSucceed()
+    {
+        var record = CreateValid();
+
+        record.UserId.Should().Be(UserId);
+        record.PeriodYear.Should().Be(2026);
+        record.PeriodMonth.Should().Be(4);
+        record.TotalIncome.Should().Be(5000m);
+        record.TotalExpense.Should().Be(3000m);
+        record.IncomeCount.Should().Be(2);
+        record.ExpenseCount.Should().Be(10);
+        record.CategorySummaryJson.Should().Be("{\"Alimentação\":500}");
+        record.CsvFileName.Should().Be("expurgo_2026_04.csv");
+        record.IsActive.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "PurgedAt deve ser UTC")]
+    public void Create_PurgedAt_ShouldBeUtc()
+    {
+        var record = CreateValid();
+        record.PurgedAt.Kind.Should().Be(DateTimeKind.Utc);
+    }
+
+    [Fact(DisplayName = "PurgedAt deve ser próximo do momento atual")]
+    public void Create_PurgedAt_ShouldBeNearNow()
+    {
+        var before = DateTime.UtcNow.AddSeconds(-1);
+        var record = CreateValid();
+        var after  = DateTime.UtcNow.AddSeconds(1);
+
+        record.PurgedAt.Should().BeAfter(before).And.BeBefore(after);
+    }
+
+    [Fact(DisplayName = "Id deve ser gerado automaticamente (Guid não vazio)")]
+    public void Create_Id_ShouldBeGenerated()
+    {
+        var record = CreateValid();
+        record.Id.Should().NotBeEmpty();
+    }
+
+    // ── Validação de UserId ───────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Deve lançar exceção para UserId vazio")]
+    public void Create_WithEmptyUserId_ShouldThrow()
+    {
+        var act = () => PurgeRecord.Create(
+            userId:              Guid.Empty,
+            periodYear:          2026,
+            periodMonth:         4,
+            totalIncome:         5000m,
+            totalExpense:        3000m,
+            incomeCount:         2,
+            expenseCount:        10,
+            categorySummaryJson: "{}",
+            csvFileName:         "file.csv"
+        );
+
+        act.Should().Throw<DomainException>();
+    }
+
+    // ── Validação de mês ──────────────────────────────────────────────────────
+
+    [Theory(DisplayName = "Deve lançar exceção para mês inválido")]
+    [InlineData(0)]
+    [InlineData(13)]
+    [InlineData(-1)]
+    public void Create_WithInvalidMonth_ShouldThrow(int month)
+    {
+        var act = () => PurgeRecord.Create(
+            userId:              UserId,
+            periodYear:          2026,
+            periodMonth:         month,
+            totalIncome:         5000m,
+            totalExpense:        3000m,
+            incomeCount:         2,
+            expenseCount:        10,
+            categorySummaryJson: "{}",
+            csvFileName:         "file.csv"
+        );
+
+        act.Should().Throw<DomainException>();
+    }
+
+    [Theory(DisplayName = "Deve aceitar todos os meses válidos (1–12)")]
+    [InlineData(1)]
+    [InlineData(6)]
+    [InlineData(12)]
+    public void Create_WithValidMonth_ShouldSucceed(int month)
+    {
+        var act = () => PurgeRecord.Create(
+            userId:              UserId,
+            periodYear:          2026,
+            periodMonth:         month,
+            totalIncome:         5000m,
+            totalExpense:        3000m,
+            incomeCount:         2,
+            expenseCount:        10,
+            categorySummaryJson: "{}",
+            csvFileName:         "file.csv"
+        );
+
+        act.Should().NotThrow();
+    }
+
+    // ── Validação de ano ──────────────────────────────────────────────────────
+
+    [Theory(DisplayName = "Deve lançar exceção para ano inválido")]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(1899)]
+    public void Create_WithInvalidYear_ShouldThrow(int year)
+    {
+        var act = () => PurgeRecord.Create(
+            userId:              UserId,
+            periodYear:          year,
+            periodMonth:         4,
+            totalIncome:         5000m,
+            totalExpense:        3000m,
+            incomeCount:         2,
+            expenseCount:        10,
+            categorySummaryJson: "{}",
+            csvFileName:         "file.csv"
+        );
+
+        act.Should().Throw<DomainException>();
+    }
+
+    // ── Validação de totais ───────────────────────────────────────────────────
+
+    [Theory(DisplayName = "Deve lançar exceção para TotalIncome negativo")]
+    [InlineData(-1)]
+    [InlineData(-0.01)]
+    public void Create_WithNegativeTotalIncome_ShouldThrow(double totalIncome)
+    {
+        var act = () => PurgeRecord.Create(
+            userId:              UserId,
+            periodYear:          2026,
+            periodMonth:         4,
+            totalIncome:         (decimal)totalIncome,
+            totalExpense:        3000m,
+            incomeCount:         2,
+            expenseCount:        10,
+            categorySummaryJson: "{}",
+            csvFileName:         "file.csv"
+        );
+
+        act.Should().Throw<DomainException>();
+    }
+
+    [Theory(DisplayName = "Deve lançar exceção para TotalExpense negativo")]
+    [InlineData(-1)]
+    [InlineData(-0.01)]
+    public void Create_WithNegativeTotalExpense_ShouldThrow(double totalExpense)
+    {
+        var act = () => PurgeRecord.Create(
+            userId:              UserId,
+            periodYear:          2026,
+            periodMonth:         4,
+            totalIncome:         5000m,
+            totalExpense:        (decimal)totalExpense,
+            incomeCount:         2,
+            expenseCount:        10,
+            categorySummaryJson: "{}",
+            csvFileName:         "file.csv"
+        );
+
+        act.Should().Throw<DomainException>();
+    }
+
+    [Fact(DisplayName = "Deve aceitar TotalIncome e TotalExpense zerados")]
+    public void Create_WithZeroTotals_ShouldSucceed()
+    {
+        var act = () => PurgeRecord.Create(
+            userId:              UserId,
+            periodYear:          2026,
+            periodMonth:         4,
+            totalIncome:         0m,
+            totalExpense:        0m,
+            incomeCount:         0,
+            expenseCount:        0,
+            categorySummaryJson: "{}",
+            csvFileName:         "file.csv"
+        );
+
+        act.Should().NotThrow();
+    }
+
+    // ── Validação de contagens ────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Deve lançar exceção para ExpenseCount negativo")]
+    public void Create_WithNegativeExpenseCount_ShouldThrow()
+    {
+        var act = () => PurgeRecord.Create(
+            userId:              UserId,
+            periodYear:          2026,
+            periodMonth:         4,
+            totalIncome:         5000m,
+            totalExpense:        3000m,
+            incomeCount:         2,
+            expenseCount:        -1,
+            categorySummaryJson: "{}",
+            csvFileName:         "file.csv"
+        );
+
+        act.Should().Throw<DomainException>();
+    }
+
+    [Fact(DisplayName = "Deve lançar exceção para IncomeCount negativo")]
+    public void Create_WithNegativeIncomeCount_ShouldThrow()
+    {
+        var act = () => PurgeRecord.Create(
+            userId:              UserId,
+            periodYear:          2026,
+            periodMonth:         4,
+            totalIncome:         5000m,
+            totalExpense:        3000m,
+            incomeCount:         -1,
+            expenseCount:        10,
+            categorySummaryJson: "{}",
+            csvFileName:         "file.csv"
+        );
+
+        act.Should().Throw<DomainException>();
+    }
+
+    // ── Validação de CsvFileName ──────────────────────────────────────────────
+
+    [Theory(DisplayName = "Deve lançar exceção para CsvFileName vazio ou nulo")]
+    [InlineData("")]
+    [InlineData("  ")]
+    [InlineData(null)]
+    public void Create_WithInvalidCsvFileName_ShouldThrow(string? csvFileName)
+    {
+        var act = () => PurgeRecord.Create(
+            userId:              UserId,
+            periodYear:          2026,
+            periodMonth:         4,
+            totalIncome:         5000m,
+            totalExpense:        3000m,
+            incomeCount:         2,
+            expenseCount:        10,
+            categorySummaryJson: "{}",
+            csvFileName:         csvFileName!
+        );
+
+        act.Should().Throw<DomainException>();
+    }
+
+    // ── Validação de CategorySummaryJson ─────────────────────────────────────
+
+    [Theory(DisplayName = "Deve lançar exceção para CategorySummaryJson vazio ou nulo")]
+    [InlineData("")]
+    [InlineData("  ")]
+    [InlineData(null)]
+    public void Create_WithInvalidCategorySummaryJson_ShouldThrow(string? json)
+    {
+        var act = () => PurgeRecord.Create(
+            userId:              UserId,
+            periodYear:          2026,
+            periodMonth:         4,
+            totalIncome:         5000m,
+            totalExpense:        3000m,
+            incomeCount:         2,
+            expenseCount:        10,
+            categorySummaryJson: json!,
+            csvFileName:         "file.csv"
+        );
+
+        act.Should().Throw<DomainException>();
+    }
+}


### PR DESCRIPTION
## Motivação
> Azure SQL Free Tier (32 MB) — módulo de expurgo físico de períodos antigos após exportação CSV. Sessão 1: camada Domain + Application.

## O que foi implementado
Entidade `PurgeRecord` com factory e validações, interfaces `IPurgeRepository` e `ICsvExportService`, e os use cases `ExportPeriodUseCase`, `PurgePeriodUseCase`, `GetPurgeRecordsUseCase` e `DeletePurgeRecordUseCase`. Implementado via TDD (Red → Green → correções pós-review).

## Arquivos

### Adicionados
| Arquivo | Descrição |
|---|---|
| `src/PersonalFinance.Domain/Entities/Financial/PurgeRecord.cs` | Entidade de auditoria do expurgo com 9 validações na factory |
| `src/PersonalFinance.Domain/Interfaces/Repositories/IPurgeRepository.cs` | Interface do repositório de expurgo |
| `src/PersonalFinance.Application/Interfaces/ICsvExportService.cs` | Interface de exportação CSV |
| `src/PersonalFinance.Application/UseCases/Financial/Purge/ExportPeriodUseCase.cs` | Exporta o período para CSV via ICsvExportService |
| `src/PersonalFinance.Application/UseCases/Financial/Purge/PurgePeriodUseCase.cs` | Expurgo físico: Insert PurgeRecord + DELETE Incomes + DELETE Expenses + DELETE Period em transação única |
| `src/PersonalFinance.Application/UseCases/Financial/Purge/GetPurgeRecordsUseCase.cs` | Lista registros de expurgo do usuário ordenados por data desc |
| `src/PersonalFinance.Application/UseCases/Financial/Purge/DeletePurgeRecordUseCase.cs` | Remove registro de expurgo com validação de ownership |
| `tests/PersonalFinance.Domain.Tests/Unit/Financial/PurgeRecordTests.cs` | 15 testes: factory, validações, PurgedAt UTC |
| `tests/PersonalFinance.Application.Tests/Unit/Financial/ExportPeriodUseCaseTests.cs` | 4 testes: caminho feliz, not found, ownership, CT |
| `tests/PersonalFinance.Application.Tests/Unit/Financial/PurgePeriodUseCaseTests.cs` | 6 testes: totais, CategorySummaryJson, CsvFileName, rollback |
| `tests/PersonalFinance.Application.Tests/Unit/Financial/GetPurgeRecordsUseCaseTests.cs` | 5 testes: filtro por userId, ordenação desc, lista vazia, CT |
| `tests/PersonalFinance.Application.Tests/Unit/Financial/DeletePurgeRecordUseCaseTests.cs` | 3 testes: caminho feliz, not found, ownership |

### Modificados
| Arquivo | O que mudou |
|---|---|
| `src/PersonalFinance.Domain/Interfaces/Repositories/IPeriodRepository.cs` | Adicionado `DeleteAsync` (str_replace cirúrgico) |
| `src/PersonalFinance.Domain/Interfaces/Repositories/IExpenseRepository.cs` | Adicionado `DeleteAsync` (str_replace cirúrgico) |
| `src/PersonalFinance.Domain/Interfaces/Repositories/IIncomeRepository.cs` | Adicionado `DeleteAsync` (str_replace cirúrgico) |
| Repositórios correspondentes em Infrastructure | Implementação de `DeleteAsync` com `_context.Remove()` |

## Casos de teste

### Caminho feliz
- [ ] `PurgeRecord.Create()` com dados válidos popula todas as propriedades corretamente
- [ ] `ExportPeriodUseCase` delega ao `ICsvExportService` e retorna o resultado
- [ ] `PurgePeriodUseCase` calcula totais, monta `PurgeRecord`, commita transação única
- [ ] `GetPurgeRecordsUseCase` retorna registros do usuário ordenados por `PurgedAt` desc
- [ ] `DeletePurgeRecordUseCase` remove o registro e commita

### Caminho triste
- [ ] `PurgeRecord.Create()` com `UserId` vazio → `DomainException`
- [ ] `PurgeRecord.Create()` com mês fora de 1–12 → `DomainException`
- [ ] `PurgeRecord.Create()` com `CsvFileName` vazio → `DomainException`
- [ ] `ExportPeriodUseCase` período não encontrado → `DomainException`
- [ ] `PurgePeriodUseCase` falha na transação → rollback, sem commit
- [ ] `DeletePurgeRecordUseCase` ownership inválido → `DomainException`

## Critérios de aceite
- [ ] 457 testes passando (128 Domain + 217 Application + 112 Api), 0 falhas
- [ ] `PurgePeriodUseCase.ExecuteAsync` recebe `csvFileName` como parâmetro externo
- [ ] Todas as interfaces estendidas via str_replace cirúrgico
- [ ] Nenhum arquivo de Infrastructure criado (escopo de #329)

Closes #328