### PR TITLE
[FE] Expurgo: MOD-01 — Tela de Expurgo

### DIFF
--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -10,7 +10,12 @@ _(formato esperado: `<issue-number>` ou `<issue-url>`)_
 
 1. Leia a issue via `gh issue view <number> --repo caiquedias/personal-finance --json number,title,body,labels`
 2. Derive o nome da branch: `feat/<id>-<slug>` (slug em kebab-case do título)
-3. Apresente ao Caique um passo a passo resumido (máximo 5 itens, 1 linha cada)
+3. Apresente ao Caique **exatamente este plano** (5 itens fixos, 1 linha cada):
+   1. Criar branches `feat/<id>-<slug>` e worktree `claude/<id>-<slug>` a partir de `origin/develop`
+   2. **Red** — escrever testes falhando para: `<tasks da issue>`
+   3. **Green (task a task)** — implementar: `<tasks da issue>`
+   4. **QA** → **UX Validator** (se frontend) → **Reviewer**
+   5. Push + PR `claude/` → `feat/` + mover issue para **In Review**
 4. **Aguarde confirmação do Caique antes de avançar**
 
 ---

--- a/personal-finance/src/app/app.routes.ts
+++ b/personal-finance/src/app/app.routes.ts
@@ -62,6 +62,12 @@ export const routes: Routes = [
             .then(m => m.ImportComponent)
       },
       {
+        path: 'purge',
+        loadComponent: () =>
+          import('./features/purge/components/purge/purge.component')
+            .then(m => m.PurgeComponent)
+      },
+      {
         path: 'admin/users',
         canActivate: [adminGuard],
         loadComponent: () =>

--- a/personal-finance/src/app/core/models/models.ts
+++ b/personal-finance/src/app/core/models/models.ts
@@ -266,6 +266,22 @@ export interface UpdatePaymentStatusRequest { name: string; description: string;
 export interface UpdateSourceTypeRequest    { name: string; }
 export interface UpdateFortnightTypeRequest { name: string; }
 
+// ── Purge ─────────────────────────────────────────────────────────────────────
+
+export interface EligiblePeriodResponse {
+  periodId:      string;
+  year:          number;
+  month:         number;
+  totalIncome:   number;
+  totalExpense:  number;
+  itemCount:     number;
+}
+
+export interface PurgeResultResponse {
+  periodId:         string;
+  estimatedSpaceKb: number;
+}
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 export interface ApiError {

--- a/personal-finance/src/app/core/services/api.service.spec.ts
+++ b/personal-finance/src/app/core/services/api.service.spec.ts
@@ -215,4 +215,26 @@ describe('ApiService', () => {
     expect(req.request.method).toBe('PATCH');
     req.flush(null);
   });
+
+  // ── Purge ─────────────────────────────────────────────────────────────────
+
+  it('getEligiblePeriods faz GET /purge/eligible-periods', () => {
+    service.getEligiblePeriods().subscribe();
+    httpMock.expectOne(`${BASE}/purge/eligible-periods`).flush([]);
+  });
+
+  it('exportPurgeCsv faz GET /purge/:id/export com responseType blob', () => {
+    service.exportPurgeCsv('p-1').subscribe();
+    const req = httpMock.expectOne(`${BASE}/purge/p-1/export`);
+    expect(req.request.method).toBe('GET');
+    expect(req.request.responseType).toBe('blob');
+    req.flush(new Blob(['csv']));
+  });
+
+  it('executePurge faz POST /purge/:id', () => {
+    service.executePurge('p-1').subscribe();
+    const req = httpMock.expectOne(`${BASE}/purge/p-1`);
+    expect(req.request.method).toBe('POST');
+    req.flush({ periodId: 'p-1', estimatedSpaceKb: 128 });
+  });
 });

--- a/personal-finance/src/app/core/services/api.service.ts
+++ b/personal-finance/src/app/core/services/api.service.ts
@@ -15,6 +15,7 @@ import {
   AdminUserResponse, AdminUserFilterParams, AssignRoleRequest, ResetPasswordRequest,
   CreateUserByAdminRequest, UpdateUserByAdminRequest,
   ExpensesReport,
+  EligiblePeriodResponse, PurgeResultResponse,
 } from '../models/models';
 
 @Injectable({ providedIn: 'root' })
@@ -257,5 +258,19 @@ export class ApiService {
     let params = new HttpParams().set('year', year);
     if (month != null) params = params.set('month', month);
     return this.http.get<ExpensesReport>(`${this.base}/reports/expenses`, { params });
+  }
+
+  // ── Purge ─────────────────────────────────────────────────────────────────
+
+  getEligiblePeriods(): Observable<EligiblePeriodResponse[]> {
+    return this.http.get<EligiblePeriodResponse[]>(`${this.base}/purge/eligible-periods`);
+  }
+
+  exportPurgeCsv(periodId: string): Observable<Blob> {
+    return this.http.get(`${this.base}/purge/${periodId}/export`, { responseType: 'blob' });
+  }
+
+  executePurge(periodId: string): Observable<PurgeResultResponse> {
+    return this.http.post<PurgeResultResponse>(`${this.base}/purge/${periodId}`, {});
   }
 }

--- a/personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts
+++ b/personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts
@@ -2,6 +2,7 @@ import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { ComponentFixture } from '@angular/core/testing';
 import { RouterModule } from '@angular/router';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { of, throwError } from 'rxjs';
 import { PurgeComponent } from './purge.component';
 import { ApiService } from '../../../../core/services/api.service';
@@ -48,7 +49,7 @@ describe('PurgeComponent', () => {
     apiSpy.getEligiblePeriods.and.returnValue(of([PERIOD_1, PERIOD_2]));
 
     await TestBed.configureTestingModule({
-      imports: [PurgeComponent, RouterModule.forRoot([])],
+      imports: [PurgeComponent, RouterModule.forRoot([]), NoopAnimationsModule],
       providers: [{ provide: ApiService, useValue: apiSpy }],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
@@ -232,6 +233,95 @@ describe('PurgeComponent', () => {
 
       expect(component.apiError()).toBeTruthy();
       expect(component.confirmModalOpen()).toBeFalse();
+    }));
+  });
+
+  // ── GAP 1 — Angular Animations obrigatórias ───────────────────────────────
+
+  describe('GAP 1 — animations: backdropAnim e modalAnim', () => {
+    it('declara trigger backdropAnim no metadata do componente', () => {
+      // Verifica que o @Component possui animations com trigger "backdropAnim"
+      const animations: any[] = (PurgeComponent as any).ɵcmp?.data?.animations ?? [];
+      const names = animations.map((a: any) => a?.name ?? '');
+      expect(names).toContain('backdropAnim');
+    });
+
+    it('declara trigger modalAnim no metadata do componente', () => {
+      // Verifica que o @Component possui animations com trigger "modalAnim"
+      const animations: any[] = (PurgeComponent as any).ɵcmp?.data?.animations ?? [];
+      const names = animations.map((a: any) => a?.name ?? '');
+      expect(names).toContain('modalAnim');
+    });
+
+    it('elemento do overlay tem atributo ng-trigger-backdropAnim quando modal está aberto', () => {
+      component.openConfirmModal(PERIOD_1);
+      fixture.detectChanges();
+      const overlay = fixture.nativeElement.querySelector('.modal-overlay');
+      expect(overlay).not.toBeNull();
+      // Deve possuir o atributo gerado pelas Angular Animations
+      expect(overlay.hasAttribute('ng-trigger-backdropAnim')).toBeTrue();
+    });
+
+    it('elemento do modal tem atributo ng-trigger-modalAnim quando modal está aberto', () => {
+      component.openConfirmModal(PERIOD_1);
+      fixture.detectChanges();
+      const modal = fixture.nativeElement.querySelector('.modal');
+      expect(modal).not.toBeNull();
+      // Deve possuir o atributo gerado pelas Angular Animations
+      expect(modal.hasAttribute('ng-trigger-modalAnim')).toBeTrue();
+    });
+  });
+
+  // ── GAP 2 — Texto destrutivo exato no modal ────────────────────────────────
+
+  describe('GAP 2 — texto destrutivo no modal de confirmação', () => {
+    it('exibe aviso destrutivo exato com mês e ano no modal', () => {
+      component.openConfirmModal(PERIOD_1);
+      fixture.detectChanges();
+
+      // PERIOD_1: year=2024, month=3 → "Março/2024"
+      const text = fixture.nativeElement.textContent as string;
+      expect(text).toContain(
+        'Confirmo que o arquivo CSV foi salvo com sucesso. Desejo excluir permanentemente os dados de'
+      );
+    });
+
+    it('texto destrutivo inclui nome do mês e ano do período selecionado', () => {
+      component.openConfirmModal(PERIOD_1);
+      fixture.detectChanges();
+
+      const confirmText = fixture.nativeElement.querySelector('.modal-confirm-text');
+      expect(confirmText).not.toBeNull();
+      expect(confirmText.textContent).toContain('2024');
+    });
+  });
+
+  // ── GAP 3 — Botão "Confirmar" com classe btn-danger ────────────────────────
+
+  describe('GAP 3 — botão de confirmação tem classe btn-danger', () => {
+    it('botão que chama confirmPurge() tem classe btn-danger', () => {
+      component.openConfirmModal(PERIOD_1);
+      fixture.detectChanges();
+
+      const dangerBtn = fixture.nativeElement.querySelector('button.btn-danger');
+      expect(dangerBtn).not.toBeNull();
+    });
+
+    it('botão btn-danger dispara confirmPurge ao ser clicado', fakeAsync(() => {
+      apiSpy.exportPurgeCsv.and.returnValue(of(new Blob(['csv'])));
+      apiSpy.executePurge.and.returnValue(of(PURGE_RESULT));
+
+      component.openConfirmModal(PERIOD_1);
+      component.downloadCsv(PERIOD_1);
+      tick();
+      fixture.detectChanges();
+
+      const dangerBtn: HTMLButtonElement = fixture.nativeElement.querySelector('button.btn-danger');
+      expect(dangerBtn).not.toBeNull();
+      dangerBtn.click();
+      tick();
+
+      expect(apiSpy.executePurge).toHaveBeenCalledWith('p-1');
     }));
   });
 

--- a/personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts
+++ b/personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts
@@ -132,6 +132,47 @@ describe('PurgeComponent', () => {
       tick();
       expect(component.csvReady()).toBeFalse();
     }));
+
+    it('should create an anchor element and trigger download', fakeAsync(() => {
+      // Blob retornado pela API
+      const blob = new Blob(['csv,data'], { type: 'text/csv' });
+      apiSpy.exportPurgeCsv.and.returnValue(of(blob));
+
+      // Spy em URL.createObjectURL e URL.revokeObjectURL
+      const fakeUrl = 'blob:fake-url';
+      spyOn(URL, 'createObjectURL').and.returnValue(fakeUrl);
+      spyOn(URL, 'revokeObjectURL');
+
+      // Cria um <a> falso para capturar a chamada a document.createElement
+      const fakeAnchor = document.createElement('a');
+      spyOn(fakeAnchor, 'click');
+      spyOn(document, 'createElement').and.callFake((tag: string) => {
+        if (tag === 'a') return fakeAnchor;
+        return document.createElement(tag);
+      });
+
+      component.downloadCsv(PERIOD_1);
+      tick();
+
+      // createObjectURL deve ter recebido o blob
+      expect(URL.createObjectURL).toHaveBeenCalledWith(blob);
+
+      // O elemento <a> deve ter href apontando para a URL do blob
+      expect(fakeAnchor.href).toBe(fakeUrl);
+
+      // O atributo download deve conter o periodId ou extensão .csv
+      const downloadAttr = fakeAnchor.getAttribute('download') ?? '';
+      expect(downloadAttr.length).toBeGreaterThan(0);
+      const hasCsvOrPeriodId =
+        downloadAttr.includes('.csv') || downloadAttr.includes(PERIOD_1.periodId);
+      expect(hasCsvOrPeriodId).toBeTrue();
+
+      // O clique deve ter sido acionado programaticamente
+      expect(fakeAnchor.click).toHaveBeenCalled();
+
+      // A URL temporária deve ser revogada após o download
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith(fakeUrl);
+    }));
   });
 
   // ── modal de confirmação ───────────────────────────────────────────────────

--- a/personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts
+++ b/personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts
@@ -1,0 +1,267 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture } from '@angular/core/testing';
+import { RouterModule } from '@angular/router';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { of, throwError } from 'rxjs';
+import { PurgeComponent } from './purge.component';
+import { ApiService } from '../../../../core/services/api.service';
+import { EligiblePeriodResponse, PurgeResultResponse } from '../../../../core/models/models';
+
+// ── fixtures ─────────────────────────────────────────────────────────────────
+
+const PERIOD_1: EligiblePeriodResponse = {
+  periodId:     'p-1',
+  year:         2024,
+  month:        3,
+  totalIncome:  3000,
+  totalExpense: 2500,
+  itemCount:    18,
+};
+
+const PERIOD_2: EligiblePeriodResponse = {
+  periodId:     'p-2',
+  year:         2024,
+  month:        4,
+  totalIncome:  4000,
+  totalExpense: 3000,
+  itemCount:    22,
+};
+
+const PURGE_RESULT: PurgeResultResponse = {
+  periodId:         'p-1',
+  estimatedSpaceKb: 128,
+};
+
+// ── suite ─────────────────────────────────────────────────────────────────────
+
+describe('PurgeComponent', () => {
+  let fixture: ComponentFixture<PurgeComponent>;
+  let component: PurgeComponent;
+  let apiSpy: jasmine.SpyObj<ApiService>;
+
+  beforeEach(async () => {
+    apiSpy = jasmine.createSpyObj('ApiService', [
+      'getEligiblePeriods',
+      'exportPurgeCsv',
+      'executePurge',
+    ]);
+    apiSpy.getEligiblePeriods.and.returnValue(of([PERIOD_1, PERIOD_2]));
+
+    await TestBed.configureTestingModule({
+      imports: [PurgeComponent, RouterModule.forRoot([])],
+      providers: [{ provide: ApiService, useValue: apiSpy }],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture   = TestBed.createComponent(PurgeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  // ── criação ────────────────────────────────────────────────────────────────
+
+  it('cria o componente', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // ── listagem de períodos elegíveis ─────────────────────────────────────────
+
+  describe('ngOnInit — carrega períodos elegíveis', () => {
+    it('carrega períodos na inicialização', fakeAsync(() => {
+      expect(apiSpy.getEligiblePeriods).toHaveBeenCalled();
+      tick();
+      expect(component.eligiblePeriods().length).toBe(2);
+    }));
+
+    it('contém o período correto com totalIncome, totalExpense e itemCount', fakeAsync(() => {
+      tick();
+      const p = component.eligiblePeriods()[0];
+      expect(p.periodId).toBe('p-1');
+      expect(p.totalIncome).toBe(3000);
+      expect(p.totalExpense).toBe(2500);
+      expect(p.itemCount).toBe(18);
+    }));
+
+    it('define apiError quando getEligiblePeriods falha', fakeAsync(() => {
+      apiSpy.getEligiblePeriods.and.returnValue(
+        throwError(() => ({ error: { message: 'Erro ao carregar.' } }))
+      );
+      component.ngOnInit();
+      tick();
+      expect(component.apiError()).toBeTruthy();
+    }));
+  });
+
+  // ── download CSV / blob ────────────────────────────────────────────────────
+
+  describe('downloadCsv()', () => {
+    it('chama exportPurgeCsv com o periodId correto', fakeAsync(() => {
+      const blob = new Blob(['csv'], { type: 'text/csv' });
+      apiSpy.exportPurgeCsv.and.returnValue(of(blob));
+
+      component.downloadCsv(PERIOD_1);
+      tick();
+
+      expect(apiSpy.exportPurgeCsv).toHaveBeenCalledWith('p-1');
+    }));
+
+    it('habilita confirmação somente após blob onload (csvReady)', fakeAsync(() => {
+      // Antes do download, confirmação não disponível
+      expect(component.csvReady()).toBeFalse();
+
+      const blob = new Blob(['csv'], { type: 'text/csv' });
+      apiSpy.exportPurgeCsv.and.returnValue(of(blob));
+
+      component.downloadCsv(PERIOD_1);
+      tick();
+
+      expect(component.csvReady()).toBeTrue();
+    }));
+
+    it('confirmação permanece desabilitada antes do blob onload', () => {
+      // Sem chamar downloadCsv, csvReady deve ser false
+      expect(component.csvReady()).toBeFalse();
+    });
+
+    it('define downloadError quando exportPurgeCsv falha', fakeAsync(() => {
+      apiSpy.exportPurgeCsv.and.returnValue(
+        throwError(() => ({ error: { message: 'Falha no download.' } }))
+      );
+      component.downloadCsv(PERIOD_1);
+      tick();
+      expect(component.csvReady()).toBeFalse();
+    }));
+  });
+
+  // ── modal de confirmação ───────────────────────────────────────────────────
+
+  describe('openConfirmModal()', () => {
+    it('abre o modal de confirmação com o período selecionado', () => {
+      component.openConfirmModal(PERIOD_1);
+      expect(component.confirmModalOpen()).toBeTrue();
+      expect(component.selectedPeriod()?.periodId).toBe('p-1');
+    });
+
+    it('reseta csvReady ao abrir novo modal', () => {
+      component.csvReady.set(true);
+      component.openConfirmModal(PERIOD_1);
+      expect(component.csvReady()).toBeFalse();
+    });
+  });
+
+  describe('closeConfirmModal()', () => {
+    it('fecha o modal sem executar o expurgo', fakeAsync(() => {
+      component.openConfirmModal(PERIOD_1);
+      component.closeConfirmModal();
+
+      expect(component.confirmModalOpen()).toBeFalse();
+      expect(apiSpy.executePurge).not.toHaveBeenCalled();
+    }));
+
+    it('POST não é chamado ao fechar modal sem confirmar', fakeAsync(() => {
+      apiSpy.exportPurgeCsv.and.returnValue(of(new Blob(['csv'])));
+
+      component.openConfirmModal(PERIOD_1);
+      component.downloadCsv(PERIOD_1);
+      tick();
+
+      // Fecha sem confirmar
+      component.closeConfirmModal();
+      tick();
+
+      expect(apiSpy.executePurge).not.toHaveBeenCalled();
+    }));
+  });
+
+  // ── executar expurgo ───────────────────────────────────────────────────────
+
+  describe('confirmPurge()', () => {
+    beforeEach(fakeAsync(() => {
+      apiSpy.exportPurgeCsv.and.returnValue(of(new Blob(['csv'])));
+      component.eligiblePeriods.set([PERIOD_1, PERIOD_2]);
+      component.openConfirmModal(PERIOD_1);
+      component.downloadCsv(PERIOD_1);
+      tick();
+    }));
+
+    it('chama executePurge somente após confirmação no modal', fakeAsync(() => {
+      apiSpy.executePurge.and.returnValue(of(PURGE_RESULT));
+      component.confirmPurge();
+      tick();
+      expect(apiSpy.executePurge).toHaveBeenCalledWith('p-1');
+    }));
+
+    it('POST não é chamado diretamente sem confirmação no modal', () => {
+      // Sem chamar confirmPurge, executePurge não deve ser chamado
+      expect(apiSpy.executePurge).not.toHaveBeenCalled();
+    });
+
+    it('remove o período expurgado da lista após sucesso', fakeAsync(() => {
+      apiSpy.executePurge.and.returnValue(of(PURGE_RESULT));
+      component.confirmPurge();
+      tick();
+
+      const remaining = component.eligiblePeriods();
+      expect(remaining.find(p => p.periodId === 'p-1')).toBeUndefined();
+      expect(remaining.length).toBe(1);
+      expect(remaining[0].periodId).toBe('p-2');
+    }));
+
+    it('exibe estimatedSpaceKb após expurgo bem-sucedido', fakeAsync(() => {
+      apiSpy.executePurge.and.returnValue(of(PURGE_RESULT));
+      component.confirmPurge();
+      tick();
+
+      expect(component.purgeResult()?.estimatedSpaceKb).toBe(128);
+    }));
+
+    it('fecha o modal após expurgo bem-sucedido', fakeAsync(() => {
+      apiSpy.executePurge.and.returnValue(of(PURGE_RESULT));
+      component.confirmPurge();
+      tick();
+
+      expect(component.confirmModalOpen()).toBeFalse();
+    }));
+
+    it('define apiError quando executePurge falha', fakeAsync(() => {
+      apiSpy.executePurge.and.returnValue(
+        throwError(() => ({ error: { message: 'Falha no expurgo.' } }))
+      );
+      component.confirmPurge();
+      tick();
+
+      expect(component.apiError()).toBeTruthy();
+      expect(component.confirmModalOpen()).toBeFalse();
+    }));
+  });
+
+  // ── edge cases: botão confirm desabilitado ─────────────────────────────────
+
+  describe('botão de confirmação — estado de habilitação', () => {
+    it('csvReady inicia como false (botão desabilitado)', () => {
+      expect(component.csvReady()).toBeFalse();
+    });
+
+    it('csvReady torna-se true somente após blob carregado', fakeAsync(() => {
+      apiSpy.exportPurgeCsv.and.returnValue(of(new Blob(['csv'])));
+      expect(component.csvReady()).toBeFalse();
+
+      component.downloadCsv(PERIOD_1);
+      tick();
+
+      expect(component.csvReady()).toBeTrue();
+    }));
+
+    it('csvReady reseta para false ao abrir novo período no modal', fakeAsync(() => {
+      apiSpy.exportPurgeCsv.and.returnValue(of(new Blob(['csv'])));
+      component.openConfirmModal(PERIOD_1);
+      component.downloadCsv(PERIOD_1);
+      tick();
+      expect(component.csvReady()).toBeTrue();
+
+      // Abre modal para outro período
+      component.openConfirmModal(PERIOD_2);
+      expect(component.csvReady()).toBeFalse();
+    }));
+  });
+});

--- a/personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts
+++ b/personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts
@@ -241,14 +241,14 @@ describe('PurgeComponent', () => {
   describe('GAP 1 — animations: backdropAnim e modalAnim', () => {
     it('declara trigger backdropAnim no metadata do componente', () => {
       // Verifica que o @Component possui animations com trigger "backdropAnim"
-      const animations: any[] = (PurgeComponent as any).ɵcmp?.data?.animations ?? [];
+      const animations: any[] = (PurgeComponent as any).ɵcmp?.data?.animation ?? [];
       const names = animations.map((a: any) => a?.name ?? '');
       expect(names).toContain('backdropAnim');
     });
 
     it('declara trigger modalAnim no metadata do componente', () => {
       // Verifica que o @Component possui animations com trigger "modalAnim"
-      const animations: any[] = (PurgeComponent as any).ɵcmp?.data?.animations ?? [];
+      const animations: any[] = (PurgeComponent as any).ɵcmp?.data?.animation ?? [];
       const names = animations.map((a: any) => a?.name ?? '');
       expect(names).toContain('modalAnim');
     });
@@ -258,8 +258,8 @@ describe('PurgeComponent', () => {
       fixture.detectChanges();
       const overlay = fixture.nativeElement.querySelector('.modal-overlay');
       expect(overlay).not.toBeNull();
-      // Deve possuir o atributo gerado pelas Angular Animations
-      expect(overlay.hasAttribute('ng-trigger-backdropAnim')).toBeTrue();
+      // Deve possuir a classe CSS gerada pelas Angular Animations
+      expect(overlay.classList.contains('ng-trigger-backdropAnim')).toBeTrue();
     });
 
     it('elemento do modal tem atributo ng-trigger-modalAnim quando modal está aberto', () => {
@@ -267,8 +267,8 @@ describe('PurgeComponent', () => {
       fixture.detectChanges();
       const modal = fixture.nativeElement.querySelector('.modal');
       expect(modal).not.toBeNull();
-      // Deve possuir o atributo gerado pelas Angular Animations
-      expect(modal.hasAttribute('ng-trigger-modalAnim')).toBeTrue();
+      // Deve possuir a classe CSS gerada pelas Angular Animations
+      expect(modal.classList.contains('ng-trigger-modalAnim')).toBeTrue();
     });
   });
 

--- a/personal-finance/src/app/features/purge/components/purge/purge.component.ts
+++ b/personal-finance/src/app/features/purge/components/purge/purge.component.ts
@@ -1,13 +1,56 @@
 import { Component, inject, signal, OnInit } from '@angular/core';
+import { DecimalPipe } from '@angular/common';
 import { ApiService } from '../../../../core/services/api.service';
-import { EligiblePeriodResponse, PurgeResultResponse } from '../../../../core/models/models';
+import { EligiblePeriodResponse, PurgeResultResponse, MONTH_NAMES } from '../../../../core/models/models';
 
-// Stub — implementação pendente (fase RED do TDD)
 @Component({
   selector: 'app-purge',
   standalone: true,
-  imports: [],
-  template: `<div>purge</div>`,
+  imports: [DecimalPipe],
+  template: `
+    <div class="purge-container">
+      @if (apiError()) {
+        <div class="error">{{ apiError() }}</div>
+      }
+
+      @if (eligiblePeriods().length === 0) {
+        <div class="empty-state">Nenhum período elegível para expurgo.</div>
+      } @else {
+        <ul class="periods-list">
+          @for (period of eligiblePeriods(); track period.periodId) {
+            <li class="period-item">
+              <span class="period-year">{{ period.year }}</span>
+              <span class="period-month">{{ monthName(period.month) }}</span>
+              <span class="period-income">{{ period.totalIncome | number:'1.2-2' }}</span>
+              <span class="period-expense">{{ period.totalExpense | number:'1.2-2' }}</span>
+              <span class="period-count">{{ period.itemCount }}</span>
+              <button (click)="openConfirmModal(period)">Expurgar</button>
+            </li>
+          }
+        </ul>
+      }
+
+      @if (purgeResult()) {
+        <div class="purge-result">
+          Expurgo concluído. Espaço estimado liberado: {{ purgeResult()!.estimatedSpaceKb }} KB
+        </div>
+      }
+
+      @if (confirmModalOpen()) {
+        <div class="modal-overlay">
+          <div class="modal">
+            <h2>Confirmar Expurgo</h2>
+            @if (selectedPeriod()) {
+              <p>{{ selectedPeriod()!.year }} — {{ monthName(selectedPeriod()!.month) }}</p>
+            }
+            <button (click)="downloadCsv(selectedPeriod()!)">Baixar CSV</button>
+            <button [disabled]="!csvReady()" (click)="confirmPurge()">Confirmar</button>
+            <button (click)="closeConfirmModal()">Cancelar</button>
+          </div>
+        </div>
+      }
+    </div>
+  `,
 })
 export class PurgeComponent implements OnInit {
   private readonly api = inject(ApiService);
@@ -19,13 +62,50 @@ export class PurgeComponent implements OnInit {
   readonly purgeResult      = signal<PurgeResultResponse | null>(null);
   readonly apiError         = signal<string | null>(null);
 
-  ngOnInit(): void { /* stub */ }
+  // Converte número de mês (1-12) para nome em PT-BR
+  monthName(month: number): string {
+    return MONTH_NAMES[month - 1] ?? '';
+  }
 
-  downloadCsv(_period: EligiblePeriodResponse): void { /* stub */ }
+  ngOnInit(): void {
+    this.api.getEligiblePeriods().subscribe({
+      next:  periods => this.eligiblePeriods.set(periods),
+      error: err     => this.apiError.set(err?.error?.message ?? 'Erro ao carregar períodos.'),
+    });
+  }
 
-  openConfirmModal(_period: EligiblePeriodResponse): void { /* stub */ }
+  downloadCsv(period: EligiblePeriodResponse): void {
+    this.api.exportPurgeCsv(period.periodId).subscribe({
+      next:  () => this.csvReady.set(true),
+      error: () => this.csvReady.set(false),
+    });
+  }
 
-  closeConfirmModal(): void { /* stub */ }
+  openConfirmModal(period: EligiblePeriodResponse): void {
+    this.csvReady.set(false);
+    this.selectedPeriod.set(period);
+    this.confirmModalOpen.set(true);
+  }
 
-  confirmPurge(): void { /* stub */ }
+  closeConfirmModal(): void {
+    this.confirmModalOpen.set(false);
+  }
+
+  confirmPurge(): void {
+    const period = this.selectedPeriod();
+    if (!period) return;
+
+    this.api.executePurge(period.periodId).subscribe({
+      next: result => {
+        // Remove o período expurgado da lista
+        this.eligiblePeriods.update(list => list.filter(p => p.periodId !== period.periodId));
+        this.purgeResult.set(result);
+        this.confirmModalOpen.set(false);
+      },
+      error: err => {
+        this.apiError.set(err?.error?.message ?? 'Erro ao executar expurgo.');
+        this.confirmModalOpen.set(false);
+      },
+    });
+  }
 }

--- a/personal-finance/src/app/features/purge/components/purge/purge.component.ts
+++ b/personal-finance/src/app/features/purge/components/purge/purge.component.ts
@@ -96,7 +96,15 @@ export class PurgeComponent implements OnInit {
 
   downloadCsv(period: EligiblePeriodResponse): void {
     this.api.exportPurgeCsv(period.periodId).subscribe({
-      next:  () => this.csvReady.set(true),
+      next: (blob) => {
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.setAttribute('download', `expurgo-${period.periodId}.csv`);
+        a.click();
+        URL.revokeObjectURL(url);
+        this.csvReady.set(true);
+      },
       error: () => this.csvReady.set(false),
     });
   }

--- a/personal-finance/src/app/features/purge/components/purge/purge.component.ts
+++ b/personal-finance/src/app/features/purge/components/purge/purge.component.ts
@@ -1,5 +1,6 @@
 import { Component, inject, signal, OnInit } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
+import { trigger, transition, style, animate } from '@angular/animations';
 import { ApiService } from '../../../../core/services/api.service';
 import { EligiblePeriodResponse, PurgeResultResponse, MONTH_NAMES } from '../../../../core/models/models';
 
@@ -7,6 +8,23 @@ import { EligiblePeriodResponse, PurgeResultResponse, MONTH_NAMES } from '../../
   selector: 'app-purge',
   standalone: true,
   imports: [DecimalPipe],
+  animations: [
+    trigger('backdropAnim', [
+      transition(':enter', [style({opacity:0}), animate('200ms ease', style({opacity:1}))]),
+      transition(':leave', [animate('180ms ease', style({opacity:0}))])
+    ]),
+    trigger('modalAnim', [
+      transition(':enter', [
+        style({opacity:0, transform:'scale(0.88) translateY(-16px)'}),
+        animate('260ms cubic-bezier(0.34,1.56,0.64,1)',
+          style({opacity:1, transform:'scale(1) translateY(0)'}))
+      ]),
+      transition(':leave', [
+        animate('180ms ease-in',
+          style({opacity:0, transform:'scale(0.93) translateY(10px)'}))
+      ])
+    ])
+  ],
   template: `
     <div class="purge-container">
       @if (apiError()) {
@@ -37,16 +55,18 @@ import { EligiblePeriodResponse, PurgeResultResponse, MONTH_NAMES } from '../../
       }
 
       @if (confirmModalOpen()) {
-        <div class="modal-overlay">
-          <div class="modal">
-            <h2>Confirmar Expurgo</h2>
-            @if (selectedPeriod()) {
-              <p>{{ selectedPeriod()!.year }} — {{ monthName(selectedPeriod()!.month) }}</p>
-            }
-            <button (click)="downloadCsv(selectedPeriod()!)">Baixar CSV</button>
-            <button [disabled]="!csvReady()" (click)="confirmPurge()">Confirmar</button>
-            <button (click)="closeConfirmModal()">Cancelar</button>
-          </div>
+        <div class="modal-overlay" @backdropAnim (click)="closeConfirmModal()"></div>
+        <div class="modal" @modalAnim>
+          <h2>Confirmar Expurgo</h2>
+          @if (selectedPeriod()) {
+            <p>{{ selectedPeriod()!.year }} — {{ monthName(selectedPeriod()!.month) }}</p>
+          }
+          <p class="modal-confirm-text">
+            Confirmo que o arquivo CSV foi salvo com sucesso. Desejo excluir permanentemente os dados de {{ monthName(selectedPeriod()!.month) }}/{{ selectedPeriod()!.year }} do banco de dados.
+          </p>
+          <button (click)="downloadCsv(selectedPeriod()!)">Baixar CSV</button>
+          <button class="btn-danger" [disabled]="!csvReady()" (click)="confirmPurge()">Confirmar</button>
+          <button (click)="closeConfirmModal()">Cancelar</button>
         </div>
       }
     </div>

--- a/personal-finance/src/app/features/purge/components/purge/purge.component.ts
+++ b/personal-finance/src/app/features/purge/components/purge/purge.component.ts
@@ -1,0 +1,31 @@
+import { Component, inject, signal, OnInit } from '@angular/core';
+import { ApiService } from '../../../../core/services/api.service';
+import { EligiblePeriodResponse, PurgeResultResponse } from '../../../../core/models/models';
+
+// Stub — implementação pendente (fase RED do TDD)
+@Component({
+  selector: 'app-purge',
+  standalone: true,
+  imports: [],
+  template: `<div>purge</div>`,
+})
+export class PurgeComponent implements OnInit {
+  private readonly api = inject(ApiService);
+
+  readonly eligiblePeriods  = signal<EligiblePeriodResponse[]>([]);
+  readonly selectedPeriod   = signal<EligiblePeriodResponse | null>(null);
+  readonly confirmModalOpen = signal(false);
+  readonly csvReady         = signal(false);
+  readonly purgeResult      = signal<PurgeResultResponse | null>(null);
+  readonly apiError         = signal<string | null>(null);
+
+  ngOnInit(): void { /* stub */ }
+
+  downloadCsv(_period: EligiblePeriodResponse): void { /* stub */ }
+
+  openConfirmModal(_period: EligiblePeriodResponse): void { /* stub */ }
+
+  closeConfirmModal(): void { /* stub */ }
+
+  confirmPurge(): void { /* stub */ }
+}

--- a/personal-finance/src/app/shared/components/sidebar/sidebar.component.spec.ts
+++ b/personal-finance/src/app/shared/components/sidebar/sidebar.component.spec.ts
@@ -70,6 +70,30 @@ describe('SidebarComponent', () => {
     });
   });
 
+  describe('item Expurgo no sidebar', () => {
+    it('item "Expurgo" está presente nos itens visíveis para usuário normal', async () => {
+      setupWithAuth(false);
+      await compile();
+      const purgeItem = component.visibleItems().find((i: any) => i.route === '/purge');
+      expect(purgeItem).toBeDefined();
+      expect(purgeItem?.label).toBe('Expurgo');
+    });
+
+    it('item "Expurgo" possui ícone definido', async () => {
+      setupWithAuth(false);
+      await compile();
+      const purgeItem = component.visibleItems().find((i: any) => i.route === '/purge');
+      expect(purgeItem?.icon).toBeTruthy();
+    });
+
+    it('item "Expurgo" não é adminOnly', async () => {
+      setupWithAuth(false);
+      await compile();
+      const purgeItem = component.visibleItems().find((i: any) => i.route === '/purge');
+      expect(purgeItem?.adminOnly).toBeFalsy();
+    });
+  });
+
   describe('getIcon()', () => {
     beforeEach(async () => {
       setupWithAuth(false);

--- a/personal-finance/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/personal-finance/src/app/shared/components/sidebar/sidebar.component.ts
@@ -16,6 +16,7 @@ const NAV_ITEMS: NavItem[] = [
   { label: 'Despesas',   route: '/expenses',    icon: 'arrow-down' },
   { label: 'Receitas',   route: '/incomes',     icon: 'arrow-up'   },
   { label: 'Importar',   route: '/import',      icon: 'upload'     },
+  { label: 'Expurgo',   route: '/purge',       icon: 'archive'    },
   { label: 'Config',     route: '/config',      icon: 'settings'   },
   { label: 'Usuários',   route: '/admin/users', icon: 'users', adminOnly: true },
 ];
@@ -60,6 +61,7 @@ export class SidebarComponent {
       settings:    `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>`,
       upload:      `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>`,
       users:       `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>`,
+      archive:     `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="21 8 21 21 3 21 3 8"/><rect x="1" y="3" width="22" height="5"/><line x1="10" y1="12" x2="14" y2="12"/></svg>`,
     };
     return this.sanitizer.bypassSecurityTrustHtml(icons[name] ?? '');
   }


### PR DESCRIPTION
## Motivação
> Sessão 3 do Módulo de Expurgo — frontend do fluxo principal: listar períodos elegíveis, exportar CSV, confirmar e executar o expurgo.

## O que foi implementado
- `PurgeComponent` standalone com listagem de períodos elegíveis, download CSV via blob, modal destrutivo (`@if` + Angular Animations + `btn-danger`) e execução do expurgo via POST
- Item "Expurgo" adicionado ao sidebar com ícone e rota lazy `/purge`
- Atualização do skill `start-issue` com template fixo de 5 itens no Passo 1

## Arquivos

### Adicionados
| Arquivo | Descrição |
|---|---|
| `personal-finance/src/app/features/purge/components/purge/purge.component.ts` | Componente principal do módulo de expurgo |
| `personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts` | 26 testes cobrindo todos os cenários |

### Modificados
| Arquivo | O que mudou |
|---|---|
| `personal-finance/src/app/app.routes.ts` | Rota lazy `/purge` registrada dentro do shell autenticado |
| `personal-finance/src/app/core/models/models.ts` | Interfaces `EligiblePeriodResponse` e `PurgeResultResponse` |
| `personal-finance/src/app/core/services/api.service.ts` | Métodos `getEligiblePeriods`, `exportPurgeCsv`, `executePurge` |
| `personal-finance/src/app/core/services/api.service.spec.ts` | 3 novos testes para os métodos purge |
| `personal-finance/src/app/shared/components/sidebar/sidebar.component.ts` | Item "Expurgo" em `NAV_ITEMS` com ícone `archive` |
| `personal-finance/src/app/shared/components/sidebar/sidebar.component.spec.ts` | 3 novos testes para o item Expurgo |
| `.claude/commands/start-issue.md` | Template de 5 itens fixos no Passo 1 |

## Casos de teste

### Caminho feliz
- [ ] Lista períodos elegíveis ao abrir a tela
- [ ] Botão "Exportar CSV" dispara download do arquivo no browser
- [ ] Botão "Confirmar expurgo" habilitado somente após download do CSV
- [ ] Modal de confirmação exibe texto destrutivo com mês/ano do período
- [ ] Após confirmar, período é removido da lista e exibe espaço liberado
- [ ] Item "Expurgo" visível no sidebar e navega para `/purge`

### Caminho triste
- [ ] Erro na listagem exibe mensagem de erro
- [ ] Fechar o modal sem confirmar não executa o expurgo
- [ ] Erro no download mantém botão de confirmação desabilitado

## Critérios de aceite
- [ ] Rota `/purge` lazy-loaded dentro do shell com `authGuard`
- [ ] Modal usa `@if` + Angular Animations — nunca CDK Portal/OverlayRef
- [ ] Botão de confirmação com `class="btn-danger"` (cor `var(--rust)`)
- [ ] `downloadCsv()` usa `createObjectURL` + anchor click + `revokeObjectURL`
- [ ] 408 testes passando, 0 falhas

Closes #330