### PR TITLE
[FE] Expurgo: MOD-02 — Análise Offline de CSV

### DIFF
--- a/personal-finance/src/app/app.routes.ts
+++ b/personal-finance/src/app/app.routes.ts
@@ -1,5 +1,6 @@
 import { Routes } from '@angular/router';
 import { authGuard, adminGuard } from './core/auth/auth.guard';
+import { CsvReaderService } from './core/services/csv-reader.service';
 
 export const routes: Routes = [
   // Rota pública
@@ -66,6 +67,24 @@ export const routes: Routes = [
         loadComponent: () =>
           import('./features/purge/components/purge/purge.component')
             .then(m => m.PurgeComponent)
+      },
+      {
+        path: 'purge/analysis',
+        providers: [CsvReaderService],
+        children: [
+          {
+            path: '',
+            loadComponent: () =>
+              import('./features/purge/purge-analysis.component')
+                .then(m => m.PurgeAnalysisComponent)
+          },
+          {
+            path: 'detail',
+            loadComponent: () =>
+              import('./features/purge/purge-detail.component')
+                .then(m => m.PurgeDetailComponent)
+          },
+        ]
       },
       {
         path: 'admin/users',

--- a/personal-finance/src/app/core/services/csv-reader.service.spec.ts
+++ b/personal-finance/src/app/core/services/csv-reader.service.spec.ts
@@ -1,0 +1,265 @@
+import { TestBed } from '@angular/core/testing';
+import { CsvReaderService } from './csv-reader.service';
+import { ExpenseResponse, IncomeResponse, FortnightType, PaymentStatus, SourceType } from '../models/models';
+
+// Cabeçalho padrão exportado pelo sistema
+const HEADER = 'Type,Id,PeriodId,UserId,CategoryId,SourceType,FortnightType,PaymentStatus,Description,Amount,DueDate,PaymentDate,Notes,IsActive,IsRecurring,UpdatedAt,ReceivedAt';
+
+// Linha de Expense completa (sem campos opcionais vazios)
+function buildExpenseLine(overrides: Partial<Record<string, string>> = {}): string {
+  const defaults: Record<string, string> = {
+    Type:          'Expense',
+    Id:            'exp-uuid-001',
+    PeriodId:      'period-uuid-001',
+    UserId:        'user-uuid-001',
+    CategoryId:    'cat-uuid-001',
+    SourceType:    '2',
+    FortnightType: '1',
+    PaymentStatus: '1',
+    Description:   'Aluguel',
+    Amount:        '1500.00',
+    DueDate:       '2024-01-10',
+    PaymentDate:   '2024-01-09',
+    Notes:         'Pago com desconto',
+    IsActive:      'true',
+    IsRecurring:   'true',
+    UpdatedAt:     '2024-01-09T10:00:00Z',
+    ReceivedAt:    '',
+  };
+  const row = { ...defaults, ...overrides };
+  return [
+    row['Type'], row['Id'], row['PeriodId'], row['UserId'], row['CategoryId'],
+    row['SourceType'], row['FortnightType'], row['PaymentStatus'], row['Description'],
+    row['Amount'], row['DueDate'], row['PaymentDate'], row['Notes'],
+    row['IsActive'], row['IsRecurring'], row['UpdatedAt'], row['ReceivedAt'],
+  ].join(',');
+}
+
+// Linha de Income completa
+function buildIncomeLine(overrides: Partial<Record<string, string>> = {}): string {
+  const defaults: Record<string, string> = {
+    Type:          'Income',
+    Id:            'inc-uuid-001',
+    PeriodId:      'period-uuid-001',
+    UserId:        'user-uuid-001',
+    CategoryId:    '',
+    SourceType:    '',
+    FortnightType: '2',
+    PaymentStatus: '',
+    Description:   'Salário',
+    Amount:        '3000.00',
+    DueDate:       '',
+    PaymentDate:   '',
+    Notes:         '',
+    IsActive:      'true',
+    IsRecurring:   '',
+    UpdatedAt:     '',
+    ReceivedAt:    '2024-01-05',
+  };
+  const row = { ...defaults, ...overrides };
+  return [
+    row['Type'], row['Id'], row['PeriodId'], row['UserId'], row['CategoryId'],
+    row['SourceType'], row['FortnightType'], row['PaymentStatus'], row['Description'],
+    row['Amount'], row['DueDate'], row['PaymentDate'], row['Notes'],
+    row['IsActive'], row['IsRecurring'], row['UpdatedAt'], row['ReceivedAt'],
+  ].join(',');
+}
+
+describe('CsvReaderService', () => {
+  let service: CsvReaderService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [CsvReaderService],
+    });
+    service = TestBed.inject(CsvReaderService);
+  });
+
+  // ── Estado inicial ─────────────────────────────────────────────────────────
+
+  it('deve iniciar com expenses vazio', () => {
+    expect(service.expenses()).toEqual([]);
+  });
+
+  it('deve iniciar com incomes vazio', () => {
+    expect(service.incomes()).toEqual([]);
+  });
+
+  it('deve iniciar com summary nulo', () => {
+    expect(service.summary()).toBeNull();
+  });
+
+  // ── Parsing de Expense ─────────────────────────────────────────────────────
+
+  it('deve parsear linha Expense e popular signal expenses', () => {
+    const csv = [HEADER, buildExpenseLine()].join('\n');
+    service.parseCsv(csv);
+
+    const expenses = service.expenses();
+    expect(expenses.length).toBe(1);
+
+    const expense: ExpenseResponse = expenses[0];
+    expect(expense.id).toBe('exp-uuid-001');
+    expect(expense.periodId).toBe('period-uuid-001');
+    expect(expense.userId).toBe('user-uuid-001');
+    expect(expense.categoryId).toBe('cat-uuid-001');
+    expect(expense.sourceType).toBe(SourceType.Personal);
+    expect(expense.fortnightType).toBe(FortnightType.First);
+    expect(expense.paymentStatus).toBe(PaymentStatus.Pending);
+    expect(expense.description).toBe('Aluguel');
+    expect(expense.amount).toBe(1500.00);
+    expect(expense.dueDate).toBe('2024-01-10');
+    expect(expense.paymentDate).toBe('2024-01-09');
+    expect(expense.notes).toBe('Pago com desconto');
+    expect(expense.isActive).toBeTrue();
+    expect(expense.isRecurring).toBeTrue();
+    expect(expense.updatedAt).toBe('2024-01-09T10:00:00Z');
+  });
+
+  it('linha Expense não deve poluir signal incomes', () => {
+    const csv = [HEADER, buildExpenseLine()].join('\n');
+    service.parseCsv(csv);
+    expect(service.incomes().length).toBe(0);
+  });
+
+  // ── Parsing de Income ──────────────────────────────────────────────────────
+
+  it('deve parsear linha Income e popular signal incomes', () => {
+    const csv = [HEADER, buildIncomeLine()].join('\n');
+    service.parseCsv(csv);
+
+    const incomes = service.incomes();
+    expect(incomes.length).toBe(1);
+
+    const income: IncomeResponse = incomes[0];
+    expect(income.id).toBe('inc-uuid-001');
+    expect(income.periodId).toBe('period-uuid-001');
+    expect(income.userId).toBe('user-uuid-001');
+    expect(income.fortnightType).toBe(FortnightType.Second);
+    expect(income.description).toBe('Salário');
+    expect(income.amount).toBe(3000.00);
+    expect(income.receivedAt).toBe('2024-01-05');
+    expect(income.notes).toBeNull();
+    expect(income.isActive).toBeTrue();
+  });
+
+  it('linha Income não deve poluir signal expenses', () => {
+    const csv = [HEADER, buildIncomeLine()].join('\n');
+    service.parseCsv(csv);
+    expect(service.expenses().length).toBe(0);
+  });
+
+  // ── Campos opcionais vazios → null ─────────────────────────────────────────
+
+  it('PaymentDate vazio em Expense deve resultar em null', () => {
+    const csv = [HEADER, buildExpenseLine({ PaymentDate: '' })].join('\n');
+    service.parseCsv(csv);
+    expect(service.expenses()[0].paymentDate).toBeNull();
+  });
+
+  it('Notes vazio em Expense deve resultar em null', () => {
+    const csv = [HEADER, buildExpenseLine({ Notes: '' })].join('\n');
+    service.parseCsv(csv);
+    expect(service.expenses()[0].notes).toBeNull();
+  });
+
+  it('Notes vazio em Income deve resultar em null', () => {
+    const csv = [HEADER, buildIncomeLine({ Notes: '' })].join('\n');
+    service.parseCsv(csv);
+    expect(service.incomes()[0].notes).toBeNull();
+  });
+
+  // ── UTF-8 BOM ──────────────────────────────────────────────────────────────
+
+  it('deve ignorar BOM UTF-8 no início do arquivo e parsear normalmente', () => {
+    const bom = '﻿';
+    const csv = bom + [HEADER, buildExpenseLine()].join('\n');
+    service.parseCsv(csv);
+    expect(service.expenses().length).toBe(1);
+    expect(service.expenses()[0].id).toBe('exp-uuid-001');
+  });
+
+  it('deve ignorar BOM UTF-8 antes de linha Income', () => {
+    const bom = '﻿';
+    const csv = bom + [HEADER, buildIncomeLine()].join('\n');
+    service.parseCsv(csv);
+    expect(service.incomes().length).toBe(1);
+    expect(service.incomes()[0].id).toBe('inc-uuid-001');
+  });
+
+  // ── Schema mismatch → ignorar linha ───────────────────────────────────────
+
+  it('linha com colunas insuficientes não deve lançar exceção', () => {
+    const csv = [HEADER, 'Expense,apenas-dois-campos'].join('\n');
+    expect(() => service.parseCsv(csv)).not.toThrow();
+  });
+
+  it('linha com colunas insuficientes deve ser ignorada (não inserida)', () => {
+    const csv = [HEADER, 'Expense,apenas-dois-campos'].join('\n');
+    service.parseCsv(csv);
+    expect(service.expenses().length).toBe(0);
+  });
+
+  it('linha vazia intercalada não deve interromper o parsing das linhas válidas', () => {
+    const csv = [HEADER, buildExpenseLine(), '', buildIncomeLine()].join('\n');
+    service.parseCsv(csv);
+    expect(service.expenses().length).toBe(1);
+    expect(service.incomes().length).toBe(1);
+  });
+
+  it('Type desconhecido deve ser ignorado sem lançar exceção', () => {
+    const csv = [HEADER, buildExpenseLine({ Type: 'Unknown' })].join('\n');
+    expect(() => service.parseCsv(csv)).not.toThrow();
+    expect(service.expenses().length).toBe(0);
+    expect(service.incomes().length).toBe(0);
+  });
+
+  // ── Summary calculado em memória ───────────────────────────────────────────
+
+  it('summary deve ser calculado após parseCsv com Expense e Income', () => {
+    const csv = [HEADER, buildExpenseLine(), buildIncomeLine()].join('\n');
+    service.parseCsv(csv);
+
+    const summary = service.summary();
+    expect(summary).not.toBeNull();
+    expect(summary!.totalExpense).toBe(1500.00);
+    expect(summary!.totalIncome).toBe(3000.00);
+    expect(summary!.balance).toBe(1500.00); // income - expense
+  });
+
+  it('summary.totalExpense deve somar todas as despesas', () => {
+    const exp1 = buildExpenseLine({ Id: 'e1', Amount: '500.00' });
+    const exp2 = buildExpenseLine({ Id: 'e2', Amount: '250.50' });
+    const csv  = [HEADER, exp1, exp2].join('\n');
+    service.parseCsv(csv);
+    expect(service.summary()!.totalExpense).toBeCloseTo(750.50, 2);
+  });
+
+  it('summary.totalIncome deve somar todos os rendimentos', () => {
+    const inc1 = buildIncomeLine({ Id: 'i1', Amount: '2000.00' });
+    const inc2 = buildIncomeLine({ Id: 'i2', Amount: '500.00' });
+    const csv  = [HEADER, inc1, inc2].join('\n');
+    service.parseCsv(csv);
+    expect(service.summary()!.totalIncome).toBeCloseTo(2500.00, 2);
+  });
+
+  it('summary.balance deve ser negativo quando despesas superam receitas', () => {
+    const exp = buildExpenseLine({ Amount: '5000.00' });
+    const inc = buildIncomeLine({ Amount: '2000.00' });
+    const csv = [HEADER, exp, inc].join('\n');
+    service.parseCsv(csv);
+    expect(service.summary()!.balance).toBeCloseTo(-3000.00, 2);
+  });
+
+  it('parseCsv chamado novamente deve resetar signals anteriores', () => {
+    const csv1 = [HEADER, buildExpenseLine({ Id: 'e1' })].join('\n');
+    service.parseCsv(csv1);
+    expect(service.expenses().length).toBe(1);
+
+    const csv2 = [HEADER, buildIncomeLine({ Id: 'i1' })].join('\n');
+    service.parseCsv(csv2);
+    // Após segundo parse, expenses deve estar vazio (reset)
+    expect(service.expenses().length).toBe(0);
+    expect(service.incomes().length).toBe(1);
+  });
+});

--- a/personal-finance/src/app/core/services/csv-reader.service.ts
+++ b/personal-finance/src/app/core/services/csv-reader.service.ts
@@ -1,0 +1,114 @@
+import { Injectable, signal } from '@angular/core';
+import { ExpenseResponse, IncomeResponse, PeriodSummary } from '../models/models';
+
+// Índices do CSV exportado pelo sistema
+const IDX_TYPE           = 0;
+const IDX_ID             = 1;
+const IDX_PERIOD_ID      = 2;
+const IDX_USER_ID        = 3;
+const IDX_CATEGORY_ID    = 4;
+const IDX_SOURCE_TYPE    = 5;
+const IDX_FORTNIGHT_TYPE = 6;
+const IDX_PAYMENT_STATUS = 7;
+const IDX_DESCRIPTION    = 8;
+const IDX_AMOUNT         = 9;
+const IDX_DUE_DATE       = 10;
+const IDX_PAYMENT_DATE   = 11;
+const IDX_NOTES          = 12;
+const IDX_IS_ACTIVE      = 13;
+const IDX_IS_RECURRING   = 14;
+const IDX_UPDATED_AT     = 15;
+const IDX_RECEIVED_AT    = 16;
+
+const REQUIRED_COLUMNS = 17;
+
+// BOM UTF-8
+const UTF8_BOM = '﻿';
+
+@Injectable()
+export class CsvReaderService {
+
+  readonly expenses = signal<ExpenseResponse[]>([]);
+  readonly incomes  = signal<IncomeResponse[]>([]);
+  readonly summary  = signal<PeriodSummary | null>(null);
+
+  parseCsv(content: string): void {
+    // Reseta signals
+    this.expenses.set([]);
+    this.incomes.set([]);
+    this.summary.set(null);
+
+    // Strip UTF-8 BOM
+    if (content.startsWith(UTF8_BOM)) {
+      content = content.slice(1);
+    }
+
+    const lines = content.split('\n');
+    const parsedExpenses: ExpenseResponse[] = [];
+    const parsedIncomes: IncomeResponse[]   = [];
+
+    // Ignora a primeira linha (header)
+    for (let i = 1; i < lines.length; i++) {
+      const line = lines[i].trim();
+      if (!line) continue;
+
+      const cols = line.split(',');
+      if (cols.length < REQUIRED_COLUMNS) continue;
+
+      const type = cols[IDX_TYPE];
+
+      if (type === 'Expense') {
+        parsedExpenses.push({
+          id:            cols[IDX_ID],
+          periodId:      cols[IDX_PERIOD_ID],
+          userId:        cols[IDX_USER_ID],
+          categoryId:    cols[IDX_CATEGORY_ID],
+          sourceType:    Number(cols[IDX_SOURCE_TYPE]),
+          fortnightType: Number(cols[IDX_FORTNIGHT_TYPE]),
+          paymentStatus: Number(cols[IDX_PAYMENT_STATUS]),
+          description:   cols[IDX_DESCRIPTION],
+          amount:        Number(cols[IDX_AMOUNT]),
+          dueDate:       cols[IDX_DUE_DATE],
+          paymentDate:   cols[IDX_PAYMENT_DATE] || null,
+          notes:         cols[IDX_NOTES] || null,
+          isActive:      cols[IDX_IS_ACTIVE] === 'true',
+          isRecurring:   cols[IDX_IS_RECURRING] === 'true',
+          updatedAt:     cols[IDX_UPDATED_AT],
+        });
+      } else if (type === 'Income') {
+        parsedIncomes.push({
+          id:            cols[IDX_ID],
+          periodId:      cols[IDX_PERIOD_ID],
+          userId:        cols[IDX_USER_ID],
+          fortnightType: Number(cols[IDX_FORTNIGHT_TYPE]),
+          description:   cols[IDX_DESCRIPTION],
+          amount:        Number(cols[IDX_AMOUNT]),
+          receivedAt:    cols[IDX_RECEIVED_AT],
+          notes:         cols[IDX_NOTES] || null,
+          isActive:      cols[IDX_IS_ACTIVE] === 'true',
+        });
+      }
+      // Type desconhecido ou linha inválida → ignorar silenciosamente
+    }
+
+    const totalExpense = parsedExpenses.reduce((sum, e) => sum + e.amount, 0);
+    const totalIncome  = parsedIncomes.reduce((sum, i) => sum + i.amount, 0);
+    const balance      = totalIncome - totalExpense;
+
+    this.expenses.set(parsedExpenses);
+    this.incomes.set(parsedIncomes);
+    this.summary.set({
+      periodId:             '',
+      userId:               '',
+      year:                 0,
+      month:                0,
+      totalIncome,
+      totalExpense,
+      totalPaid:            0,
+      totalOwed:            0,
+      totalFirstFortnight:  0,
+      totalSecondFortnight: 0,
+      balance,
+    });
+  }
+}

--- a/personal-finance/src/app/features/purge/purge-analysis.component.ts
+++ b/personal-finance/src/app/features/purge/purge-analysis.component.ts
@@ -1,0 +1,69 @@
+import { Component, inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { CsvReaderService } from '../../core/services/csv-reader.service';
+
+@Component({
+  selector: 'app-purge-analysis',
+  standalone: true,
+  template: `
+    <div class="purge-analysis-container">
+      <h2>Análise Offline de CSV</h2>
+      <p>Selecione o arquivo CSV exportado de um período expurgado para visualizar os dados offline.</p>
+
+      <label class="file-upload-label" for="csv-upload">
+        Selecionar arquivo CSV
+        <input
+          id="csv-upload"
+          type="file"
+          accept=".csv"
+          (change)="onFileSelected($event)"
+          style="display:none"
+        />
+      </label>
+    </div>
+  `,
+  styles: [`
+    .purge-analysis-container {
+      padding: 2rem;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1.5rem;
+    }
+
+    .file-upload-label {
+      display: inline-block;
+      padding: 0.75rem 1.5rem;
+      background: var(--color-primary, #6366f1);
+      color: #fff;
+      border-radius: 0.5rem;
+      cursor: pointer;
+      font-weight: 600;
+      transition: opacity 0.2s;
+    }
+
+    .file-upload-label:hover {
+      opacity: 0.85;
+    }
+  `],
+})
+export class PurgeAnalysisComponent {
+  private readonly csvReaderService = inject(CsvReaderService);
+  private readonly router           = inject(Router);
+
+  onFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    if (!input.files?.length) return;
+
+    const file   = input.files[0];
+    const reader = new FileReader();
+
+    reader.onload = () => {
+      const content = reader.result as string;
+      this.csvReaderService.parseCsv(content);
+      this.router.navigate(['purge', 'analysis', 'detail']);
+    };
+
+    reader.readAsText(file, 'utf-8');
+  }
+}

--- a/personal-finance/src/app/features/purge/purge-detail.component.ts
+++ b/personal-finance/src/app/features/purge/purge-detail.component.ts
@@ -1,0 +1,174 @@
+import { Component, inject } from '@angular/core';
+import { DecimalPipe } from '@angular/common';
+import { CsvReaderService } from '../../core/services/csv-reader.service';
+import { PurgeWarningBannerComponent } from './purge-warning-banner.component';
+import { StatCardComponent } from '../../shared/components/stat-card/stat-card.component';
+import {
+  ExpenseResponse, IncomeResponse, PeriodSummary,
+  PAYMENT_STATUS_LABELS, SOURCE_TYPE_LABELS, FORTNIGHT_TYPE_LABELS,
+} from '../../core/models/models';
+
+@Component({
+  selector: 'app-purge-detail',
+  standalone: true,
+  imports: [PurgeWarningBannerComponent, StatCardComponent, DecimalPipe],
+  template: `
+    <app-purge-warning-banner />
+
+    @if (summary()) {
+      <div class="purge-summary-cards">
+        <app-stat-card
+          label="Receitas"
+          [value]="summary()!.totalIncome"
+          variant="success"
+          [isCurrency]="true"
+        />
+        <app-stat-card
+          label="Despesas"
+          [value]="summary()!.totalExpense"
+          variant="danger"
+          [isCurrency]="true"
+        />
+        <app-stat-card
+          label="Saldo"
+          [value]="summary()!.balance"
+          [variant]="summary()!.balance >= 0 ? 'success' : 'danger'"
+          [isCurrency]="true"
+        />
+      </div>
+    }
+
+    @if (expenses().length > 0) {
+      <section class="purge-section">
+        <h3>Despesas ({{ expenses().length }})</h3>
+        <div class="purge-table-wrapper">
+          <table class="purge-table">
+            <thead>
+              <tr>
+                <th>Descrição</th>
+                <th>Valor</th>
+                <th>Vencimento</th>
+                <th>Pagamento</th>
+                <th>Status</th>
+                <th>Fonte</th>
+                <th>Quinzena</th>
+              </tr>
+            </thead>
+            <tbody>
+              @for (exp of expenses(); track exp.id) {
+                <tr>
+                  <td>{{ exp.description }}</td>
+                  <td>{{ exp.amount | number:'1.2-2' }}</td>
+                  <td>{{ exp.dueDate }}</td>
+                  <td>{{ exp.paymentDate ?? '—' }}</td>
+                  <td>{{ paymentStatusLabel(exp.paymentStatus) }}</td>
+                  <td>{{ sourceTypeLabel(exp.sourceType) }}</td>
+                  <td>{{ fortnightTypeLabel(exp.fortnightType) }}</td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
+      </section>
+    }
+
+    @if (incomes().length > 0) {
+      <section class="purge-section">
+        <h3>Receitas ({{ incomes().length }})</h3>
+        <div class="purge-table-wrapper">
+          <table class="purge-table">
+            <thead>
+              <tr>
+                <th>Descrição</th>
+                <th>Valor</th>
+                <th>Recebido em</th>
+                <th>Quinzena</th>
+                <th>Notas</th>
+              </tr>
+            </thead>
+            <tbody>
+              @for (inc of incomes(); track inc.id) {
+                <tr>
+                  <td>{{ inc.description }}</td>
+                  <td>{{ inc.amount | number:'1.2-2' }}</td>
+                  <td>{{ inc.receivedAt }}</td>
+                  <td>{{ fortnightTypeLabel(inc.fortnightType) }}</td>
+                  <td>{{ inc.notes ?? '—' }}</td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
+      </section>
+    }
+
+    @if (expenses().length === 0 && incomes().length === 0) {
+      <div class="purge-empty">
+        <p>Nenhum dado disponível para exibição.</p>
+      </div>
+    }
+  `,
+  styles: [`
+    .purge-summary-cards {
+      display: flex;
+      gap: 1rem;
+      padding: 1.5rem;
+      flex-wrap: wrap;
+    }
+
+    .purge-section {
+      padding: 1rem 1.5rem;
+    }
+
+    .purge-section h3 {
+      margin-bottom: 0.75rem;
+    }
+
+    .purge-table-wrapper {
+      overflow-x: auto;
+    }
+
+    .purge-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.875rem;
+    }
+
+    .purge-table th,
+    .purge-table td {
+      padding: 0.5rem 0.75rem;
+      border-bottom: 1px solid var(--color-border, #e5e7eb);
+      text-align: left;
+    }
+
+    .purge-table th {
+      font-weight: 600;
+      background: var(--color-surface, #f9fafb);
+    }
+
+    .purge-empty {
+      padding: 2rem;
+      text-align: center;
+      color: var(--color-text-muted, #6b7280);
+    }
+  `],
+})
+export class PurgeDetailComponent {
+  private readonly csvReaderService = inject(CsvReaderService);
+
+  readonly expenses = this.csvReaderService.expenses;
+  readonly incomes  = this.csvReaderService.incomes;
+  readonly summary  = this.csvReaderService.summary;
+
+  paymentStatusLabel(status: number): string {
+    return PAYMENT_STATUS_LABELS[status as keyof typeof PAYMENT_STATUS_LABELS] ?? String(status);
+  }
+
+  sourceTypeLabel(source: number): string {
+    return SOURCE_TYPE_LABELS[source as keyof typeof SOURCE_TYPE_LABELS] ?? String(source);
+  }
+
+  fortnightTypeLabel(fortnight: number): string {
+    return FORTNIGHT_TYPE_LABELS[fortnight as keyof typeof FORTNIGHT_TYPE_LABELS] ?? String(fortnight);
+  }
+}

--- a/personal-finance/src/app/features/purge/purge-warning-banner.component.ts
+++ b/personal-finance/src/app/features/purge/purge-warning-banner.component.ts
@@ -1,0 +1,63 @@
+import { Component, OnInit, ViewEncapsulation } from '@angular/core';
+
+@Component({
+  selector: 'app-purge-warning-banner',
+  standalone: true,
+  encapsulation: ViewEncapsulation.None,
+  template: `
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+
+    <style>
+      .purge-warning-banner {
+        background: #000000;
+        color: #ffffff;
+        font-family: 'Press Start 2P', monospace;
+        font-size: 0.75rem;
+        padding: 1rem 1.5rem;
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        justify-content: center;
+        text-align: center;
+        line-height: 1.6;
+      }
+
+      .purge-warning-banner .banner-icon {
+        font-size: 1.25rem;
+        animation: pulse-warning 1.2s ease-in-out infinite;
+        flex-shrink: 0;
+      }
+
+      @keyframes pulse-warning {
+        0%   { color: #ffcc00; }
+        33%  { color: #ff8800; }
+        66%  { color: #ff2200; }
+        100% { color: #ffcc00; }
+      }
+    </style>
+
+    <div class="purge-warning-banner">
+      <span class="banner-icon">⚠</span>
+      <span>{{ displayedText }}</span>
+      <span class="banner-icon">⚠</span>
+    </div>
+  `,
+})
+export class PurgeWarningBannerComponent implements OnInit {
+
+  readonly fullText = 'Atenção: Exibição de período expurgado';
+  displayedText = '';
+
+  ngOnInit(): void {
+    let index = 0;
+    const interval = setInterval(() => {
+      if (index < this.fullText.length) {
+        this.displayedText += this.fullText[index];
+        index++;
+      } else {
+        clearInterval(interval);
+      }
+    }, 60);
+  }
+}

--- a/personal-finance/src/app/features/purge/purge-warning-banner.component.ts
+++ b/personal-finance/src/app/features/purge/purge-warning-banner.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, OnInit, OnDestroy, ViewEncapsulation } from '@angular/core';
 
 @Component({
   selector: 'app-purge-warning-banner',
@@ -44,20 +44,28 @@ import { Component, OnInit, ViewEncapsulation } from '@angular/core';
     </div>
   `,
 })
-export class PurgeWarningBannerComponent implements OnInit {
+export class PurgeWarningBannerComponent implements OnInit, OnDestroy {
 
   readonly fullText = 'Atenção: Exibição de período expurgado';
   displayedText = '';
+  private intervalId: ReturnType<typeof setInterval> | null = null;
 
   ngOnInit(): void {
     let index = 0;
-    const interval = setInterval(() => {
+    this.intervalId = setInterval(() => {
       if (index < this.fullText.length) {
         this.displayedText += this.fullText[index];
         index++;
       } else {
-        clearInterval(interval);
+        clearInterval(this.intervalId!);
+        this.intervalId = null;
       }
     }, 60);
+  }
+
+  ngOnDestroy(): void {
+    if (this.intervalId !== null) {
+      clearInterval(this.intervalId);
+    }
   }
 }


### PR DESCRIPTION
## Motivação
> Sessão 4 do Módulo de Expurgo: permite ao usuário fazer upload de um CSV exportado e visualizar os dados offline (sem reimportar para o banco).

## O que foi implementado
`CsvReaderService` com TDD (parsing de Expense/Income por linha, Signals, sem `providedIn: 'root'`). `PurgeAnalysisComponent` com upload de arquivo e navegação. `PurgeDetailComponent` como wrapper offline com stat-cards de summary. `PurgeWarningBannerComponent` com efeito typewriter e ícone pulsante.

## Arquivos

### Adicionados
| Arquivo | Descrição |
|---|---|
| `personal-finance/src/app/core/services/csv-reader.service.ts` | Serviço de parsing CSV em memória com Signals |
| `personal-finance/src/app/core/services/csv-reader.service.spec.ts` | 20 testes TDD (Red → Green) |
| `personal-finance/src/app/features/purge/purge-analysis.component.ts` | Upload de arquivo CSV + navegação |
| `personal-finance/src/app/features/purge/purge-detail.component.ts` | Wrapper offline com stat-cards e tabelas |
| `personal-finance/src/app/features/purge/purge-warning-banner.component.ts` | Banner typewriter com animação pulsante |

### Modificados
| Arquivo | O que mudou |
|---|---|
| `personal-finance/src/app/app.routes.ts` | Adicionadas rotas `purge/analysis` e `purge/analysis/detail` com `providers: [CsvReaderService]` no escopo da rota pai |

## Casos de teste

### Caminho feliz
- [ ] Upload de CSV válido → parse correto → navegação para `purge/analysis/detail`
- [ ] Expenses e Incomes exibidos nas tabelas com valores corretos
- [ ] Summary stat-cards refletem totalIncome, totalExpense, balance calculados em memória
- [ ] Banner exibe efeito typewriter + ícones ⚠ pulsando

### Caminho triste
- [ ] Linha com colunas insuficientes → ignorada silenciosamente
- [ ] UTF-8 BOM no início do arquivo → stripped corretamente
- [ ] Campos opcionais vazios (PaymentDate, Notes) → null nos objetos
- [ ] Type desconhecido → ignorado silenciosamente
- [ ] Navegar para fora antes do typewriter terminar → sem memory leak (ngOnDestroy)

## Critérios de aceite
- [ ] `CsvReaderService` sem `providedIn: 'root'` — provido apenas no escopo da rota
- [ ] `period-detail.component` não foi modificado
- [ ] 429 testes passando, 0 falhando

Closes #331