### PR TITLE
feat(purge): nome do CSV inclui year e month #356

### DIFF
--- a/personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts
+++ b/personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts
@@ -645,6 +645,43 @@ describe('PurgeComponent', () => {
     }));
   });
 
+  // ── #356 — nome do arquivo CSV com year_month ────────────────────────────
+
+  describe('downloadCsv() — nome do arquivo', () => {
+    it('downloadCsv define nome do arquivo com periodId, year e month', fakeAsync(() => {
+      // Arrange
+      const blob = new Blob(['csv,data'], { type: 'text/csv' });
+      apiSpy.exportPurgeCsv.and.returnValue(of(blob));
+
+      const fakeUrl = 'blob:fake-url-year-month';
+      spyOn(URL, 'createObjectURL').and.returnValue(fakeUrl);
+      spyOn(URL, 'revokeObjectURL');
+
+      const fakeAnchor = document.createElement('a');
+      spyOn(fakeAnchor, 'click');
+      spyOn(document, 'createElement').and.callFake((tag: string) => {
+        if (tag === 'a') return fakeAnchor;
+        return document.createElement(tag);
+      });
+
+      // Act — period com periodId='p-1', year=2025, month=3
+      const period: EligiblePeriodResponse = {
+        periodId:     'p-1',
+        year:         2025,
+        month:        3,
+        totalIncome:  3000,
+        totalExpense: 2500,
+        itemCount:    18,
+      };
+      component.downloadCsv(period);
+      tick();
+
+      // Assert — nome deve ser "expurgo-p-1-2025_3.csv"
+      const downloadAttr = fakeAnchor.getAttribute('download') ?? '';
+      expect(downloadAttr).toBe('expurgo-p-1-2025_3.csv');
+    }));
+  });
+
   // ── Reviewer #356 — lógica do botão Confirmar e checkbox ──────────────────
 
   describe('Reviewer #356 — lógica do botão Confirmar e checkbox', () => {

--- a/personal-finance/src/app/features/purge/components/purge/purge.component.ts
+++ b/personal-finance/src/app/features/purge/components/purge/purge.component.ts
@@ -328,7 +328,7 @@ export class PurgeComponent implements OnInit {
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
         a.href = url;
-        a.setAttribute('download', `expurgo-${period.periodId}.csv`);
+        a.setAttribute('download', `expurgo-${period.periodId}-${period.year}_${period.month}.csv`);
         a.click();
         URL.revokeObjectURL(url);
         this.purgeConfirmed.set(true);


### PR DESCRIPTION
## Motivação
O arquivo exportado saía como `expurgo-<periodId>.csv`, sem identificação do período. A melhoria torna o nome autoexplicativo para o usuário.

## O que foi implementado
Nome do arquivo CSV alterado para `expurgo-<periodId>-<year>_<month>.csv` (ex: `expurgo-abc123-2025_3.csv`). `year` e `month` já estavam disponíveis no objeto `EligiblePeriodResponse` recebido pelo método `downloadCsv`.

## Arquivos

### Modificados
| Arquivo | O que mudou |
|---|---|
| `personal-finance/src/app/features/purge/components/purge/purge.component.ts` | Atributo `download` do link inclui `year` e `month` |
| `personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts` | 1 teste verifica o novo formato do nome |

## Casos de teste

### Caminho feliz
- [ ] CSV baixado com nome `expurgo-<periodId>-<year>_<month>.csv`

## Critérios de aceite
- [ ] 453 specs FE passando

Closes #356