### PR TITLE
fix(purge): envia csvFileName no body do expurgo #356

### DIFF
--- a/personal-finance/src/app/core/services/api.service.spec.ts
+++ b/personal-finance/src/app/core/services/api.service.spec.ts
@@ -232,7 +232,7 @@ describe('ApiService', () => {
   });
 
   it('executePurge faz POST /purge/:id', () => {
-    service.executePurge('p-1').subscribe();
+    service.executePurge('p-1', 'expurgo-p-1-2024_3.csv').subscribe();
     const req = httpMock.expectOne(`${BASE}/purge/p-1`);
     expect(req.request.method).toBe('POST');
     req.flush({ periodId: 'p-1', estimatedSpaceKb: 128 });

--- a/personal-finance/src/app/core/services/api.service.spec.ts
+++ b/personal-finance/src/app/core/services/api.service.spec.ts
@@ -237,4 +237,15 @@ describe('ApiService', () => {
     expect(req.request.method).toBe('POST');
     req.flush({ periodId: 'p-1', estimatedSpaceKb: 128 });
   });
+
+  // ── #356 RED — executePurge deve enviar csvFileName no body ──────────────
+
+  it('executePurge envia body com csvFileName', () => {
+    // Cast necessário pois a assinatura atual ainda não aceita 2 argumentos (RED)
+    (service.executePurge as (id: string, csv: string) => any)('p-1', 'expurgo-p-1-2025_3.csv').subscribe();
+    const req = httpMock.expectOne(`${BASE}/purge/p-1`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ csvFileName: 'expurgo-p-1-2025_3.csv' });
+    req.flush({ periodId: 'p-1', estimatedSpaceKb: 128 });
+  });
 });

--- a/personal-finance/src/app/core/services/api.service.ts
+++ b/personal-finance/src/app/core/services/api.service.ts
@@ -270,8 +270,8 @@ export class ApiService {
     return this.http.get(`${this.base}/purge/${periodId}/export`, { responseType: 'blob' });
   }
 
-  executePurge(periodId: string): Observable<PurgeResultResponse> {
-    return this.http.post<PurgeResultResponse>(`${this.base}/purge/${periodId}`, {});
+  executePurge(periodId: string, csvFileName: string): Observable<PurgeResultResponse> {
+    return this.http.post<PurgeResultResponse>(`${this.base}/purge/${periodId}`, { csvFileName });
   }
 
   getPurgeRecords(): Observable<PurgeRecordResponse[]> {

--- a/personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts
+++ b/personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts
@@ -247,7 +247,7 @@ describe('PurgeComponent', () => {
       apiSpy.executePurge.and.returnValue(of(PURGE_RESULT));
       component.confirmPurge();
       tick();
-      expect(apiSpy.executePurge).toHaveBeenCalledWith('p-1');
+      expect(apiSpy.executePurge).toHaveBeenCalledWith('p-1', 'expurgo-p-1-2024_3.csv');
     }));
 
     it('POST não é chamado diretamente sem confirmação no modal', () => {
@@ -391,7 +391,7 @@ describe('PurgeComponent', () => {
       dangerBtn.click();
       tick();
 
-      expect(apiSpy.executePurge).toHaveBeenCalledWith('p-1');
+      expect(apiSpy.executePurge).toHaveBeenCalledWith('p-1', 'expurgo-p-1-2024_3.csv');
     }));
   });
 

--- a/personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts
+++ b/personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts
@@ -645,6 +645,47 @@ describe('PurgeComponent', () => {
     }));
   });
 
+  // ── #356 RED — confirmPurge envia csvFileName no body ────────────────────
+
+  describe('#356 RED — confirmPurge envia csvFileName', () => {
+    it('confirmPurge envia csvFileName no formato correto', fakeAsync(() => {
+      // Arrange: período com periodId='p-1', year=2025, month=3
+      const period: EligiblePeriodResponse = {
+        periodId:     'p-1',
+        year:         2025,
+        month:        3,
+        totalIncome:  3000,
+        totalExpense: 2500,
+        itemCount:    18,
+      };
+
+      const blob = new Blob(['csv'], { type: 'text/csv' });
+      apiSpy.exportPurgeCsv.and.returnValue(of(blob));
+      apiSpy.executePurge.and.returnValue(of(PURGE_RESULT));
+
+      spyOn(URL, 'createObjectURL').and.returnValue('blob:fake');
+      spyOn(URL, 'revokeObjectURL');
+      const fakeAnchor = document.createElement('a');
+      spyOn(fakeAnchor, 'click');
+      spyOn(document, 'createElement').and.callFake((tag: string) => {
+        if (tag === 'a') return fakeAnchor;
+        return document.createElement(tag);
+      });
+
+      component.openConfirmModal(period);
+      component.downloadCsv(period);
+      tick();
+
+      // Act
+      component.confirmPurge();
+      tick();
+
+      // Assert: executePurge chamado com ('p-1', 'expurgo-p-1-2025_3.csv')
+      // Cast necessário pois a assinatura atual ainda não aceita 2 argumentos (RED)
+      expect(apiSpy.executePurge as jasmine.Spy).toHaveBeenCalledWith('p-1', 'expurgo-p-1-2025_3.csv');
+    }));
+  });
+
   // ── #356 — nome do arquivo CSV com year_month ────────────────────────────
 
   describe('downloadCsv() — nome do arquivo', () => {

--- a/personal-finance/src/app/features/purge/components/purge/purge.component.ts
+++ b/personal-finance/src/app/features/purge/components/purge/purge.component.ts
@@ -351,7 +351,8 @@ export class PurgeComponent implements OnInit {
     const period = this.selectedPeriod();
     if (!period) return;
 
-    this.api.executePurge(period.periodId).subscribe({
+    const csvFileName = `expurgo-${period.periodId}-${period.year}_${period.month}.csv`;
+    this.api.executePurge(period.periodId, csvFileName).subscribe({
       next: result => {
         // Remove o período expurgado da lista e recarrega os registros de expurgo
         this.eligiblePeriods.update(list => list.filter(p => p.periodId !== period.periodId));


### PR DESCRIPTION
## Motivação
Clicar em "Expurgar" retornava 400 com `CsvFileName field is required` porque o frontend enviava body vazio `{}`. O backend requer o nome do CSV no `PurgeRequestDto` para armazenar no histórico de expurgos.

## O que foi implementado
- `ApiService.executePurge()` recebe `csvFileName` como segundo parâmetro e o envia no body do POST
- `PurgeComponent.confirmPurge()` constrói o nome no padrão `expurgo-{periodId}-{year}_{month}.csv` e o passa ao serviço

## Arquivos

### Modificados
| Arquivo | O que mudou |
|---|---|
| `personal-finance/src/app/core/services/api.service.ts` | `executePurge(periodId, csvFileName)` — body inclui `csvFileName` |
| `personal-finance/src/app/features/purge/components/purge/purge.component.ts` | `confirmPurge()` constrói e passa `csvFileName` |
| `personal-finance/src/app/core/services/api.service.spec.ts` | Teste atualizado com segundo argumento |
| `personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts` | 1 teste Red + testes existentes atualizados |

## Casos de teste

### Caminho feliz
- [ ] Clicar em "Expurgar" executa sem erro 400
- [ ] `CsvFileName` no histórico corresponde ao arquivo baixado

## Critérios de aceite
- [ ] 455 specs FE passando

Closes #356