### PR TITLE
fix(purge): corrige parser CSV Análise Detalhe — 12 colunas + aspas + enums

### DIFF
--- a/personal-finance/src/app/core/services/csv-reader.service.spec.ts
+++ b/personal-finance/src/app/core/services/csv-reader.service.spec.ts
@@ -292,4 +292,24 @@ describe('CsvReaderService', () => {
     service.parseCsv(csv);
     expect(service.expenses()[0].sourceType).toBe(SourceType.Parental);
   });
+
+  // ── Fallback para enum string inválida ────────────────────────────────────
+
+  it('FortnightType string inválida deve resultar em FortnightType.First (fallback)', () => {
+    const csv = [HEADER, buildExpenseLine({ FortnightType: 'Invalid' })].join('\n');
+    service.parseCsv(csv);
+    expect(service.expenses()[0].fortnightType).toBe(FortnightType.First);
+  });
+
+  it('PaymentStatus string inválida deve resultar em PaymentStatus.Pending (fallback)', () => {
+    const csv = [HEADER, buildExpenseLine({ PaymentStatus: 'Invalid' })].join('\n');
+    service.parseCsv(csv);
+    expect(service.expenses()[0].paymentStatus).toBe(PaymentStatus.Pending);
+  });
+
+  it('SourceType string inválida deve resultar em SourceType.Personal (fallback)', () => {
+    const csv = [HEADER, buildExpenseLine({ SourceType: 'Invalid' })].join('\n');
+    service.parseCsv(csv);
+    expect(service.expenses()[0].sourceType).toBe(SourceType.Personal);
+  });
 });

--- a/personal-finance/src/app/core/services/csv-reader.service.spec.ts
+++ b/personal-finance/src/app/core/services/csv-reader.service.spec.ts
@@ -2,66 +2,54 @@ import { TestBed } from '@angular/core/testing';
 import { CsvReaderService } from './csv-reader.service';
 import { ExpenseResponse, IncomeResponse, FortnightType, PaymentStatus, SourceType } from '../models/models';
 
-// Cabeçalho padrão exportado pelo sistema
-const HEADER = 'Type,Id,PeriodId,UserId,CategoryId,SourceType,FortnightType,PaymentStatus,Description,Amount,DueDate,PaymentDate,Notes,IsActive,IsRecurring,UpdatedAt,ReceivedAt';
+// Cabeçalho exportado pelo CsvExportService (12 colunas)
+const HEADER = 'Type,PeriodYear,PeriodMonth,Description,Amount,Category,FortnightType,PaymentStatus,SourceType,DueDate,PaymentDate,Notes';
 
-// Linha de Expense completa (sem campos opcionais vazios)
+// Linha de Expense completa com 12 colunas; enums como strings
 function buildExpenseLine(overrides: Partial<Record<string, string>> = {}): string {
   const defaults: Record<string, string> = {
     Type:          'Expense',
-    Id:            'exp-uuid-001',
-    PeriodId:      'period-uuid-001',
-    UserId:        'user-uuid-001',
-    CategoryId:    'cat-uuid-001',
-    SourceType:    '2',
-    FortnightType: '1',
-    PaymentStatus: '1',
+    PeriodYear:    '2024',
+    PeriodMonth:   '1',
     Description:   'Aluguel',
     Amount:        '1500.00',
+    Category:      '',
+    FortnightType: 'First',
+    PaymentStatus: 'Pending',
+    SourceType:    'Personal',
     DueDate:       '2024-01-10',
     PaymentDate:   '2024-01-09',
     Notes:         'Pago com desconto',
-    IsActive:      'true',
-    IsRecurring:   'true',
-    UpdatedAt:     '2024-01-09T10:00:00Z',
-    ReceivedAt:    '',
   };
   const row = { ...defaults, ...overrides };
   return [
-    row['Type'], row['Id'], row['PeriodId'], row['UserId'], row['CategoryId'],
-    row['SourceType'], row['FortnightType'], row['PaymentStatus'], row['Description'],
-    row['Amount'], row['DueDate'], row['PaymentDate'], row['Notes'],
-    row['IsActive'], row['IsRecurring'], row['UpdatedAt'], row['ReceivedAt'],
+    row['Type'], row['PeriodYear'], row['PeriodMonth'], row['Description'],
+    row['Amount'], row['Category'], row['FortnightType'], row['PaymentStatus'],
+    row['SourceType'], row['DueDate'], row['PaymentDate'], row['Notes'],
   ].join(',');
 }
 
-// Linha de Income completa
+// Linha de Income com 12 colunas; colunas específicas de Expense ficam vazias
 function buildIncomeLine(overrides: Partial<Record<string, string>> = {}): string {
   const defaults: Record<string, string> = {
     Type:          'Income',
-    Id:            'inc-uuid-001',
-    PeriodId:      'period-uuid-001',
-    UserId:        'user-uuid-001',
-    CategoryId:    '',
-    SourceType:    '',
-    FortnightType: '2',
-    PaymentStatus: '',
+    PeriodYear:    '2024',
+    PeriodMonth:   '1',
     Description:   'Salário',
     Amount:        '3000.00',
+    Category:      '',
+    FortnightType: '',
+    PaymentStatus: '',
+    SourceType:    '',
     DueDate:       '',
     PaymentDate:   '',
     Notes:         '',
-    IsActive:      'true',
-    IsRecurring:   '',
-    UpdatedAt:     '',
-    ReceivedAt:    '2024-01-05',
   };
   const row = { ...defaults, ...overrides };
   return [
-    row['Type'], row['Id'], row['PeriodId'], row['UserId'], row['CategoryId'],
-    row['SourceType'], row['FortnightType'], row['PaymentStatus'], row['Description'],
-    row['Amount'], row['DueDate'], row['PaymentDate'], row['Notes'],
-    row['IsActive'], row['IsRecurring'], row['UpdatedAt'], row['ReceivedAt'],
+    row['Type'], row['PeriodYear'], row['PeriodMonth'], row['Description'],
+    row['Amount'], row['Category'], row['FortnightType'], row['PaymentStatus'],
+    row['SourceType'], row['DueDate'], row['PaymentDate'], row['Notes'],
   ].join(',');
 }
 
@@ -99,10 +87,6 @@ describe('CsvReaderService', () => {
     expect(expenses.length).toBe(1);
 
     const expense: ExpenseResponse = expenses[0];
-    expect(expense.id).toBe('exp-uuid-001');
-    expect(expense.periodId).toBe('period-uuid-001');
-    expect(expense.userId).toBe('user-uuid-001');
-    expect(expense.categoryId).toBe('cat-uuid-001');
     expect(expense.sourceType).toBe(SourceType.Personal);
     expect(expense.fortnightType).toBe(FortnightType.First);
     expect(expense.paymentStatus).toBe(PaymentStatus.Pending);
@@ -111,9 +95,6 @@ describe('CsvReaderService', () => {
     expect(expense.dueDate).toBe('2024-01-10');
     expect(expense.paymentDate).toBe('2024-01-09');
     expect(expense.notes).toBe('Pago com desconto');
-    expect(expense.isActive).toBeTrue();
-    expect(expense.isRecurring).toBeTrue();
-    expect(expense.updatedAt).toBe('2024-01-09T10:00:00Z');
   });
 
   it('linha Expense não deve poluir signal incomes', () => {
@@ -132,15 +113,10 @@ describe('CsvReaderService', () => {
     expect(incomes.length).toBe(1);
 
     const income: IncomeResponse = incomes[0];
-    expect(income.id).toBe('inc-uuid-001');
-    expect(income.periodId).toBe('period-uuid-001');
-    expect(income.userId).toBe('user-uuid-001');
-    expect(income.fortnightType).toBe(FortnightType.Second);
     expect(income.description).toBe('Salário');
     expect(income.amount).toBe(3000.00);
-    expect(income.receivedAt).toBe('2024-01-05');
+    expect(income.receivedAt).toBe('01/2024');
     expect(income.notes).toBeNull();
-    expect(income.isActive).toBeTrue();
   });
 
   it('linha Income não deve poluir signal expenses', () => {
@@ -176,7 +152,6 @@ describe('CsvReaderService', () => {
     const csv = bom + [HEADER, buildExpenseLine()].join('\n');
     service.parseCsv(csv);
     expect(service.expenses().length).toBe(1);
-    expect(service.expenses()[0].id).toBe('exp-uuid-001');
   });
 
   it('deve ignorar BOM UTF-8 antes de linha Income', () => {
@@ -184,7 +159,6 @@ describe('CsvReaderService', () => {
     const csv = bom + [HEADER, buildIncomeLine()].join('\n');
     service.parseCsv(csv);
     expect(service.incomes().length).toBe(1);
-    expect(service.incomes()[0].id).toBe('inc-uuid-001');
   });
 
   // ── Schema mismatch → ignorar linha ───────────────────────────────────────
@@ -228,16 +202,16 @@ describe('CsvReaderService', () => {
   });
 
   it('summary.totalExpense deve somar todas as despesas', () => {
-    const exp1 = buildExpenseLine({ Id: 'e1', Amount: '500.00' });
-    const exp2 = buildExpenseLine({ Id: 'e2', Amount: '250.50' });
+    const exp1 = buildExpenseLine({ Amount: '500.00' });
+    const exp2 = buildExpenseLine({ Amount: '250.50' });
     const csv  = [HEADER, exp1, exp2].join('\n');
     service.parseCsv(csv);
     expect(service.summary()!.totalExpense).toBeCloseTo(750.50, 2);
   });
 
   it('summary.totalIncome deve somar todos os rendimentos', () => {
-    const inc1 = buildIncomeLine({ Id: 'i1', Amount: '2000.00' });
-    const inc2 = buildIncomeLine({ Id: 'i2', Amount: '500.00' });
+    const inc1 = buildIncomeLine({ Amount: '2000.00' });
+    const inc2 = buildIncomeLine({ Amount: '500.00' });
     const csv  = [HEADER, inc1, inc2].join('\n');
     service.parseCsv(csv);
     expect(service.summary()!.totalIncome).toBeCloseTo(2500.00, 2);
@@ -252,14 +226,70 @@ describe('CsvReaderService', () => {
   });
 
   it('parseCsv chamado novamente deve resetar signals anteriores', () => {
-    const csv1 = [HEADER, buildExpenseLine({ Id: 'e1' })].join('\n');
+    const csv1 = [HEADER, buildExpenseLine()].join('\n');
     service.parseCsv(csv1);
     expect(service.expenses().length).toBe(1);
 
-    const csv2 = [HEADER, buildIncomeLine({ Id: 'i1' })].join('\n');
+    const csv2 = [HEADER, buildIncomeLine()].join('\n');
     service.parseCsv(csv2);
     // Após segundo parse, expenses deve estar vazio (reset)
     expect(service.expenses().length).toBe(0);
     expect(service.incomes().length).toBe(1);
+  });
+
+  // ── Escape CSV: campo com vírgula entre aspas ──────────────────────────────
+
+  it('campo com vírgula entre aspas deve ser parseado como campo único', () => {
+    // Description contém vírgula, então fica entre aspas no CSV
+    const line = `Expense,2024,1,"Aluguel, residencial",1500.00,,First,Pending,Personal,2024-01-10,2024-01-09,`;
+    const csv = [HEADER, line].join('\n');
+    service.parseCsv(csv);
+
+    expect(service.expenses().length).toBe(1);
+    expect(service.expenses()[0].description).toBe('Aluguel, residencial');
+  });
+
+  it('aspas escapadas duplicadas devem ser resolvidas para aspas simples', () => {
+    // Description = Diz "olá" → CSV: "Diz ""olá"""
+    const line = `Expense,2024,1,"Diz ""olá""",500.00,,First,Pending,Personal,2024-01-10,,`;
+    const csv = [HEADER, line].join('\n');
+    service.parseCsv(csv);
+
+    expect(service.expenses().length).toBe(1);
+    expect(service.expenses()[0].description).toBe('Diz "olá"');
+  });
+
+  // ── receivedAt de Income sintetizado a partir de PeriodYear + PeriodMonth ──
+
+  it('receivedAt de Income deve ser sintetizado como "MM/YYYY"', () => {
+    const csv = [HEADER, buildIncomeLine({ PeriodYear: '2024', PeriodMonth: '1' })].join('\n');
+    service.parseCsv(csv);
+    expect(service.incomes()[0].receivedAt).toBe('01/2024');
+  });
+
+  it('receivedAt de Income com mês >= 10 deve usar zero-padding correto', () => {
+    const csv = [HEADER, buildIncomeLine({ PeriodYear: '2024', PeriodMonth: '10' })].join('\n');
+    service.parseCsv(csv);
+    expect(service.incomes()[0].receivedAt).toBe('10/2024');
+  });
+
+  // ── Enums como strings: FortnightType, PaymentStatus, SourceType ──────────
+
+  it('FortnightType "Second" deve ser parseado como FortnightType.Second (2)', () => {
+    const csv = [HEADER, buildExpenseLine({ FortnightType: 'Second' })].join('\n');
+    service.parseCsv(csv);
+    expect(service.expenses()[0].fortnightType).toBe(FortnightType.Second);
+  });
+
+  it('PaymentStatus "Paid" deve ser parseado como PaymentStatus.Paid (2)', () => {
+    const csv = [HEADER, buildExpenseLine({ PaymentStatus: 'Paid' })].join('\n');
+    service.parseCsv(csv);
+    expect(service.expenses()[0].paymentStatus).toBe(PaymentStatus.Paid);
+  });
+
+  it('SourceType "Parental" deve ser parseado como SourceType.Parental (1)', () => {
+    const csv = [HEADER, buildExpenseLine({ SourceType: 'Parental' })].join('\n');
+    service.parseCsv(csv);
+    expect(service.expenses()[0].sourceType).toBe(SourceType.Parental);
   });
 });

--- a/personal-finance/src/app/core/services/csv-reader.service.ts
+++ b/personal-finance/src/app/core/services/csv-reader.service.ts
@@ -1,26 +1,60 @@
 import { Injectable, signal } from '@angular/core';
-import { ExpenseResponse, IncomeResponse, PeriodSummary } from '../models/models';
+import { ExpenseResponse, IncomeResponse, PeriodSummary, FortnightType, PaymentStatus, SourceType } from '../models/models';
 
-// Índices do CSV exportado pelo sistema
+// Índices do CSV exportado pelo sistema (12 colunas)
+// Type,PeriodYear,PeriodMonth,Description,Amount,Category,FortnightType,PaymentStatus,SourceType,DueDate,PaymentDate,Notes
 const IDX_TYPE           = 0;
-const IDX_ID             = 1;
-const IDX_PERIOD_ID      = 2;
-const IDX_USER_ID        = 3;
-const IDX_CATEGORY_ID    = 4;
-const IDX_SOURCE_TYPE    = 5;
+const IDX_PERIOD_YEAR    = 1;
+const IDX_PERIOD_MONTH   = 2;
+const IDX_DESCRIPTION    = 3;
+const IDX_AMOUNT         = 4;
+const IDX_CATEGORY       = 5;
 const IDX_FORTNIGHT_TYPE = 6;
 const IDX_PAYMENT_STATUS = 7;
-const IDX_DESCRIPTION    = 8;
-const IDX_AMOUNT         = 9;
-const IDX_DUE_DATE       = 10;
-const IDX_PAYMENT_DATE   = 11;
-const IDX_NOTES          = 12;
-const IDX_IS_ACTIVE      = 13;
-const IDX_IS_RECURRING   = 14;
-const IDX_UPDATED_AT     = 15;
-const IDX_RECEIVED_AT    = 16;
+const IDX_SOURCE_TYPE    = 8;
+const IDX_DUE_DATE       = 9;
+const IDX_PAYMENT_DATE   = 10;
+const IDX_NOTES          = 11;
 
-const REQUIRED_COLUMNS = 17;
+const REQUIRED_COLUMNS = 12;
+
+// Mapeamentos de string → enum numérico
+const FORTNIGHT_TYPE_MAP: Record<string, FortnightType> = {
+  First:  FortnightType.First,
+  Second: FortnightType.Second,
+};
+
+const PAYMENT_STATUS_MAP: Record<string, PaymentStatus> = {
+  Pending:   PaymentStatus.Pending,
+  Paid:      PaymentStatus.Paid,
+  Cancelled: PaymentStatus.Cancelled,
+  Partial:   PaymentStatus.Partial,
+};
+
+const SOURCE_TYPE_MAP: Record<string, SourceType> = {
+  Personal: SourceType.Personal,
+  Parental: SourceType.Parental,
+};
+
+// Parser CSV que respeita campos entre aspas (RFC 4180)
+function parseCsvLine(line: string): string[] {
+  const result: string[] = [];
+  let current = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') {
+      if (inQuotes && line[i + 1] === '"') { current += '"'; i++; }
+      else { inQuotes = !inQuotes; }
+    } else if (ch === ',' && !inQuotes) {
+      result.push(current); current = '';
+    } else {
+      current += ch;
+    }
+  }
+  result.push(current);
+  return result;
+}
 
 // BOM UTF-8
 const UTF8_BOM = '﻿';
@@ -52,40 +86,43 @@ export class CsvReaderService {
       const line = lines[i].trim();
       if (!line) continue;
 
-      const cols = line.split(',');
+      const cols = parseCsvLine(line);
       if (cols.length < REQUIRED_COLUMNS) continue;
 
       const type = cols[IDX_TYPE];
+      const lineIndex = i - 1; // lineIndex começa em 0 (desconta o header)
 
       if (type === 'Expense') {
         parsedExpenses.push({
-          id:            cols[IDX_ID],
-          periodId:      cols[IDX_PERIOD_ID],
-          userId:        cols[IDX_USER_ID],
-          categoryId:    cols[IDX_CATEGORY_ID],
-          sourceType:    Number(cols[IDX_SOURCE_TYPE]),
-          fortnightType: Number(cols[IDX_FORTNIGHT_TYPE]),
-          paymentStatus: Number(cols[IDX_PAYMENT_STATUS]),
+          id:            `expense-${lineIndex}`,
+          periodId:      '',
+          userId:        '',
+          categoryId:    '',
+          sourceType:    SOURCE_TYPE_MAP[cols[IDX_SOURCE_TYPE]] ?? SourceType.Personal,
+          fortnightType: FORTNIGHT_TYPE_MAP[cols[IDX_FORTNIGHT_TYPE]] ?? FortnightType.First,
+          paymentStatus: PAYMENT_STATUS_MAP[cols[IDX_PAYMENT_STATUS]] ?? PaymentStatus.Pending,
           description:   cols[IDX_DESCRIPTION],
           amount:        Number(cols[IDX_AMOUNT]),
           dueDate:       cols[IDX_DUE_DATE],
           paymentDate:   cols[IDX_PAYMENT_DATE] || null,
           notes:         cols[IDX_NOTES] || null,
-          isActive:      cols[IDX_IS_ACTIVE] === 'true',
-          isRecurring:   cols[IDX_IS_RECURRING] === 'true',
-          updatedAt:     cols[IDX_UPDATED_AT],
+          isActive:      true,
+          isRecurring:   false,
+          updatedAt:     '',
         });
       } else if (type === 'Income') {
+        const year  = cols[IDX_PERIOD_YEAR];
+        const month = cols[IDX_PERIOD_MONTH].padStart(2, '0');
         parsedIncomes.push({
-          id:            cols[IDX_ID],
-          periodId:      cols[IDX_PERIOD_ID],
-          userId:        cols[IDX_USER_ID],
-          fortnightType: Number(cols[IDX_FORTNIGHT_TYPE]),
+          id:            `income-${lineIndex}`,
+          periodId:      '',
+          userId:        '',
+          fortnightType: 0 as FortnightType,
           description:   cols[IDX_DESCRIPTION],
           amount:        Number(cols[IDX_AMOUNT]),
-          receivedAt:    cols[IDX_RECEIVED_AT],
+          receivedAt:    `${month}/${year}`,
           notes:         cols[IDX_NOTES] || null,
-          isActive:      cols[IDX_IS_ACTIVE] === 'true',
+          isActive:      true,
         });
       }
       // Type desconhecido ou linha inválida → ignorar silenciosamente

--- a/personal-finance/src/app/core/services/csv-reader.service.ts
+++ b/personal-finance/src/app/core/services/csv-reader.service.ts
@@ -8,7 +8,6 @@ const IDX_PERIOD_YEAR    = 1;
 const IDX_PERIOD_MONTH   = 2;
 const IDX_DESCRIPTION    = 3;
 const IDX_AMOUNT         = 4;
-const IDX_CATEGORY       = 5;
 const IDX_FORTNIGHT_TYPE = 6;
 const IDX_PAYMENT_STATUS = 7;
 const IDX_SOURCE_TYPE    = 8;
@@ -117,7 +116,7 @@ export class CsvReaderService {
           id:            `income-${lineIndex}`,
           periodId:      '',
           userId:        '',
-          fortnightType: 0 as FortnightType,
+          fortnightType: FortnightType.First,
           description:   cols[IDX_DESCRIPTION],
           amount:        Number(cols[IDX_AMOUNT]),
           receivedAt:    `${month}/${year}`,

--- a/personal-finance/src/app/features/purge/purge-detail.component.ts
+++ b/personal-finance/src/app/features/purge/purge-detail.component.ts
@@ -81,8 +81,7 @@ import {
               <tr>
                 <th>Descrição</th>
                 <th>Valor</th>
-                <th>Recebido em</th>
-                <th>Quinzena</th>
+                <th>Período</th>
                 <th>Notas</th>
               </tr>
             </thead>
@@ -92,7 +91,6 @@ import {
                   <td>{{ inc.description }}</td>
                   <td>{{ inc.amount | number:'1.2-2' }}</td>
                   <td>{{ inc.receivedAt }}</td>
-                  <td>{{ fortnightTypeLabel(inc.fortnightType) }}</td>
                   <td>{{ inc.notes ?? '—' }}</td>
                 </tr>
               }


### PR DESCRIPTION
## Motivação
Parser `CsvReaderService` esperava 17 colunas com GUIDs mas backend exporta 12 colunas simples — `REQUIRED_COLUMNS = 17` descartava todos os registros silenciosamente, deixando a tela Análise Detalhe sem dados após upload do CSV.

## O que foi implementado
Reescrita do `CsvReaderService` para formato real de 12 colunas; parser RFC 4180 com suporte a campos entre aspas (descrições com vírgula); mapeamento de enums exportados como string ("First"/"Second", "Pending"/"Paid", etc.) para valores numéricos com fallback defensivo; `receivedAt` de Income sintetizado como "MM/YYYY" a partir de PeriodYear/PeriodMonth; `PurgeDetailComponent` atualizado com coluna Quinzena removida de Income e header "Período".

## Arquivos

### Modificados
| Arquivo | O que mudou |
|---|---|
| `csv-reader.service.ts` | IDX constants para 12 colunas, REQUIRED_COLUMNS=12, parseCsvLine RFC 4180, mapas enum string→número, FortnightType.First para Income |
| `csv-reader.service.spec.ts` | 30 testes: novo formato 12 colunas, parser aspas, receivedAt sintetizado, enums como string, fallbacks |
| `purge-detail.component.ts` | Coluna Quinzena removida de Income; header "Recebido em" → "Período" |

## Casos de teste

### Caminho feliz
- [ ] CSV com Expense e Income de 12 colunas é parseado corretamente
- [ ] Descrição com vírgula entre aspas é tratada como campo único
- [ ] Enums exportados como string ("First", "Pending", "Personal") são convertidos corretamente
- [ ] Income exibe "MM/YYYY" na coluna Período

### Caminho triste
- [ ] String de enum inválida usa fallback (FortnightType.First, PaymentStatus.Pending, SourceType.Personal)
- [ ] Linha com menos de 12 colunas é ignorada sem exceção
- [ ] Type desconhecido é ignorado silenciosamente

## Critérios de aceite
- [ ] Tela Análise Detalhe exibe Despesas e Receitas após upload do CSV exportado pelo sistema
- [ ] 465 testes frontend passando, 0 falhando

Closes #369