### PR TITLE
Expurgo - Layout Modal

### DIFF
--- a/docs/memory/367.md
+++ b/docs/memory/367.md
@@ -1,0 +1,23 @@
+# #367 — Expurgo - Layout Modal
+Issue: #367 | Data: 2026-06-29 | Branch: feat/367-expurgo-layout-modal
+
+## Arquivos criados
+_(nenhum arquivo novo)_
+
+## Arquivos modificados
+- `personal-finance/src/app/features/purge/components/purge/purge.component.ts` — substituído `<div class="page-header">` por `<app-header>`; `PurgeWarningBannerComponent` removido dos imports e template; `HeaderComponent` adicionado
+- `personal-finance/src/app/features/purge/components/purge/purge.component.css` — `.modal`: `overflow: hidden` → `overflow: visible`; `.sonic-frame`: `inset: 0` → `top/left/right/bottom: -24px; width/height: auto`
+- `personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts` — 7 novos testes para os critérios de aceite; guard para `ɵcmp.dependencies` lazy function
+
+## Decisões técnicas
+- CSS residual (`.page-header`, `.page-title`, `.page-subtitle`) mantido no CSS sem impacto funcional — tech debt a remover em oportunidade futura
+
+## Desvios do spec
+- `PurgeWarningBannerComponent` permanece em `purge-detail.component.ts` (typewriter ativo apenas no detalhe de análise) — comportamento intencional, não era escopo da issue
+
+## Estado do sistema após esta issue
+
+### Front-end
+- **Rotas:** inalteradas
+- **Componentes:** `PurgeComponent` agora usa `HeaderComponent` compartilhado (tweaks panel incluído); `PurgeWarningBannerComponent` removido da tela principal de expurgo; modal com `overflow: visible` e sonic-frame externo ao box
+- **Serviços:** inalterados

--- a/docs/memory/project-memory.md
+++ b/docs/memory/project-memory.md
@@ -15,6 +15,7 @@ Estado atual do sistema. Atualizado ao final de cada issue via `/end-issue`.
 | #355 | fix: enum string quebra deserialização no POST /expenses/batch/create | 2026-06-26 | [355.md](355.md) |
 | #356 | [FE] Expurgo: Layout e Design — tabela padrão + modal Sonic | 2026-06-27 | [356.md](356.md) |
 | #369 | Expurgo - Análise Detalhe (bugfix CSV parser) | 2026-06-29 | [369.md](369.md) |
+| #367 | Expurgo - Layout Modal | 2026-06-29 | [367.md](367.md) |
 
 ---
 
@@ -22,7 +23,7 @@ Estado atual do sistema. Atualizado ao final de cada issue via `/end-issue`.
 
 | Módulo | Issues relacionadas | Última atualização |
 |---|---|---|
-| Expurgo (Purge) | #329, #330, #331, #332, #356, #369 | 2026-06-29 |
+| Expurgo (Purge) | #329, #330, #331, #332, #356, #369, #367 | 2026-06-29 |
 | Batch Expenses / Serialização | #355 | 2026-06-26 |
 
 ---
@@ -58,7 +59,7 @@ Estado atual do sistema. Atualizado ao final de cada issue via `/end-issue`.
 
 ### Frontend (Angular 21)
 - **Rotas (app.routes.ts):** `/purge` (lazy, authGuard); `purge/analysis` (PurgeAnalysisComponent, providers: [CsvReaderService]); `purge/analysis/detail` (PurgeDetailComponent)
-- **Componentes standalone:** PurgeComponent redesenhado — cards grid, modal Sonic pixel-art, tabela histórico, modal delete (`features/purge/components/purge/`); PurgeAnalysisComponent, PurgeDetailComponent, PurgeWarningBannerComponent (`features/purge/`)
+- **Componentes standalone:** PurgeComponent redesenhado — cards grid, modal Sonic pixel-art, tabela histórico, modal delete (`features/purge/components/purge/`); PurgeAnalysisComponent, PurgeDetailComponent, PurgeWarningBannerComponent (`features/purge/`) — `PurgeWarningBannerComponent` removido da tela principal em #367; permanece apenas em `purge-detail.component.ts`
 - **Assets:** `public/sonic-tile.svg` (tile pixel-art do frame Sonic)
 - **Serviços:** ApiService (wrapper HTTP) com métodos purge (`getEligiblePeriods`, `exportPurgeCsv`, `executePurge(periodId, csvFileName)`, `getPurgeRecords`, `deletePurgeRecord`); ThemeService (dark/light); CsvReaderService (parse CSV offline, sem `providedIn: 'root'`) — corrigido em #369 para 12 colunas, RFC 4180, enums como string
 - **Componentes:** `PurgeDetailComponent` (#369) — tabela Income com 4 colunas (Descrição, Valor, Período, Notas); coluna Quinzena removida

--- a/personal-finance/src/app/features/purge/components/purge/purge.component.css
+++ b/personal-finance/src/app/features/purge/components/purge/purge.component.css
@@ -311,14 +311,19 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   box-shadow: 0 20px 60px rgba(0,0,0,.64);
-  overflow: hidden;
+  overflow: visible;
   display: flex;
   flex-direction: column;
 }
 
 .sonic-frame {
   position: absolute;
-  inset: 0;
+  top: -24px;
+  left: -24px;
+  right: -24px;
+  bottom: -24px;
+  width: auto;
+  height: auto;
   pointer-events: none;
   z-index: 0;
 }

--- a/personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts
+++ b/personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts
@@ -751,4 +751,93 @@ describe('PurgeComponent', () => {
       expect(component.purgeConfirmed()).toBeTrue();
     }));
   });
+
+  // ── #367 RED — Layout: app-header, remoção do banner e CSS do modal ────────
+
+  describe('#367 — header compartilhado (app-header)', () => {
+    it('renderiza o elemento app-header no template', fakeAsync(() => {
+      tick();
+      fixture.detectChanges();
+      // PurgeComponent deve usar <app-header> em vez de div.page-header manual
+      const appHeader = fixture.nativeElement.querySelector('app-header');
+      expect(appHeader).withContext('app-header deve estar no DOM — PurgeComponent ainda usa div.page-header manual').not.toBeNull();
+    }));
+
+    it('NÃO renderiza div.page-header manual', fakeAsync(() => {
+      tick();
+      fixture.detectChanges();
+      // div.page-header deve ser removida quando app-header for introduzido
+      const pageHeader = fixture.nativeElement.querySelector('.page-header');
+      expect(pageHeader).withContext('div.page-header manual não deve mais existir no template após introdução do app-header').toBeNull();
+    }));
+
+    it('app-header recebe o atributo title com o valor "Expurgo de Períodos"', fakeAsync(() => {
+      tick();
+      fixture.detectChanges();
+      const appHeader = fixture.nativeElement.querySelector('app-header');
+      expect(appHeader).not.toBeNull();
+      // Angular projeta inputs via atributo no DOM ao usar NO_ERRORS_SCHEMA
+      const titleAttr = appHeader.getAttribute('title') ?? appHeader.getAttribute('ng-reflect-title') ?? '';
+      expect(titleAttr).toContain('Expurgo');
+    }));
+  });
+
+  describe('#367 — remoção do PurgeWarningBannerComponent', () => {
+    it('NÃO renderiza app-purge-warning-banner na seção de records', fakeAsync(() => {
+      tick();
+      fixture.detectChanges();
+      // O typewriter banner deve ser removido do template
+      const banner = fixture.nativeElement.querySelector('app-purge-warning-banner');
+      expect(banner).withContext('app-purge-warning-banner deve ser removido do template do PurgeComponent — issue #367').toBeNull();
+    }));
+
+    it('PurgeWarningBannerComponent NÃO está nos imports do PurgeComponent', () => {
+      // Verifica que PurgeWarningBannerComponent não é mais declarado como import
+      const imports: any[] = (PurgeComponent as any).ɵcmp?.dependencies ?? [];
+      const hasBanner = imports.some((dep: any) => {
+        const sel: string = dep?.ɵcmp?.selectors?.[0]?.[1] ?? dep?.ɵdir?.selectors?.[0]?.[1] ?? '';
+        return sel === 'app-purge-warning-banner';
+      });
+      expect(hasBanner).withContext('PurgeWarningBannerComponent não deve mais estar nos imports do PurgeComponent após issue #367').toBeFalse();
+    });
+  });
+
+  describe('#367 — CSS do modal: overflow e posicionamento do sonic-frame', () => {
+    it('.modal deve ter overflow: visible (não hidden)', fakeAsync(() => {
+      component.openConfirmModal(PERIOD_1);
+      tick();
+      fixture.detectChanges();
+
+      const modal: HTMLElement = fixture.nativeElement.querySelector('.modal');
+      expect(modal).not.toBeNull();
+
+      // O CSS do componente é scoped — computedStyle reflete o estilo aplicado
+      const computed = getComputedStyle(modal);
+      expect(computed.overflow).withContext('.modal deve ter overflow: visible para que o sonic-frame pixel-art possa extravasar o box').toBe('visible');
+    }));
+
+    it('.sonic-frame deve ter posicionamento com valores negativos (externo ao box do modal)', fakeAsync(() => {
+      component.openConfirmModal(PERIOD_1);
+      tick();
+      fixture.detectChanges();
+
+      const sonicFrame: HTMLElement = fixture.nativeElement.querySelector('.sonic-frame');
+      expect(sonicFrame).not.toBeNull();
+
+      const computed = getComputedStyle(sonicFrame);
+
+      // Pelo menos um dos lados deve ter valor negativo (margin-based external positioning)
+      const leftVal   = parseFloat(computed.left)   || 0;
+      const rightVal  = parseFloat(computed.right)  || 0;
+      const topVal    = parseFloat(computed.top)    || 0;
+      const bottomVal = parseFloat(computed.bottom) || 0;
+
+      const hasNegativePositioning =
+        leftVal < 0 || rightVal < 0 || topVal < 0 || bottomVal < 0;
+
+      expect(hasNegativePositioning).withContext(
+        '.sonic-frame deve ter pelo menos um valor de posicionamento negativo (left/right/top/bottom) para ficar externo ao box do modal'
+      ).toBeTrue();
+    }));
+  });
 });

--- a/personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts
+++ b/personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts
@@ -457,26 +457,8 @@ describe('PurgeComponent', () => {
     }));
   });
 
-  // ── MOD-03: PurgeWarningBannerComponent nos imports ───────────────────────
-
-  describe('PurgeWarningBannerComponent — import obrigatório', () => {
-    it('PurgeWarningBannerComponent está nos imports do PurgeComponent', fakeAsync(() => {
-      // Verifica via DOM: NO_ERRORS_SCHEMA ignoraria tags desconhecidas sem erro,
-      // mas o selector deve ser reconhecido pelo Angular quando importado corretamente.
-      // A segunda asserção (renderização DOM) é o critério definitivo.
-      tick();
-      fixture.detectChanges();
-      const banner = fixture.nativeElement.querySelector('app-purge-warning-banner');
-      expect(banner).not.toBeNull('app-purge-warning-banner deve estar no DOM — PurgeWarningBannerComponent não está importado');
-    }));
-
-    it('renderiza app-purge-warning-banner na seção de records', fakeAsync(() => {
-      tick();
-      fixture.detectChanges();
-      const banner = fixture.nativeElement.querySelector('app-purge-warning-banner');
-      expect(banner).not.toBeNull();
-    }));
-  });
+  // ── MOD-03: PurgeWarningBannerComponent nos imports ─── (removido em #367) ──
+  // PurgeWarningBannerComponent foi removido dos imports e template em #367.
 
   // ── MOD-03: Modal de delete de metadados ─────────────────────────────────
 
@@ -793,8 +775,11 @@ describe('PurgeComponent', () => {
 
     it('PurgeWarningBannerComponent NÃO está nos imports do PurgeComponent', () => {
       // Verifica que PurgeWarningBannerComponent não é mais declarado como import
-      const imports: any[] = (PurgeComponent as any).ɵcmp?.dependencies ?? [];
-      const hasBanner = imports.some((dep: any) => {
+      const rawDeps: any = (PurgeComponent as any).ɵcmp?.dependencies;
+      // dependencies pode ser função (lazy) ou array direto em Angular 21
+      const deps: any[] = Array.isArray(rawDeps) ? rawDeps
+        : (typeof rawDeps === 'function' ? rawDeps() : []);
+      const hasBanner = deps.some((dep: any) => {
         const sel: string = dep?.ɵcmp?.selectors?.[0]?.[1] ?? dep?.ɵdir?.selectors?.[0]?.[1] ?? '';
         return sel === 'app-purge-warning-banner';
       });

--- a/personal-finance/src/app/features/purge/components/purge/purge.component.ts
+++ b/personal-finance/src/app/features/purge/components/purge/purge.component.ts
@@ -3,13 +3,13 @@ import { DatePipe } from '@angular/common';
 import { trigger, transition, style, animate } from '@angular/animations';
 import { ApiService } from '../../../../core/services/api.service';
 import { EligiblePeriodResponse, PurgeResultResponse, PurgeRecordResponse, MONTH_NAMES } from '../../../../core/models/models';
-import { PurgeWarningBannerComponent } from '../../purge-warning-banner.component';
+import { HeaderComponent } from '../../../../shared/components/header/header.component';
 import { CurrencyBrlPipe } from '../../../../shared/pipes/currency-brl.pipe';
 
 @Component({
   selector: 'app-purge',
   standalone: true,
-  imports: [DatePipe, PurgeWarningBannerComponent, CurrencyBrlPipe],
+  imports: [DatePipe, HeaderComponent, CurrencyBrlPipe],
   styleUrls: ['./purge.component.css'],
   animations: [
     trigger('backdropAnim', [
@@ -34,11 +34,7 @@ import { CurrencyBrlPipe } from '../../../../shared/pipes/currency-brl.pipe';
         <div class="error">{{ apiError() }}</div>
       }
 
-      <!-- Page header -->
-      <div class="page-header">
-        <h1 class="page-title">Expurgo de Períodos</h1>
-        <p class="page-subtitle">Exclua permanentemente dados de períodos fechados e exportados</p>
-      </div>
+      <app-header title="Expurgo de Períodos" subtitle="Exclua permanentemente dados de períodos fechados e exportados"></app-header>
 
       <!-- Warning banner estático -->
       <div class="warning-callout">
@@ -202,7 +198,6 @@ import { CurrencyBrlPipe } from '../../../../shared/pipes/currency-brl.pipe';
 
       <!-- Seção de registros de expurgo -->
       <section class="records-section">
-        <app-purge-warning-banner />
         <div class="section-header">
           <h2 class="section-title">Histórico de expurgos</h2>
         </div>


### PR DESCRIPTION
## Motivação
O layout do modal de expurgo estava incompatível com o design proposto: header manual sem tweaks panel, banner typewriter indevido na tela principal e sonic-frame clipado pelo `overflow: hidden` do modal.

## O que foi implementado
Substituição do header manual por `<app-header>` compartilhado, remoção do `PurgeWarningBannerComponent` (typewriter) do template principal e correção do CSS do modal (`overflow: visible` + sonic-frame com posicionamento externo).

## Arquivos

### Modificados
| Arquivo | O que mudou |
|---|---|
| `purge.component.ts` | `HeaderComponent` nos imports; `PurgeWarningBannerComponent` removido; template: `<div class="page-header">` → `<app-header>`; `<app-purge-warning-banner>` removido da seção de records |
| `purge.component.css` | `.modal`: `overflow: hidden` → `overflow: visible`; `.sonic-frame`: `inset: 0` → `top/left/right/bottom: -24px; width/height: auto` |
| `purge.component.spec.ts` | 7 novos testes cobrindo os critérios de aceite |

## Casos de teste

### Caminho feliz
- [ ] Header com tweaks panel renderiza na tela de expurgo
- [ ] Modal de confirmação abre sem clipping do sonic-frame
- [ ] Nenhum banner typewriter exibido na tela principal

### Caminho triste
- [ ] Tela sem períodos elegíveis: empty state renderiza corretamente com o novo header
- [ ] Modal fechado: `overflow: visible` não causa regressão visual

## Critérios de aceite
- [ ] `<app-header title="Expurgo de Períodos">` renderizado no template
- [ ] `<div class="page-header">` manual ausente
- [ ] `<app-purge-warning-banner>` ausente do template principal
- [ ] `.modal` com `overflow: visible`
- [ ] `.sonic-frame` com posicionamento externo (`top/left/right/bottom: -24px`)

Closes #367