### PR TITLE
Expurgo - Análise: botão de navegação para tela de CSV

### DIFF
--- a/docs/memory/368.md
+++ b/docs/memory/368.md
@@ -1,0 +1,20 @@
+# #368 — Expurgo - Análise
+Issue: #368 | Data: 2026-06-29 | Branch: feat/368-expurgo-analise
+
+## Arquivos criados
+_nenhum_
+
+## Arquivos modificados
+- `personal-finance/src/app/features/purge/components/purge/purge.component.ts` — `Router` injetado, método `navigateToAnalysis()`, botão `.btn-analise` projetado dentro de `<app-header>` via `<ng-content />`
+- `personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts` — 2 novos testes: presença do botão no DOM (`app-header`) e chamada ao `router.navigate(['purge', 'analysis'])`
+
+## Decisões técnicas
+- Botão projetado via `<ng-content />` do `HeaderComponent` em vez de criar novo input/output no `HeaderComponent` — mantém o componente genérico e sem acoplamento à feature de expurgo
+
+## Desvios do spec
+_nenhum_
+
+## Estado do sistema após esta issue
+
+### Front-end
+- **Componentes:** `PurgeComponent` — botão "Análise" adicionado no header via ng-content, navega para `/purge/analysis`

--- a/docs/memory/project-memory.md
+++ b/docs/memory/project-memory.md
@@ -16,6 +16,7 @@ Estado atual do sistema. Atualizado ao final de cada issue via `/end-issue`.
 | #356 | [FE] Expurgo: Layout e Design — tabela padrão + modal Sonic | 2026-06-27 | [356.md](356.md) |
 | #369 | Expurgo - Análise Detalhe (bugfix CSV parser) | 2026-06-29 | [369.md](369.md) |
 | #367 | Expurgo - Layout Modal | 2026-06-29 | [367.md](367.md) |
+| #368 | Expurgo - Análise: botão de navegação para tela de CSV | 2026-06-29 | [368.md](368.md) |
 
 ---
 
@@ -23,7 +24,7 @@ Estado atual do sistema. Atualizado ao final de cada issue via `/end-issue`.
 
 | Módulo | Issues relacionadas | Última atualização |
 |---|---|---|
-| Expurgo (Purge) | #329, #330, #331, #332, #356, #369, #367 | 2026-06-29 |
+| Expurgo (Purge) | #329, #330, #331, #332, #356, #369, #367, #368 | 2026-06-29 |
 | Batch Expenses / Serialização | #355 | 2026-06-26 |
 
 ---
@@ -59,7 +60,7 @@ Estado atual do sistema. Atualizado ao final de cada issue via `/end-issue`.
 
 ### Frontend (Angular 21)
 - **Rotas (app.routes.ts):** `/purge` (lazy, authGuard); `purge/analysis` (PurgeAnalysisComponent, providers: [CsvReaderService]); `purge/analysis/detail` (PurgeDetailComponent)
-- **Componentes standalone:** PurgeComponent redesenhado — cards grid, modal Sonic pixel-art, tabela histórico, modal delete (`features/purge/components/purge/`); PurgeAnalysisComponent, PurgeDetailComponent, PurgeWarningBannerComponent (`features/purge/`) — `PurgeWarningBannerComponent` removido da tela principal em #367; permanece apenas em `purge-detail.component.ts`
+- **Componentes standalone:** PurgeComponent redesenhado — cards grid, modal Sonic pixel-art, tabela histórico, modal delete, botão "Análise" no header via ng-content (#368) (`features/purge/components/purge/`); PurgeAnalysisComponent, PurgeDetailComponent, PurgeWarningBannerComponent (`features/purge/`) — `PurgeWarningBannerComponent` removido da tela principal em #367; permanece apenas em `purge-detail.component.ts`
 - **Assets:** `public/sonic-tile.svg` (tile pixel-art do frame Sonic)
 - **Serviços:** ApiService (wrapper HTTP) com métodos purge (`getEligiblePeriods`, `exportPurgeCsv`, `executePurge(periodId, csvFileName)`, `getPurgeRecords`, `deletePurgeRecord`); ThemeService (dark/light); CsvReaderService (parse CSV offline, sem `providedIn: 'root'`) — corrigido em #369 para 12 colunas, RFC 4180, enums como string
 - **Componentes:** `PurgeDetailComponent` (#369) — tabela Income com 4 colunas (Descrição, Valor, Período, Notas); coluna Quinzena removida

--- a/personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts
+++ b/personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { ComponentFixture } from '@angular/core/testing';
-import { RouterModule } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { of, throwError } from 'rxjs';
@@ -731,6 +731,49 @@ describe('PurgeComponent', () => {
       tick();
 
       expect(component.purgeConfirmed()).toBeTrue();
+    }));
+  });
+
+  // ── #368 — botão de navegação para Análise de CSV ────────────────────────
+
+  describe('#368 — botão de navegação para Análise de CSV', () => {
+    it('renderiza um botão dentro de app-header para navegar para análise de CSV', fakeAsync(() => {
+      tick();
+      fixture.detectChanges();
+      // O PurgeComponent deve projetar um botão via ng-content dentro de <app-header>
+      // Com NO_ERRORS_SCHEMA, o conteúdo projetado fica como filho de app-header no DOM
+      const appHeader = fixture.nativeElement.querySelector('app-header');
+      expect(appHeader).withContext('app-header deve estar presente no DOM').not.toBeNull();
+      const btnAnalise: HTMLElement | null | undefined =
+        appHeader.querySelector('.btn-analise') ??
+        appHeader.querySelector('[data-testid="btn-analise"]') ??
+        Array.from(appHeader.querySelectorAll('button') as NodeListOf<HTMLElement>)
+          .find((btn: HTMLElement) => btn.textContent?.toLowerCase().includes('análise')) ??
+        null;
+      expect(btnAnalise).withContext('deve existir um botão de Análise dentro de app-header via ng-content — PurgeComponent ainda não projeta o botão').not.toBeNull();
+    }));
+
+    it('clicar no botão de análise chama router.navigate com [\'purge\', \'analysis\']', fakeAsync(() => {
+      tick();
+      fixture.detectChanges();
+      const router = TestBed.inject(Router);
+      spyOn(router, 'navigate');
+
+      const appHeader = fixture.nativeElement.querySelector('app-header');
+      expect(appHeader).withContext('app-header deve estar presente').not.toBeNull();
+      const btnAnalise: HTMLButtonElement | null =
+        appHeader.querySelector('.btn-analise') ??
+        appHeader.querySelector('[data-testid="btn-analise"]') ??
+        Array.from(appHeader.querySelectorAll('button') as NodeListOf<HTMLElement>)
+          .find((btn: HTMLElement) => btn.textContent?.toLowerCase().includes('análise')) ??
+        null;
+      expect(btnAnalise).withContext('botão de Análise deve existir para ser clicado — PurgeComponent ainda não projeta o botão').not.toBeNull();
+
+      if (btnAnalise) {
+        btnAnalise.click();
+        tick();
+        expect(router.navigate).toHaveBeenCalledWith(['purge', 'analysis']);
+      }
     }));
   });
 

--- a/personal-finance/src/app/features/purge/components/purge/purge.component.ts
+++ b/personal-finance/src/app/features/purge/components/purge/purge.component.ts
@@ -1,5 +1,6 @@
 import { Component, inject, signal, OnInit } from '@angular/core';
 import { DatePipe } from '@angular/common';
+import { Router } from '@angular/router';
 import { trigger, transition, style, animate } from '@angular/animations';
 import { ApiService } from '../../../../core/services/api.service';
 import { EligiblePeriodResponse, PurgeResultResponse, PurgeRecordResponse, MONTH_NAMES } from '../../../../core/models/models';
@@ -34,7 +35,9 @@ import { CurrencyBrlPipe } from '../../../../shared/pipes/currency-brl.pipe';
         <div class="error">{{ apiError() }}</div>
       }
 
-      <app-header title="Expurgo de Períodos" subtitle="Exclua permanentemente dados de períodos fechados e exportados"></app-header>
+      <app-header title="Expurgo de Períodos" subtitle="Exclua permanentemente dados de períodos fechados e exportados">
+        <button class="btn btn-sm btn-analise" (click)="navigateToAnalysis()">Análise</button>
+      </app-header>
 
       <!-- Warning banner estático -->
       <div class="warning-callout">
@@ -288,7 +291,8 @@ import { CurrencyBrlPipe } from '../../../../shared/pipes/currency-brl.pipe';
   `,
 })
 export class PurgeComponent implements OnInit {
-  private readonly api = inject(ApiService);
+  private readonly api    = inject(ApiService);
+  private readonly router = inject(Router);
 
   readonly eligiblePeriods       = signal<EligiblePeriodResponse[]>([]);
   readonly selectedPeriod        = signal<EligiblePeriodResponse | null>(null);
@@ -299,6 +303,10 @@ export class PurgeComponent implements OnInit {
   readonly purgeRecords          = signal<PurgeRecordResponse[]>([]);
   readonly deleteRecordModalOpen = signal(false);
   readonly selectedRecord        = signal<PurgeRecordResponse | null>(null);
+
+  navigateToAnalysis(): void {
+    this.router.navigate(['purge', 'analysis']);
+  }
 
   // Converte número de mês (1-12) para nome em PT-BR
   monthName(month: number): string {


### PR DESCRIPTION
## Motivação
> A tela de expurgo não tinha botão para navegar até a tela de upload de CSV (`/purge/analysis`), forçando o usuário a acessar a rota manualmente.

## O que foi implementado
Botão "Análise" adicionado no header do `PurgeComponent`, projetado via `<ng-content />` do `HeaderComponent` (ao lado do botão Tweaks). Clicar no botão chama `router.navigate(['purge', 'analysis'])`.

## Arquivos

### Modificados
| Arquivo | O que mudou |
|---|---|
| `personal-finance/src/app/features/purge/components/purge/purge.component.ts` | `Router` injetado, método `navigateToAnalysis()`, botão `.btn-analise` projetado em `<app-header>` |
| `personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts` | 2 novos testes: presença do botão no DOM e chamada ao `router.navigate` |

## Casos de teste

### Caminho feliz
- [ ] Botão "Análise" aparece no header ao lado do botão Tweaks
- [ ] Clicar navega para `/purge/analysis`

### Caminho triste
- [ ] N/A — botão de navegação simples sem casos de erro

## Critérios de aceite
- [ ] Botão visível no header da tela de expurgo
- [ ] Navegação correta para `/purge/analysis`
- [ ] 472 testes passando, 0 falhas

Closes #368