### PR TITLE
fix(purge): corrigir campos da grid Histórico de Expurgos #377

### DIFF
--- a/docs/memory/377.md
+++ b/docs/memory/377.md
@@ -1,0 +1,29 @@
+# #377 — Expurgo - Bug Grid "Histórico de Expurgos"
+Issue: #377 | Data: 2026-06-29 | Branch: fix/377-expurgo-bug-grid-historico-de-expurgos
+
+## Arquivos criados
+- `src/PersonalFinance.Application/DTOs/Financial/PurgeRecordDto.cs` — DTO de resposta com `Id`, `Year`, `Month`, `ItemCount`, `TotalIncome`, `TotalExpense`, `PurgedAt`
+
+## Arquivos modificados
+- `src/PersonalFinance.Application/UseCases/Financial/Purge/GetPurgeRecordsUseCase.cs` — retorna `IEnumerable<PurgeRecordDto>` com mapeamento interno; `ItemCount = ExpenseCount + IncomeCount`
+- `src/PersonalFinance.Api/Controllers/V1/Purge/PurgeController.cs` — `GetRecords` simplificado para `return Ok(result)` (mapeamento saiu do controller)
+- `tests/PersonalFinance.Api.Tests/Integration/PurgeControllerTests.cs` — 2 testes novos: `GetRecords_ReturnsYearAndMonth_NotPeriodYearPeriodMonth`, `GetRecords_ReturnsItemCount_AsExpenseCountPlusIncomeCount`
+
+## Decisões técnicas
+- DTO colocado em `Application/DTOs/Financial/` (padrão do projeto, alinhado com `EligiblePeriodDto`) — inicialmente criado em `UseCases/Financial/Purge/` e movido após revisão de código
+- Mapeamento encapsulado no use case (não no controller) — Clean Architecture exige orquestração pura nos controllers
+
+## Desvios do spec
+- Nenhum
+
+## Estado do sistema após esta issue
+
+### Back-end
+- **Application:** `GetPurgeRecordsUseCase` retorna `IEnumerable<PurgeRecordDto>` (antes retornava `IEnumerable<PurgeRecord>`); `PurgeRecordDto` adicionado em `DTOs/Financial/`
+- **Api:** `GET /api/v1/purge/records` agora serializa `year`, `month`, `itemCount` (antes expunha campos da entidade: `periodYear`, `periodMonth`, `expenseCount`, `incomeCount`)
+
+### Front-end
+- Nenhuma alteração (modelo `PurgeRecordResponse` já estava correto)
+
+### Banco de dados
+- Nenhuma migration

--- a/docs/memory/project-memory.md
+++ b/docs/memory/project-memory.md
@@ -17,6 +17,7 @@ Estado atual do sistema. Atualizado ao final de cada issue via `/end-issue`.
 | #369 | Expurgo - Análise Detalhe (bugfix CSV parser) | 2026-06-29 | [369.md](369.md) |
 | #367 | Expurgo - Layout Modal | 2026-06-29 | [367.md](367.md) |
 | #368 | Expurgo - Análise: botão de navegação para tela de CSV | 2026-06-29 | [368.md](368.md) |
+| #377 | Expurgo - Bug Grid "Histórico de Expurgos" | 2026-06-29 | [377.md](377.md) |
 
 ---
 
@@ -24,7 +25,7 @@ Estado atual do sistema. Atualizado ao final de cada issue via `/end-issue`.
 
 | Módulo | Issues relacionadas | Última atualização |
 |---|---|---|
-| Expurgo (Purge) | #329, #330, #331, #332, #356, #369, #367, #368 | 2026-06-29 |
+| Expurgo (Purge) | #329, #330, #331, #332, #356, #369, #367, #368, #377 | 2026-06-29 |
 | Batch Expenses / Serialização | #355 | 2026-06-26 |
 
 ---
@@ -39,7 +40,8 @@ Estado atual do sistema. Atualizado ao final de cada issue via `/end-issue`.
 
 ### Application
 - **Use cases:** ExportPeriodUseCase, PurgePeriodUseCase, GetPurgeRecordsUseCase, DeletePurgeRecordUseCase, GetEligiblePeriodsUseCase
-- **DTOs:** EligiblePeriodDto
+- **DTOs:** EligiblePeriodDto, PurgeRecordDto
+- **Use cases alterados:** GetPurgeRecordsUseCase — retorna `IEnumerable<PurgeRecordDto>` (antes `IEnumerable<PurgeRecord>`), mapeamento interno com `ItemCount = ExpenseCount + IncomeCount`
 - **Validações (FluentValidation):** —
 
 ### Infrastructure
@@ -53,7 +55,7 @@ Estado atual do sistema. Atualizado ao final de cada issue via `/end-issue`.
   - GET /api/v1/purge/eligible-periods — retorna periodId, year, month, totalIncome, totalExpense, itemCount
   - GET /api/v1/purge/{periodId}/export — (era POST /purge/export/{periodId})
   - POST /api/v1/purge/{periodId} — requer { csvFileName } no body
-  - GET /api/v1/purge/records
+  - GET /api/v1/purge/records — retorna `year`, `month`, `itemCount` (DTO, não entidade direta)
   - DELETE /api/v1/purge/records/{id}
 - **Auth:** JWT Bearer; AuthController [AllowAnonymous]; Admin [Authorize(Roles="Admin")]
 - **Converters:** `FlexibleEnumConverterFactory` registrada globalmente via `AddJsonOptions` — deserializa enums de int, string numérica ou nome; serializa como int

--- a/src/PersonalFinance.Api/Controllers/V1/Purge/PurgeController.cs
+++ b/src/PersonalFinance.Api/Controllers/V1/Purge/PurgeController.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using PersonalFinance.Application.DTOs.Financial;
 using PersonalFinance.Application.UseCases.Financial.Purge;
 using PersonalFinance.Domain.Interfaces.Repositories;
 
@@ -79,18 +80,8 @@ public sealed class PurgeController(
     [ProducesResponseType(StatusCodes.Status200OK)]
     public async Task<IActionResult> GetRecords(CancellationToken ct)
     {
-        var records = await _getPurgeRecordsUseCase.ExecuteAsync(CurrentUserId, ct);
-        var dtos = records.Select(r => new PurgeRecordDto
-        {
-            Id           = r.Id,
-            Year         = r.PeriodYear,
-            Month        = r.PeriodMonth,
-            ItemCount    = r.ExpenseCount + r.IncomeCount,
-            TotalIncome  = r.TotalIncome,
-            TotalExpense = r.TotalExpense,
-            PurgedAt     = r.PurgedAt,
-        });
-        return Ok(dtos);
+        var result = await _getPurgeRecordsUseCase.ExecuteAsync(CurrentUserId, ct);
+        return Ok(result);
     }
 
     /// <summary>Remove um registro de expurgo do usuário autenticado.</summary>

--- a/src/PersonalFinance.Api/Controllers/V1/Purge/PurgeController.cs
+++ b/src/PersonalFinance.Api/Controllers/V1/Purge/PurgeController.cs
@@ -80,7 +80,17 @@ public sealed class PurgeController(
     public async Task<IActionResult> GetRecords(CancellationToken ct)
     {
         var records = await _getPurgeRecordsUseCase.ExecuteAsync(CurrentUserId, ct);
-        return Ok(records);
+        var dtos = records.Select(r => new PurgeRecordDto
+        {
+            Id           = r.Id,
+            Year         = r.PeriodYear,
+            Month        = r.PeriodMonth,
+            ItemCount    = r.ExpenseCount + r.IncomeCount,
+            TotalIncome  = r.TotalIncome,
+            TotalExpense = r.TotalExpense,
+            PurgedAt     = r.PurgedAt,
+        });
+        return Ok(dtos);
     }
 
     /// <summary>Remove um registro de expurgo do usuário autenticado.</summary>

--- a/src/PersonalFinance.Application/DTOs/Financial/PurgeRecordDto.cs
+++ b/src/PersonalFinance.Application/DTOs/Financial/PurgeRecordDto.cs
@@ -1,4 +1,4 @@
-namespace PersonalFinance.Application.UseCases.Financial.Purge;
+namespace PersonalFinance.Application.DTOs.Financial;
 
 /// <summary>
 /// DTO de retorno para registros de expurgo.

--- a/src/PersonalFinance.Application/UseCases/Financial/Purge/GetPurgeRecordsUseCase.cs
+++ b/src/PersonalFinance.Application/UseCases/Financial/Purge/GetPurgeRecordsUseCase.cs
@@ -1,10 +1,11 @@
-using PersonalFinance.Domain.Entities.Financial;
+using PersonalFinance.Application.DTOs.Financial;
 using PersonalFinance.Domain.Interfaces.Repositories;
 
 namespace PersonalFinance.Application.UseCases.Financial.Purge;
 
 /// <summary>
-/// Retorna todos os registros de expurgo do usuário, ordenados por PurgedAt decrescente.
+/// Retorna todos os registros de expurgo do usuário, ordenados por PurgedAt decrescente,
+/// já mapeados para PurgeRecordDto.
 /// </summary>
 public sealed class GetPurgeRecordsUseCase
 {
@@ -15,11 +16,22 @@ public sealed class GetPurgeRecordsUseCase
         _purgeRepository = purgeRepository;
     }
 
-    public async Task<IEnumerable<PurgeRecord>> ExecuteAsync(
+    public async Task<IEnumerable<PurgeRecordDto>> ExecuteAsync(
         Guid userId,
         CancellationToken ct = default)
     {
         var records = await _purgeRepository.GetByUserAsync(userId, ct);
-        return records.OrderByDescending(r => r.PurgedAt);
+        return records
+            .OrderByDescending(r => r.PurgedAt)
+            .Select(r => new PurgeRecordDto
+            {
+                Id           = r.Id,
+                Year         = r.PeriodYear,
+                Month        = r.PeriodMonth,
+                ItemCount    = r.ExpenseCount + r.IncomeCount,
+                TotalIncome  = r.TotalIncome,
+                TotalExpense = r.TotalExpense,
+                PurgedAt     = r.PurgedAt,
+            });
     }
 }

--- a/src/PersonalFinance.Application/UseCases/Financial/Purge/PurgeRecordDto.cs
+++ b/src/PersonalFinance.Application/UseCases/Financial/Purge/PurgeRecordDto.cs
@@ -1,0 +1,18 @@
+namespace PersonalFinance.Application.UseCases.Financial.Purge;
+
+/// <summary>
+/// DTO de retorno para registros de expurgo.
+/// Mapeia os campos da entidade PurgeRecord para o payload da API,
+/// expondo 'year'/'month' em vez de 'periodYear'/'periodMonth'
+/// e 'itemCount' como soma de ExpenseCount + IncomeCount.
+/// </summary>
+public sealed class PurgeRecordDto
+{
+    public Guid     Id           { get; init; }
+    public int      Year         { get; init; }
+    public int      Month        { get; init; }
+    public int      ItemCount    { get; init; }
+    public decimal  TotalIncome  { get; init; }
+    public decimal  TotalExpense { get; init; }
+    public DateTime PurgedAt     { get; init; }
+}

--- a/tests/PersonalFinance.Api.Tests/Integration/PurgeControllerTests.cs
+++ b/tests/PersonalFinance.Api.Tests/Integration/PurgeControllerTests.cs
@@ -231,4 +231,64 @@ public class PurgeControllerTests : ApiIntegrationTestBase
         r.StatusCode.Should().Be(HttpStatusCode.OK);
         r.Content.Headers.ContentType!.MediaType.Should().Be("text/csv");
     }
+
+    // ── RED: Bug 3 — GET /purge/records retorna campos errados ───────────────
+
+    [Fact(DisplayName = "RED: GET /purge/records deve retornar campos 'year' e 'month', não 'periodYear'/'periodMonth'")]
+    public async Task GetRecords_ReturnsYearAndMonth_NotPeriodYearPeriodMonth()
+    {
+        // Arrange — cria um período, expurga e verifica os campos do DTO
+        var (client, periodId) = await SetupInactivePeriodAsync(month: 12);
+        await client.PostAsJsonAsync($"/api/v1/purge/{periodId}",
+            new { csvFileName = "pf_2025_12_expurgo.csv" });
+
+        // Act
+        var r = await client.GetAsync("/api/v1/purge/records");
+
+        // Assert
+        r.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await r.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetArrayLength().Should().BeGreaterThan(0);
+
+        var first = body[0];
+
+        // Campos que devem existir no DTO
+        first.TryGetProperty("year", out _).Should().BeTrue(
+            "o payload deve expor 'year' (mapeado de PeriodYear)");
+        first.TryGetProperty("month", out _).Should().BeTrue(
+            "o payload deve expor 'month' (mapeado de PeriodMonth)");
+
+        // Campos da entidade que NÃO devem ser expostos diretamente
+        first.TryGetProperty("periodYear", out _).Should().BeFalse(
+            "a entidade PurgeRecord não deve ser serializada diretamente — usar DTO");
+        first.TryGetProperty("periodMonth", out _).Should().BeFalse(
+            "a entidade PurgeRecord não deve ser serializada diretamente — usar DTO");
+    }
+
+    [Fact(DisplayName = "RED: GET /purge/records deve retornar 'itemCount' igual a expenseCount + incomeCount")]
+    public async Task GetRecords_ReturnsItemCount_AsExpenseCountPlusIncomeCount()
+    {
+        // Arrange — expurga um período e confirma que itemCount agrega despesas + receitas
+        var (client, periodId) = await SetupInactivePeriodAsync(month: 2);
+        await client.PostAsJsonAsync($"/api/v1/purge/{periodId}",
+            new { csvFileName = "pf_2025_02_expurgo.csv" });
+
+        // Act
+        var r = await client.GetAsync("/api/v1/purge/records");
+
+        // Assert
+        r.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await r.Content.ReadFromJsonAsync<JsonElement>();
+        body.GetArrayLength().Should().BeGreaterThan(0);
+
+        var first = body[0];
+
+        // Deve expor itemCount (não expenseCount/incomeCount separados)
+        first.TryGetProperty("itemCount", out _).Should().BeTrue(
+            "o DTO deve expor 'itemCount' = ExpenseCount + IncomeCount");
+        first.TryGetProperty("expenseCount", out _).Should().BeFalse(
+            "a entidade não deve ser serializada diretamente — 'expenseCount' não deve aparecer");
+        first.TryGetProperty("incomeCount", out _).Should().BeFalse(
+            "a entidade não deve ser serializada diretamente — 'incomeCount' não deve aparecer");
+    }
 }


### PR DESCRIPTION
## Motivação
> Colunas "Período" e "Lançamentos" chegavam como `null` na grid de histórico de expurgos porque o controller serializava a entidade `PurgeRecord` diretamente (`periodYear`/`periodMonth`/`expenseCount`/`incomeCount`) em vez dos campos esperados pelo frontend (`year`/`month`/`itemCount`).

## O que foi implementado
Criado `PurgeRecordDto` em `Application/DTOs/Financial/` com os campos corretos. Mapeamento encapsulado em `GetPurgeRecordsUseCase` (retorna `IEnumerable<PurgeRecordDto>`). Controller simplificado para `return Ok(result)`.

## Arquivos

### Adicionados
| Arquivo | Descrição |
|---|---|
| `src/PersonalFinance.Application/DTOs/Financial/PurgeRecordDto.cs` | DTO com `Year`, `Month`, `ItemCount`, `TotalIncome`, `TotalExpense`, `PurgedAt` |

### Modificados
| Arquivo | O que mudou |
|---|---|
| `src/PersonalFinance.Application/UseCases/Financial/Purge/GetPurgeRecordsUseCase.cs` | Retorna `IEnumerable<PurgeRecordDto>` com mapeamento interno |
| `src/PersonalFinance.Api/Controllers/V1/Purge/PurgeController.cs` | `GetRecords` simplificado para `return Ok(result)` |
| `tests/PersonalFinance.Api.Tests/Integration/PurgeControllerTests.cs` | 2 testes novos cobrindo campos `year`/`month`/`itemCount` |

## Casos de teste

### Caminho feliz
- [ ] `GET /purge/records` retorna `year` e `month` corretamente
- [ ] `GET /purge/records` retorna `itemCount` como `expenseCount + incomeCount`

### Caminho triste
- [ ] Campos da entidade (`periodYear`, `periodMonth`) não aparecem no payload

## Critérios de aceite
- [ ] Colunas "Período" e "Lançamentos" preenchidas corretamente na grid
- [ ] 482 testes BE + 472 testes FE passando

Closes #377