### PR TITLE
Expurgo - Botão Upload CSV

### DIFF
--- a/personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts
+++ b/personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts
@@ -745,12 +745,12 @@ describe('PurgeComponent', () => {
       const appHeader = fixture.nativeElement.querySelector('app-header');
       expect(appHeader).withContext('app-header deve estar presente no DOM').not.toBeNull();
       const btnAnalise: HTMLElement | null | undefined =
-        appHeader.querySelector('.btn-analise') ??
+        appHeader.querySelector('.btn-primary') ??
         appHeader.querySelector('[data-testid="btn-analise"]') ??
         Array.from(appHeader.querySelectorAll('button') as NodeListOf<HTMLElement>)
-          .find((btn: HTMLElement) => btn.textContent?.toLowerCase().includes('análise')) ??
+          .find((btn: HTMLElement) => btn.textContent?.toLowerCase().includes('upload csv')) ??
         null;
-      expect(btnAnalise).withContext('deve existir um botão de Análise dentro de app-header via ng-content — PurgeComponent ainda não projeta o botão').not.toBeNull();
+      expect(btnAnalise).withContext('deve existir um botão Upload CSV dentro de app-header via ng-content — PurgeComponent ainda não projeta o botão').not.toBeNull();
     }));
 
     it('clicar no botão de análise chama router.navigate com [\'purge\', \'analysis\']', fakeAsync(() => {
@@ -762,12 +762,12 @@ describe('PurgeComponent', () => {
       const appHeader = fixture.nativeElement.querySelector('app-header');
       expect(appHeader).withContext('app-header deve estar presente').not.toBeNull();
       const btnAnalise: HTMLButtonElement | null =
-        appHeader.querySelector('.btn-analise') ??
+        appHeader.querySelector('.btn-primary') ??
         appHeader.querySelector('[data-testid="btn-analise"]') ??
         Array.from(appHeader.querySelectorAll('button') as NodeListOf<HTMLElement>)
-          .find((btn: HTMLElement) => btn.textContent?.toLowerCase().includes('análise')) ??
+          .find((btn: HTMLElement) => btn.textContent?.toLowerCase().includes('upload csv')) ??
         null;
-      expect(btnAnalise).withContext('botão de Análise deve existir para ser clicado — PurgeComponent ainda não projeta o botão').not.toBeNull();
+      expect(btnAnalise).withContext('botão Upload CSV deve existir para ser clicado — PurgeComponent ainda não projeta o botão').not.toBeNull();
 
       if (btnAnalise) {
         btnAnalise.click();

--- a/personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts
+++ b/personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts
@@ -868,4 +868,84 @@ describe('PurgeComponent', () => {
       ).toBeTrue();
     }));
   });
+
+  // ── #376 — botão "Upload CSV" (renomear "Análise" e corrigir classes) ────────
+
+  describe('#376 — botão Upload CSV no header', () => {
+    it('exibe o texto "Upload CSV" no botão dentro de app-header', fakeAsync(() => {
+      tick();
+      fixture.detectChanges();
+
+      const appHeader = fixture.nativeElement.querySelector('app-header');
+      expect(appHeader).withContext('app-header deve estar presente no DOM').not.toBeNull();
+
+      // Busca botão pelo texto esperado "Upload CSV"
+      const buttons = Array.from(appHeader.querySelectorAll('button') as NodeListOf<HTMLElement>);
+      const btnUploadCsv = buttons.find((btn: HTMLElement) =>
+        btn.textContent?.trim().toLowerCase() === 'upload csv'
+      ) ?? null;
+
+      expect(btnUploadCsv)
+        .withContext('deve existir um botão com texto "Upload CSV" dentro de app-header — texto ainda é "Análise"')
+        .not.toBeNull();
+    }));
+
+    it('botão dentro de app-header tem a classe btn-primary', fakeAsync(() => {
+      tick();
+      fixture.detectChanges();
+
+      const appHeader = fixture.nativeElement.querySelector('app-header');
+      expect(appHeader).withContext('app-header deve estar presente no DOM').not.toBeNull();
+
+      // Busca por btn-primary dentro do header
+      const btnPrimary: HTMLElement | null = appHeader.querySelector('.btn-primary');
+      expect(btnPrimary)
+        .withContext('deve existir um botão com classe "btn-primary" dentro de app-header — classe ainda é "btn-analise"')
+        .not.toBeNull();
+    }));
+
+    it('botão dentro de app-header NÃO tem a classe btn-analise', fakeAsync(() => {
+      tick();
+      fixture.detectChanges();
+
+      const appHeader = fixture.nativeElement.querySelector('app-header');
+      expect(appHeader).withContext('app-header deve estar presente no DOM').not.toBeNull();
+
+      // A classe btn-analise não deve existir no DOM após a correção
+      const btnAnalise: HTMLElement | null = appHeader.querySelector('.btn-analise');
+      expect(btnAnalise)
+        .withContext('não deve existir botão com classe "btn-analise" — a classe deve ser substituída por "btn-primary"')
+        .toBeNull();
+    }));
+
+    it('clicar no botão Upload CSV navega para [\'purge\', \'analysis\'] (regressão)', fakeAsync(() => {
+      tick();
+      fixture.detectChanges();
+
+      const router = TestBed.inject(Router);
+      spyOn(router, 'navigate');
+
+      const appHeader = fixture.nativeElement.querySelector('app-header');
+      expect(appHeader).withContext('app-header deve estar presente').not.toBeNull();
+
+      // Busca o botão pelo texto "Upload CSV" ou pela classe btn-primary
+      const buttons = Array.from(appHeader.querySelectorAll('button') as NodeListOf<HTMLElement>);
+      const btnUploadCsv: HTMLElement | null =
+        buttons.find((btn: HTMLElement) =>
+          btn.textContent?.trim().toLowerCase() === 'upload csv'
+        ) ??
+        appHeader.querySelector('.btn-primary') ??
+        null;
+
+      expect(btnUploadCsv)
+        .withContext('botão Upload CSV deve existir para ser clicado')
+        .not.toBeNull();
+
+      if (btnUploadCsv) {
+        btnUploadCsv.click();
+        tick();
+        expect(router.navigate).toHaveBeenCalledWith(['purge', 'analysis']);
+      }
+    }));
+  });
 });

--- a/personal-finance/src/app/features/purge/components/purge/purge.component.ts
+++ b/personal-finance/src/app/features/purge/components/purge/purge.component.ts
@@ -36,7 +36,7 @@ import { CurrencyBrlPipe } from '../../../../shared/pipes/currency-brl.pipe';
       }
 
       <app-header title="Expurgo de Períodos" subtitle="Exclua permanentemente dados de períodos fechados e exportados">
-        <button class="btn btn-sm btn-analise" (click)="navigateToAnalysis()">Análise</button>
+        <button class="btn btn-primary btn-sm" (click)="navigateToAnalysis()">Upload CSV</button>
       </app-header>
 
       <!-- Warning banner estático -->


### PR DESCRIPTION
## Motivação
> O botão "Análise" no header da página de Expurgo não seguia o padrão visual do projeto e tinha um texto pouco descritivo.

## O que foi implementado
Texto alterado de "Análise" para "Upload CSV" e classe substituída de `btn-analise` (sem definição CSS) para `btn-primary`, alinhando ao padrão do botão da tela de Períodos.

## Arquivos

### Modificados
| Arquivo | O que mudou |
|---|---|
| `personal-finance/src/app/features/purge/components/purge/purge.component.ts` | Classe e texto do botão no header |
| `personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts` | Describe #376 adicionado; describe #368 atualizado |

## Casos de teste

### Caminho feliz
- [ ] Botão exibe texto "Upload CSV"
- [ ] Botão tem classe `btn-primary`
- [ ] Clicar navega para `/purge/analysis`

### Caminho triste
- [ ] Botão não tem classe `btn-analise`

## Critérios de aceite
- [ ] Texto do botão é "Upload CSV"
- [ ] Layout idêntico ao botão "+ Novo período" da tela de Períodos
- [ ] Navegação para análise de CSV mantida

Closes #376