### PR TITLE
Expurgo - Botão Upload CSV

### DIFF
--- a/docs/memory/376.md
+++ b/docs/memory/376.md
@@ -1,0 +1,26 @@
+# #376 — Expurgo - Botão "Análise"
+Issue: #376 | Data: 2026-06-29 | Branch: feat/376-expurgo-botao-analise
+
+## Arquivos criados
+_Nenhum._
+
+## Arquivos modificados
+- `personal-finance/src/app/features/purge/components/purge/purge.component.ts` — linha 39: classe `btn btn-sm btn-analise` → `btn btn-primary btn-sm`; texto "Análise" → "Upload CSV"
+- `personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts` — describe `#376` adicionado (4 testes); describe `#368` atualizado (seletores `.btn-analise` → `.btn-primary`, textos "análise" → "upload csv")
+
+## Decisões técnicas
+- Adotado `btn-primary` em vez de criar nova classe CSS — `btn-analise` não tinha definição no CSS global e o padrão existente (`btn-primary`) já era usado nos botões dos demais headers.
+
+## Desvios do spec
+_Nenhum._
+
+## Estado do sistema após esta issue
+
+### Back-end
+_Não alterado._
+
+### Front-end
+- **Componentes:** `PurgeComponent` — botão no header atualizado (texto + classe)
+
+### Banco de dados
+_Não alterado._

--- a/docs/memory/project-memory.md
+++ b/docs/memory/project-memory.md
@@ -18,6 +18,7 @@ Estado atual do sistema. Atualizado ao final de cada issue via `/end-issue`.
 | #367 | Expurgo - Layout Modal | 2026-06-29 | [367.md](367.md) |
 | #368 | Expurgo - Análise: botão de navegação para tela de CSV | 2026-06-29 | [368.md](368.md) |
 | #377 | Expurgo - Bug Grid "Histórico de Expurgos" | 2026-06-29 | [377.md](377.md) |
+| #376 | Expurgo - Botão "Análise" | 2026-06-29 | [376.md](376.md) |
 
 ---
 
@@ -25,7 +26,7 @@ Estado atual do sistema. Atualizado ao final de cada issue via `/end-issue`.
 
 | Módulo | Issues relacionadas | Última atualização |
 |---|---|---|
-| Expurgo (Purge) | #329, #330, #331, #332, #356, #369, #367, #368, #377 | 2026-06-29 |
+| Expurgo (Purge) | #329, #330, #331, #332, #356, #369, #367, #368, #377, #376 | 2026-06-29 |
 | Batch Expenses / Serialização | #355 | 2026-06-26 |
 
 ---
@@ -62,7 +63,7 @@ Estado atual do sistema. Atualizado ao final de cada issue via `/end-issue`.
 
 ### Frontend (Angular 21)
 - **Rotas (app.routes.ts):** `/purge` (lazy, authGuard); `purge/analysis` (PurgeAnalysisComponent, providers: [CsvReaderService]); `purge/analysis/detail` (PurgeDetailComponent)
-- **Componentes standalone:** PurgeComponent redesenhado — cards grid, modal Sonic pixel-art, tabela histórico, modal delete, botão "Análise" no header via ng-content (#368) (`features/purge/components/purge/`); PurgeAnalysisComponent, PurgeDetailComponent, PurgeWarningBannerComponent (`features/purge/`) — `PurgeWarningBannerComponent` removido da tela principal em #367; permanece apenas em `purge-detail.component.ts`
+- **Componentes standalone:** PurgeComponent redesenhado — cards grid, modal Sonic pixel-art, tabela histórico, modal delete, botão "Upload CSV" no header via ng-content (classe `btn-primary`, #368/#376) (`features/purge/components/purge/`); PurgeAnalysisComponent, PurgeDetailComponent, PurgeWarningBannerComponent (`features/purge/`) — `PurgeWarningBannerComponent` removido da tela principal em #367; permanece apenas em `purge-detail.component.ts`
 - **Assets:** `public/sonic-tile.svg` (tile pixel-art do frame Sonic)
 - **Serviços:** ApiService (wrapper HTTP) com métodos purge (`getEligiblePeriods`, `exportPurgeCsv`, `executePurge(periodId, csvFileName)`, `getPurgeRecords`, `deletePurgeRecord`); ThemeService (dark/light); CsvReaderService (parse CSV offline, sem `providedIn: 'root'`) — corrigido em #369 para 12 colunas, RFC 4180, enums como string
 - **Componentes:** `PurgeDetailComponent` (#369) — tabela Income com 4 colunas (Descrição, Valor, Período, Notas); coluna Quinzena removida

--- a/personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts
+++ b/personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts
@@ -745,12 +745,12 @@ describe('PurgeComponent', () => {
       const appHeader = fixture.nativeElement.querySelector('app-header');
       expect(appHeader).withContext('app-header deve estar presente no DOM').not.toBeNull();
       const btnAnalise: HTMLElement | null | undefined =
-        appHeader.querySelector('.btn-analise') ??
+        appHeader.querySelector('.btn-primary') ??
         appHeader.querySelector('[data-testid="btn-analise"]') ??
         Array.from(appHeader.querySelectorAll('button') as NodeListOf<HTMLElement>)
-          .find((btn: HTMLElement) => btn.textContent?.toLowerCase().includes('análise')) ??
+          .find((btn: HTMLElement) => btn.textContent?.toLowerCase().includes('upload csv')) ??
         null;
-      expect(btnAnalise).withContext('deve existir um botão de Análise dentro de app-header via ng-content — PurgeComponent ainda não projeta o botão').not.toBeNull();
+      expect(btnAnalise).withContext('deve existir um botão Upload CSV dentro de app-header via ng-content — PurgeComponent ainda não projeta o botão').not.toBeNull();
     }));
 
     it('clicar no botão de análise chama router.navigate com [\'purge\', \'analysis\']', fakeAsync(() => {
@@ -762,12 +762,12 @@ describe('PurgeComponent', () => {
       const appHeader = fixture.nativeElement.querySelector('app-header');
       expect(appHeader).withContext('app-header deve estar presente').not.toBeNull();
       const btnAnalise: HTMLButtonElement | null =
-        appHeader.querySelector('.btn-analise') ??
+        appHeader.querySelector('.btn-primary') ??
         appHeader.querySelector('[data-testid="btn-analise"]') ??
         Array.from(appHeader.querySelectorAll('button') as NodeListOf<HTMLElement>)
-          .find((btn: HTMLElement) => btn.textContent?.toLowerCase().includes('análise')) ??
+          .find((btn: HTMLElement) => btn.textContent?.toLowerCase().includes('upload csv')) ??
         null;
-      expect(btnAnalise).withContext('botão de Análise deve existir para ser clicado — PurgeComponent ainda não projeta o botão').not.toBeNull();
+      expect(btnAnalise).withContext('botão Upload CSV deve existir para ser clicado — PurgeComponent ainda não projeta o botão').not.toBeNull();
 
       if (btnAnalise) {
         btnAnalise.click();

--- a/personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts
+++ b/personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts
@@ -868,4 +868,84 @@ describe('PurgeComponent', () => {
       ).toBeTrue();
     }));
   });
+
+  // ── #376 — botão "Upload CSV" (renomear "Análise" e corrigir classes) ────────
+
+  describe('#376 — botão Upload CSV no header', () => {
+    it('exibe o texto "Upload CSV" no botão dentro de app-header', fakeAsync(() => {
+      tick();
+      fixture.detectChanges();
+
+      const appHeader = fixture.nativeElement.querySelector('app-header');
+      expect(appHeader).withContext('app-header deve estar presente no DOM').not.toBeNull();
+
+      // Busca botão pelo texto esperado "Upload CSV"
+      const buttons = Array.from(appHeader.querySelectorAll('button') as NodeListOf<HTMLElement>);
+      const btnUploadCsv = buttons.find((btn: HTMLElement) =>
+        btn.textContent?.trim().toLowerCase() === 'upload csv'
+      ) ?? null;
+
+      expect(btnUploadCsv)
+        .withContext('deve existir um botão com texto "Upload CSV" dentro de app-header — texto ainda é "Análise"')
+        .not.toBeNull();
+    }));
+
+    it('botão dentro de app-header tem a classe btn-primary', fakeAsync(() => {
+      tick();
+      fixture.detectChanges();
+
+      const appHeader = fixture.nativeElement.querySelector('app-header');
+      expect(appHeader).withContext('app-header deve estar presente no DOM').not.toBeNull();
+
+      // Busca por btn-primary dentro do header
+      const btnPrimary: HTMLElement | null = appHeader.querySelector('.btn-primary');
+      expect(btnPrimary)
+        .withContext('deve existir um botão com classe "btn-primary" dentro de app-header — classe ainda é "btn-analise"')
+        .not.toBeNull();
+    }));
+
+    it('botão dentro de app-header NÃO tem a classe btn-analise', fakeAsync(() => {
+      tick();
+      fixture.detectChanges();
+
+      const appHeader = fixture.nativeElement.querySelector('app-header');
+      expect(appHeader).withContext('app-header deve estar presente no DOM').not.toBeNull();
+
+      // A classe btn-analise não deve existir no DOM após a correção
+      const btnAnalise: HTMLElement | null = appHeader.querySelector('.btn-analise');
+      expect(btnAnalise)
+        .withContext('não deve existir botão com classe "btn-analise" — a classe deve ser substituída por "btn-primary"')
+        .toBeNull();
+    }));
+
+    it('clicar no botão Upload CSV navega para [\'purge\', \'analysis\'] (regressão)', fakeAsync(() => {
+      tick();
+      fixture.detectChanges();
+
+      const router = TestBed.inject(Router);
+      spyOn(router, 'navigate');
+
+      const appHeader = fixture.nativeElement.querySelector('app-header');
+      expect(appHeader).withContext('app-header deve estar presente').not.toBeNull();
+
+      // Busca o botão pelo texto "Upload CSV" ou pela classe btn-primary
+      const buttons = Array.from(appHeader.querySelectorAll('button') as NodeListOf<HTMLElement>);
+      const btnUploadCsv: HTMLElement | null =
+        buttons.find((btn: HTMLElement) =>
+          btn.textContent?.trim().toLowerCase() === 'upload csv'
+        ) ??
+        appHeader.querySelector('.btn-primary') ??
+        null;
+
+      expect(btnUploadCsv)
+        .withContext('botão Upload CSV deve existir para ser clicado')
+        .not.toBeNull();
+
+      if (btnUploadCsv) {
+        btnUploadCsv.click();
+        tick();
+        expect(router.navigate).toHaveBeenCalledWith(['purge', 'analysis']);
+      }
+    }));
+  });
 });

--- a/personal-finance/src/app/features/purge/components/purge/purge.component.ts
+++ b/personal-finance/src/app/features/purge/components/purge/purge.component.ts
@@ -36,7 +36,7 @@ import { CurrencyBrlPipe } from '../../../../shared/pipes/currency-brl.pipe';
       }
 
       <app-header title="Expurgo de Períodos" subtitle="Exclua permanentemente dados de períodos fechados e exportados">
-        <button class="btn btn-sm btn-analise" (click)="navigateToAnalysis()">Análise</button>
+        <button class="btn btn-primary btn-sm" (click)="navigateToAnalysis()">Upload CSV</button>
       </app-header>
 
       <!-- Warning banner estático -->


### PR DESCRIPTION
## Motivação
> O botão "Análise" no header da página de Expurgo não seguia o padrão visual do projeto e tinha um texto pouco descritivo.

## O que foi implementado
Texto alterado de "Análise" para "Upload CSV" e classe substituída de `btn-analise` (sem definição CSS) para `btn-primary`, alinhando ao padrão do botão da tela de Períodos.

## Arquivos

### Modificados
| Arquivo | O que mudou |
|---|---|
| `personal-finance/src/app/features/purge/components/purge/purge.component.ts` | Classe e texto do botão no header |
| `personal-finance/src/app/features/purge/components/purge/purge.component.spec.ts` | Describe #376 adicionado; describe #368 atualizado |

## Casos de teste

### Caminho feliz
- [ ] Botão exibe texto "Upload CSV"
- [ ] Botão tem classe `btn-primary`
- [ ] Clicar navega para `/purge/analysis`

### Caminho triste
- [ ] Botão não tem classe `btn-analise`

## Critérios de aceite
- [ ] Texto do botão é "Upload CSV"
- [ ] Layout idêntico ao botão "+ Novo período" da tela de Períodos
- [ ] Navegação para análise de CSV mantida

Closes #376